### PR TITLE
feat(seo): Full SEO audit implementation — 170+ new pages

### DIFF
--- a/app/[certification]/questions/[topic]/[questionId]/page.tsx
+++ b/app/[certification]/questions/[topic]/[questionId]/page.tsx
@@ -43,10 +43,8 @@ export async function generateMetadata({
     return { title: "Question Not Found" };
   }
 
-  const truncatedQuestion = truncateText(question.question, 60);
-
   return {
-    title: `${truncatedQuestion} - ${cert.name} ${topic.name}`,
+    title: `Q${questionNumber}: ${topic.name} – ${cert.name} Practice | SNReady`,
     description: `${question.cognitiveLevel.charAt(0).toUpperCase() + question.cognitiveLevel.slice(1)} ${cert.name} ${topic.name} practice question. ${truncateText(typeof question.explanation === "string" ? question.explanation : question.explanation.correct, 120)}`,
     keywords: [
       `${cert.name} ${topic.name} question`,
@@ -124,7 +122,7 @@ export default async function QuestionPage({ params }: PageProps) {
       "@type": "Organization",
       name: "SNReady",
     },
-    dateCreated: new Date().toISOString(),
+    dateCreated: "2026-02-05",
     about: {
       "@type": "Thing",
       name: `ServiceNow ${cert.name} ${topic.name}`,

--- a/app/free-questions/[cert]/[topic]/page.tsx
+++ b/app/free-questions/[cert]/[topic]/page.tsx
@@ -1,0 +1,257 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getCertificationBySlug,
+  getTopicBySlug,
+  getFreeQuestionsForTopic,
+  getAllTopicSlugs,
+} from "@/lib/data";
+import { generateBreadcrumbJsonLd, breadcrumbs } from "@/lib/breadcrumbs";
+import { getCanonicalUrl } from "@/lib/seo";
+import QuestionCard from "@/components/QuestionCard";
+
+interface Props {
+  params: Promise<{
+    cert: string;
+    topic: string;
+  }>;
+}
+
+export async function generateStaticParams() {
+  return getAllTopicSlugs().map((slug) => ({
+    cert: slug.certification,
+    topic: slug.topic,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { cert, topic } = await params;
+  
+  const certification = getCertificationBySlug(cert);
+  const topicData = getTopicBySlug(cert, topic);
+  
+  if (!certification || !topicData) {
+    return {
+      title: "Topic Not Found",
+    };
+  }
+
+  const title = `Free ${certification.name} ${topicData.name} Practice Questions | SNReady`;
+  const description = `Practice free ServiceNow ${certification.name} questions for ${topicData.name}. Test your knowledge before the exam with our curated selection of practice questions.`;
+  
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: getCanonicalUrl(`/free-questions/${cert}/${topic}`),
+    },
+    openGraph: {
+      title,
+      description,
+      url: getCanonicalUrl(`/free-questions/${cert}/${topic}`),
+      images: ['/og-default.png'],
+    },
+    twitter: {
+      title,
+      description,
+      images: ['/og-default.png'],
+    },
+  };
+}
+
+export default async function FreeQuestionsPage({ params }: Props) {
+  const { cert, topic } = await params;
+  
+  const certification = getCertificationBySlug(cert);
+  const topicData = getTopicBySlug(cert, topic);
+  const freeQuestions = await getFreeQuestionsForTopic(cert, topic);
+  
+  if (!certification || !topicData) {
+    notFound();
+  }
+
+  const breadcrumbItems = [
+    { name: "Home", url: "/" },
+    { name: certification.name, url: `/certifications/${cert}` },
+    { name: "Free Questions", url: `/free-questions` },
+    { name: topicData.name, url: `/free-questions/${cert}/${topic}` },
+  ];
+
+  const faqData = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: `How many free ${topicData.name} questions are available?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `We provide ${freeQuestions.length} free practice questions for ${topicData.name} in the ${certification.name} certification. These questions cover key concepts and exam patterns to help you prepare effectively.`,
+        },
+      },
+      {
+        "@type": "Question",
+        name: `Are these questions similar to the actual ${certification.name} exam?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `Yes, our practice questions are designed to match the format, difficulty level, and content areas of the actual ${certification.name} certification exam.`,
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How can I access the full question bank?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `To unlock the complete question bank with detailed explanations, comprehensive coverage, and additional practice materials, upgrade to our full access plan.`,
+        },
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateBreadcrumbJsonLd(breadcrumbItems)),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqData),
+        }}
+      />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+            <Link href="/" className="hover:text-zinc-700">Home</Link>
+            <span>→</span>
+            <Link href={`/certifications/${cert}`} className="hover:text-zinc-700">
+              {certification.name}
+            </Link>
+            <span>→</span>
+            <span>Free Questions</span>
+          </div>
+          
+          <h1 className="mt-4 text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+            Free {certification.name} Questions
+          </h1>
+          <h2 className="mt-2 text-2xl font-semibold text-emerald-600">
+            {topicData.name}
+          </h2>
+          
+          <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+            Practice with {freeQuestions.length} free questions from our {topicData.name} collection
+          </p>
+        </div>
+
+        {/* Topic Introduction */}
+        {topicData.introduction && (
+          <div className="mt-8 rounded-lg border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-700 dark:bg-zinc-900">
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              About {topicData.name}
+            </h3>
+            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+              {topicData.introduction.overview}
+            </p>
+            {topicData.keyConcepts && topicData.keyConcepts.length > 0 && (
+              <div className="mt-4">
+                <h4 className="font-medium text-zinc-900 dark:text-zinc-100">Key Concepts:</h4>
+                <ul className="mt-2 grid grid-cols-1 gap-1 sm:grid-cols-2">
+                  {topicData.keyConcepts.slice(0, 6).map((concept: string, index: number) => (
+                    <li key={index} className="text-sm text-zinc-600 dark:text-zinc-400">
+                      • {concept}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Questions */}
+        <div className="mt-8 space-y-6">
+          {freeQuestions.length > 0 ? (
+            freeQuestions.map((question, index) => (
+              <QuestionCard
+                key={question.id}
+                question={question}
+                questionNumber={index + 1}
+                showAnswer={false}
+              />
+            ))
+          ) : (
+            <div className="text-center py-12">
+              <p className="text-lg text-zinc-600 dark:text-zinc-400">
+                No free questions available for this topic yet.
+              </p>
+              <p className="mt-2 text-zinc-500">
+                Check back soon for updated content!
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Unlock CTA */}
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+          <h3 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
+            Unlock Full Access
+          </h3>
+          <p className="mt-2 text-emerald-700 dark:text-emerald-300">
+            Get access to {topicData.questionCount} total questions for {topicData.name} with detailed explanations and exam insights
+          </p>
+          
+          <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-center">
+            <Link
+              href={`/${cert}/questions/${topic}`}
+              className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+            >
+              Practice All Questions
+            </Link>
+            <Link
+              href={`/certifications/${cert}`}
+              className="inline-flex items-center justify-center rounded-lg border border-emerald-600 px-6 py-3 font-semibold text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950"
+            >
+              View All Topics
+            </Link>
+          </div>
+        </div>
+
+        {/* Related Links */}
+        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Link
+            href={`/practice-tests/${cert}`}
+            className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            <h4 className="font-semibold text-zinc-900 dark:text-zinc-100">Practice Test</h4>
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              Full {certification.name} mock exam
+            </p>
+          </Link>
+          <Link
+            href={`/learn/${topic}`}
+            className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            <h4 className="font-semibold text-zinc-900 dark:text-zinc-100">Study Guide</h4>
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              Learn {topicData.name} concepts
+            </p>
+          </Link>
+          <Link
+            href={`/study-guide/${cert}`}
+            className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            <h4 className="font-semibold text-zinc-900 dark:text-zinc-100">Exam Plan</h4>
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              {certification.name} preparation strategy
+            </p>
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/glossary/[term]/page.tsx
+++ b/app/glossary/[term]/page.tsx
@@ -1,0 +1,237 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getGlossaryTermBySlug,
+  getAllGlossaryTermSlugs,
+} from "@/lib/data";
+import { generateBreadcrumbJsonLd } from "@/lib/breadcrumbs";
+import { getCanonicalUrl } from "@/lib/seo";
+
+interface Props {
+  params: Promise<{
+    term: string;
+  }>;
+}
+
+export async function generateStaticParams() {
+  return getAllGlossaryTermSlugs().map((slug) => ({
+    term: slug,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { term } = await params;
+  
+  const glossaryTerm = getGlossaryTermBySlug(term);
+  
+  if (!glossaryTerm) {
+    return {
+      title: "Term Not Found",
+    };
+  }
+
+  const title = `${glossaryTerm.name} in ServiceNow - Definition & Exam Guide | SNReady`;
+  const description = `Learn about ${glossaryTerm.name} in ServiceNow. Essential concept for ${glossaryTerm.certifications.map(c => c.certName).join(', ')} certifications. Includes definition, context, and related practice questions.`;
+  
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: getCanonicalUrl(`/glossary/${term}`),
+    },
+    openGraph: {
+      title,
+      description,
+      url: getCanonicalUrl(`/glossary/${term}`),
+      images: ['/og-default.png'],
+    },
+    twitter: {
+      title,
+      description,
+      images: ['/og-default.png'],
+    },
+  };
+}
+
+// Generate definition based on context
+function generateDefinition(termName: string): string {
+  const definitions: Record<string, string> = {
+    // Common ServiceNow terms
+    "application navigator": "The primary navigation interface in ServiceNow that provides hierarchical access to applications, modules, and functions. Located on the left side of the interface, it organizes platform capabilities by application area.",
+    "business rules": "Server-side JavaScript code that executes when records are queried, updated, inserted, or deleted. Business rules run automatically based on configured conditions and can modify field values, validate data, or trigger additional processing.",
+    "client scripts": "JavaScript code that runs in the user's browser to enhance the user interface and validate data before form submission. Client scripts can control field behavior, validate input, and provide dynamic user interactions.",
+    "cmdb": "Configuration Management Database - a centralized repository that stores information about IT infrastructure components (CIs) and their relationships. The CMDB provides visibility into the IT environment for impact analysis and change management.",
+    "service catalog": "A self-service portal where users can request IT services, equipment, and other items through a standardized interface. The service catalog streamlines request processes and provides consistent service delivery.",
+    "incident management": "The ITIL process for quickly restoring normal service operation when service disruptions occur. Incident management focuses on minimizing the impact to business operations through efficient resolution procedures.",
+    "change management": "The ITIL process for controlling and managing all changes to the IT infrastructure in a standardized way. Change management reduces risk by ensuring proper evaluation, approval, and implementation of changes.",
+    "problem management": "The ITIL process for identifying and addressing the root causes of incidents to prevent their recurrence. Problem management focuses on permanently resolving underlying issues rather than just symptoms.",
+    "knowledge management": "The process of creating, sharing, and maintaining organizational knowledge to improve decision-making and problem resolution. In ServiceNow, this includes knowledge articles and bases for self-service and agent support.",
+    "workflow": "Automated business process logic that moves work between users or systems based on defined rules and conditions. Workflows coordinate activities, route approvals, and ensure consistent process execution.",
+    "ui policies": "Client-side rules that control field behavior on forms without requiring custom JavaScript. UI policies can make fields mandatory, readonly, or visible based on specified conditions.",
+    "acl": "Access Control Lists - security rules that determine what users can read, write, create, or delete on tables and fields. ACLs enforce data security by controlling access based on user roles and conditions.",
+    "gliderecord": "ServiceNow's server-side API for database operations. GlideRecord provides methods to query, insert, update, and delete records from tables using JavaScript.",
+    "glidedatetime": "ServiceNow's API for handling date and time operations in scripts. GlideDateTime provides methods for date arithmetic, formatting, and timezone conversion.",
+    "scripted rest apis": "Custom web service endpoints created in ServiceNow that can be called by external systems. Scripted REST APIs enable integration by providing HTTP-based access to ServiceNow data and functionality.",
+    "transform maps": "Data import configurations that define how external data maps to ServiceNow table fields. Transform maps enable data integration by specifying field mappings, transformations, and validation rules.",
+    "scheduled jobs": "Automated tasks that run at specified intervals to perform maintenance, data processing, or integration activities. Scheduled jobs execute background scripts on defined schedules.",
+    "discovery": "ServiceNow's automated process for identifying and mapping IT infrastructure components and their relationships. Discovery populates the CMDB by scanning networks and systems.",
+    "orchestration": "ServiceNow's workflow automation platform that coordinates activities across multiple systems and technologies. Orchestration enables end-to-end process automation through workflow activities.",
+    "service mapping": "The process of automatically discovering and visualizing relationships between business services and their supporting IT infrastructure. Service mapping creates accurate service models for impact analysis.",
+    "event management": "The process of monitoring, filtering, and responding to events generated by IT infrastructure components. Event management provides operational visibility and automated incident creation."
+  };
+
+  const key = termName.toLowerCase();
+  return definitions[key] || `A key concept in ServiceNow that appears across multiple certification domains. Understanding ${termName} is essential for ServiceNow platform knowledge and certification success.`;
+}
+
+export default async function GlossaryTermPage({ params }: Props) {
+  const { term } = await params;
+  
+  const glossaryTerm = getGlossaryTermBySlug(term);
+  
+  if (!glossaryTerm) {
+    notFound();
+  }
+
+  const breadcrumbItems = [
+    { name: "Home", url: "/" },
+    { name: "Glossary", url: "/glossary" },
+    { name: glossaryTerm.name, url: `/glossary/${term}` },
+  ];
+
+  const definition = generateDefinition(glossaryTerm.name);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateBreadcrumbJsonLd(breadcrumbItems)),
+        }}
+      />
+
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+            <Link href="/" className="hover:text-zinc-700">Home</Link>
+            <span>→</span>
+            <Link href="/glossary" className="hover:text-zinc-700">Glossary</Link>
+            <span>→</span>
+            <span>{glossaryTerm.name}</span>
+          </div>
+          
+          <h1 className="mt-4 text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+            {glossaryTerm.name}
+          </h1>
+          <p className="mt-2 text-xl text-emerald-600">
+            ServiceNow Exam Concept
+          </p>
+        </div>
+
+        {/* Definition */}
+        <div className="mt-8">
+          <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-700 dark:bg-zinc-900">
+            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+              Definition
+            </h2>
+            <p className="mt-3 text-lg leading-relaxed text-zinc-700 dark:text-zinc-300">
+              {definition}
+            </p>
+          </div>
+        </div>
+
+        {/* Certification Coverage */}
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            Certification Coverage
+          </h2>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            This concept appears in the following ServiceNow certifications and exam domains:
+          </p>
+          
+          <div className="mt-4 space-y-4">
+            {glossaryTerm.certifications.map((cert) => (
+              <div
+                key={cert.certSlug}
+                className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-700"
+              >
+                <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                  {cert.certName}
+                </h3>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {cert.topics.map((topic) => (
+                    <Link
+                      key={topic.topicSlug}
+                      href={`/learn/${topic.topicSlug}`}
+                      className="rounded bg-emerald-100 px-2 py-1 text-sm text-emerald-700 transition-colors hover:bg-emerald-200 dark:bg-emerald-900 dark:text-emerald-300 dark:hover:bg-emerald-800"
+                    >
+                      {topic.topicName}
+                    </Link>
+                  ))}
+                </div>
+                <div className="mt-3 flex gap-4">
+                  <Link
+                    href={`/study-guide/${cert.certSlug}`}
+                    className="text-sm text-emerald-600 hover:text-emerald-700"
+                  >
+                    Study Guide
+                  </Link>
+                  <Link
+                    href={`/practice-tests/${cert.certSlug}`}
+                    className="text-sm text-emerald-600 hover:text-emerald-700"
+                  >
+                    Practice Test
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Related Questions */}
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            Practice Questions
+          </h2>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            Test your understanding with practice questions covering {glossaryTerm.name}:
+          </p>
+          
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {glossaryTerm.certifications.slice(0, 4).map((cert) => (
+              cert.topics.slice(0, 2).map((topic) => (
+                <Link
+                  key={`${cert.certSlug}-${topic.topicSlug}`}
+                  href={`/${cert.certSlug}/questions/${topic.topicSlug}`}
+                  className="rounded-lg border border-zinc-200 bg-white p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+                >
+                  <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                    {topic.topicName}
+                  </h3>
+                  <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                    {cert.certName}
+                  </p>
+                  <span className="mt-2 inline-block text-sm font-medium text-emerald-600">
+                    Practice Questions →
+                  </span>
+                </Link>
+              ))
+            )).flat()}
+          </div>
+        </div>
+
+        {/* Back to Glossary */}
+        <div className="mt-8 text-center">
+          <Link
+            href="/glossary"
+            className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700"
+          >
+            ← Back to ServiceNow Glossary
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -1,0 +1,197 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { getGlossaryTermsGroupedAlphabetically } from "@/lib/data";
+import { generateBreadcrumbJsonLd } from "@/lib/breadcrumbs";
+import { getCanonicalUrl } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: "ServiceNow Glossary - Key Terms & Concepts | SNReady",
+  description: "Complete glossary of ServiceNow terms and concepts for certification exams. Learn definitions of key platform concepts for CSA, CAD, CIS-ITSM, and other certifications.",
+  alternates: {
+    canonical: getCanonicalUrl("/glossary"),
+  },
+  openGraph: {
+    title: "ServiceNow Glossary - Key Terms & Concepts | SNReady",
+    description: "Complete glossary of ServiceNow terms and concepts for certification exams. Learn definitions of key platform concepts for CSA, CAD, CIS-ITSM, and other certifications.",
+    url: getCanonicalUrl("/glossary"),
+    images: ['/og-default.png'],
+  },
+  twitter: {
+    title: "ServiceNow Glossary - Key Terms & Concepts | SNReady",
+    description: "Complete glossary of ServiceNow terms and concepts for certification exams. Learn definitions of key platform concepts for CSA, CAD, CIS-ITSM, and other certifications.",
+    images: ['/og-default.png'],
+  },
+};
+
+export default function GlossaryIndexPage() {
+  const groupedTerms = getGlossaryTermsGroupedAlphabetically();
+  const alphabeticalSections = Object.keys(groupedTerms).sort();
+
+  const breadcrumbItems = [
+    { name: "Home", url: "/" },
+    { name: "Glossary", url: "/glossary" },
+  ];
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateBreadcrumbJsonLd(breadcrumbItems)),
+        }}
+      />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+            <Link href="/" className="hover:text-zinc-700">Home</Link>
+            <span>→</span>
+            <span>Glossary</span>
+          </div>
+          
+          <h1 className="mt-4 text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+            ServiceNow Glossary
+          </h1>
+          <p className="mt-2 text-xl text-emerald-600">
+            Key Terms & Concepts for Certification Success
+          </p>
+          
+          <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+            Essential ServiceNow concepts organized alphabetically. Perfect for exam preparation and quick reference.
+          </p>
+        </div>
+
+        {/* Quick Navigation */}
+        <div className="mt-8">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            Quick Navigation
+          </h2>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {alphabeticalSections.map((letter) => (
+              <a
+                key={letter}
+                href={`#section-${letter}`}
+                className="rounded bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-200 dark:bg-emerald-900 dark:text-emerald-300 dark:hover:bg-emerald-800"
+              >
+                {letter}
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* Terms by Letter */}
+        <div className="mt-8 space-y-8">
+          {alphabeticalSections.map((letter) => (
+            <div key={letter} id={`section-${letter}`}>
+              <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                {letter}
+              </h2>
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {groupedTerms[letter].map((term) => (
+                  <Link
+                    key={term.slug}
+                    href={`/glossary/${term.slug}`}
+                    className="group rounded-lg border border-zinc-200 bg-white p-4 transition-all hover:border-emerald-300 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-emerald-600"
+                  >
+                    <h3 className="font-semibold text-zinc-900 group-hover:text-emerald-600 dark:text-zinc-100 dark:group-hover:text-emerald-400">
+                      {term.name}
+                    </h3>
+                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                      Used in {term.certifications.length} certification{term.certifications.length !== 1 ? 's' : ''}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {term.certifications.slice(0, 3).map((cert) => (
+                        <span
+                          key={cert.certSlug}
+                          className="rounded bg-zinc-100 px-1.5 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                        >
+                          {cert.certSlug.toUpperCase()}
+                        </span>
+                      ))}
+                      {term.certifications.length > 3 && (
+                        <span className="text-xs text-zinc-500">
+                          +{term.certifications.length - 3} more
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Study Resources */}
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+          <h2 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
+            Master These Concepts
+          </h2>
+          <p className="mt-2 text-emerald-700 dark:text-emerald-300">
+            Ready to test your knowledge? Try our practice questions and study guides.
+          </p>
+          
+          <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-center">
+            <Link
+              href="/practice-tests/csa"
+              className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-8 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+            >
+              CSA Practice Test
+            </Link>
+            <Link
+              href="/study-guide/csa"
+              className="inline-flex items-center justify-center rounded-lg border border-emerald-600 px-8 py-3 font-semibold text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950"
+            >
+              Study Guides
+            </Link>
+          </div>
+        </div>
+
+        {/* Related Resources */}
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            Related Resources
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Link
+              href="/learn/ui-navigation"
+              className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">Study Guides</h3>
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                In-depth concept explanations
+              </p>
+            </Link>
+            <Link
+              href="/practice-tests/csa"
+              className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">Practice Tests</h3>
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                Full mock exams
+              </p>
+            </Link>
+            <Link
+              href="/free-questions/csa/ui-navigation"
+              className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">Free Questions</h3>
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                Sample practice questions
+              </p>
+            </Link>
+            <Link
+              href="/#certifications"
+              className="rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">All Certifications</h3>
+              <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                Browse 25+ certifications
+              </p>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
+import Link from "next/link";
 import { BASE_URL } from "@/lib/seo";
 import "./globals.css";
 
@@ -42,6 +43,7 @@ export const metadata: Metadata = {
     title: "SNReady - ServiceNow Certification Exam Prep",
     description:
       "Pass your ServiceNow certification exams with confidence. Free practice tests and exam questions.",
+    images: ['/og-default.png'],
   },
   twitter: {
     card: "summary_large_image",
@@ -60,6 +62,25 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const websiteSchema = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "SNReady",
+    url: "https://snready.com",
+    potentialAction: {
+      "@type": "SearchAction",
+      target: "https://snready.com/#certifications?q={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  };
+
+  const organizationSchema = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "SNReady",
+    url: "https://snready.com",
+  };
+
   return (
     <html lang="en">
       <head>
@@ -75,6 +96,18 @@ export default function RootLayout({
             gtag('config', 'G-21R4T0V162');
           `}
         </Script>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(websiteSchema),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationSchema),
+          }}
+        />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
@@ -82,44 +115,171 @@ export default function RootLayout({
         <nav className="border-b border-zinc-200 dark:border-zinc-800">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="flex h-16 items-center justify-between">
-              <a href="/" className="flex items-center gap-2">
+              <Link href="/" className="flex items-center gap-2">
                 <span className="text-xl font-bold text-emerald-600">
                   SNReady
                 </span>
-              </a>
+              </Link>
               <div className="hidden sm:flex sm:items-center sm:gap-6">
-                <a
+                <Link
                   href="/certifications/csa"
                   className="text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                 >
                   CSA
-                </a>
-                <a
+                </Link>
+                <Link
                   href="/certifications/cad"
                   className="text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                 >
                   CAD
-                </a>
-                <a
+                </Link>
+                <Link
+                  href="/certifications/cis-df"
+                  className="text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                >
+                  CIS-DF
+                </Link>
+                <Link
                   href="/certifications/cis-itsm"
                   className="text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                 >
                   CIS-ITSM
-                </a>
-                <a
+                </Link>
+                <Link
                   href="/#certifications"
                   className="text-sm font-medium text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
                 >
                   All 25+ Exams
-                </a>
+                </Link>
               </div>
             </div>
           </div>
         </nav>
         <main>{children}</main>
-        <footer className="border-t border-zinc-200 py-8 dark:border-zinc-800">
-          <div className="mx-auto max-w-6xl px-4 text-center text-sm text-zinc-500">
-            <p>SNReady - Your path to ServiceNow certification success</p>
+        <footer className="border-t border-zinc-200 py-12 dark:border-zinc-800">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-4">
+              {/* Certifications */}
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  Certifications
+                </h3>
+                <div className="mt-4 space-y-3">
+                  <Link
+                    href="/certifications/csa"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CSA
+                  </Link>
+                  <Link
+                    href="/certifications/cis-df"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CIS-DF
+                  </Link>
+                  <Link
+                    href="/certifications/cad"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CAD
+                  </Link>
+                  <Link
+                    href="/certifications/cis-itsm"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CIS-ITSM
+                  </Link>
+                  <Link
+                    href="/certifications/cta"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CTA
+                  </Link>
+                  <Link
+                    href="/#certifications"
+                    className="block text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
+                  >
+                    All Certifications
+                  </Link>
+                </div>
+              </div>
+
+              {/* Resources */}
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  Resources
+                </h3>
+                <div className="mt-4 space-y-3">
+                  <Link
+                    href="/practice-tests/csa"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    Practice Tests
+                  </Link>
+                  <Link
+                    href="/free-questions/csa/ui-navigation"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    Free Questions
+                  </Link>
+                  <Link
+                    href="/study-guide/csa"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    Study Guides
+                  </Link>
+                  <Link
+                    href="/compare/csa-vs-cad"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    Compare Certifications
+                  </Link>
+                </div>
+              </div>
+
+              {/* Popular Comparisons */}
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  Popular Comparisons
+                </h3>
+                <div className="mt-4 space-y-3">
+                  <Link
+                    href="/compare/csa-vs-cad"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CSA vs CAD
+                  </Link>
+                  <Link
+                    href="/compare/csa-vs-cis-itsm"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CSA vs CIS-ITSM
+                  </Link>
+                  <Link
+                    href="/compare/cis-discovery-vs-cis-sm"
+                    className="block text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  >
+                    CIS-Discovery vs CIS-SM
+                  </Link>
+                </div>
+              </div>
+
+              {/* About */}
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  SNReady
+                </h3>
+                <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
+                  Your path to ServiceNow certification success
+                </p>
+              </div>
+            </div>
+            
+            <div className="mt-8 border-t border-zinc-200 pt-8 text-center dark:border-zinc-700">
+              <p className="text-sm text-zinc-500">
+                SNReady - Your path to ServiceNow certification success
+              </p>
+            </div>
           </div>
         </footer>
       </body>

--- a/app/learn/[topic]/page.tsx
+++ b/app/learn/[topic]/page.tsx
@@ -1,0 +1,334 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getAllTopicSlugs,
+  getCertificationBySlug,
+  getTopicsForCertification,
+} from "@/lib/data";
+import { generateBreadcrumbJsonLd } from "@/lib/breadcrumbs";
+import { getCanonicalUrl } from "@/lib/seo";
+import type { Topic } from "@/types";
+
+interface Props {
+  params: Promise<{
+    topic: string;
+  }>;
+}
+
+// Find a topic by slug across all certifications
+function findTopicBySlug(topicSlug: string): {
+  topic: Topic;
+  certification: any;
+} | null {
+  const allTopicSlugs = getAllTopicSlugs();
+  
+  for (const { certification, topic } of allTopicSlugs) {
+    const cert = getCertificationBySlug(certification);
+    const topics = getTopicsForCertification(certification);
+    const topicData = topics.find(t => t.slug === topicSlug);
+    
+    if (topicData && cert) {
+      return { topic: topicData, certification: cert };
+    }
+  }
+  
+  return null;
+}
+
+export async function generateStaticParams() {
+  const allSlugs = getAllTopicSlugs();
+  // Get unique topic slugs across all certifications
+  const uniqueTopics = new Set<string>();
+  
+  allSlugs.forEach(({ topic }) => {
+    uniqueTopics.add(topic);
+  });
+  
+  return Array.from(uniqueTopics).map((topic) => ({
+    topic,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { topic } = await params;
+  
+  const result = findTopicBySlug(topic);
+  
+  if (!result) {
+    return {
+      title: "Topic Not Found",
+    };
+  }
+
+  const { topic: topicData, certification } = result;
+
+  const title = `${topicData.name} - ServiceNow ${certification.name} Study Guide | SNReady`;
+  const description = `Learn ${topicData.name} for ServiceNow ${certification.name} certification. Comprehensive study guide with key concepts, exam tips, and practice questions.`;
+  
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: getCanonicalUrl(`/learn/${topic}`),
+    },
+    openGraph: {
+      title,
+      description,
+      url: getCanonicalUrl(`/learn/${topic}`),
+      images: ['/og-default.png'],
+    },
+    twitter: {
+      title,
+      description,
+      images: ['/og-default.png'],
+    },
+  };
+}
+
+export default async function LearnTopicPage({ params }: Props) {
+  const { topic } = await params;
+  
+  const result = findTopicBySlug(topic);
+  
+  if (!result) {
+    notFound();
+  }
+
+  const { topic: topicData, certification } = result;
+
+  const breadcrumbItems = [
+    { name: "Home", url: "/" },
+    { name: "Study Guides", url: "/learn" },
+    { name: topicData.name, url: `/learn/${topic}` },
+  ];
+
+  const articleSchema = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: `${topicData.name} - ServiceNow Study Guide`,
+    description: topicData.introduction?.overview || topicData.description,
+    author: {
+      "@type": "Organization",
+      name: "SNReady",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "SNReady",
+    },
+    datePublished: "2026-02-05",
+    dateModified: "2026-02-05",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": getCanonicalUrl(`/learn/${topic}`),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateBreadcrumbJsonLd(breadcrumbItems)),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(articleSchema),
+        }}
+      />
+
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+            <Link href="/" className="hover:text-zinc-700">Home</Link>
+            <span>→</span>
+            <Link href="/learn" className="hover:text-zinc-700">Study Guides</Link>
+            <span>→</span>
+            <span>{topicData.name}</span>
+          </div>
+          
+          <h1 className="mt-4 text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+            {topicData.name}
+          </h1>
+          <p className="mt-2 text-xl text-emerald-600">
+            ServiceNow {certification.name} Study Guide
+          </p>
+        </div>
+
+        {/* Topic Overview */}
+        {topicData.introduction && (
+          <div className="mt-8">
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-700 dark:bg-zinc-900">
+              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                Overview
+              </h2>
+              <p className="mt-3 text-zinc-700 dark:text-zinc-300 leading-relaxed">
+                {topicData.introduction.overview}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Why It Matters */}
+        {topicData.introduction?.whyItMatters && (
+          <div className="mt-6">
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 dark:border-amber-800 dark:bg-amber-950">
+              <h2 className="text-xl font-semibold text-amber-900 dark:text-amber-100">
+                Why It Matters for the Exam
+              </h2>
+              <p className="mt-3 text-amber-800 dark:text-amber-200 leading-relaxed">
+                {topicData.introduction.whyItMatters}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Key Concepts */}
+        {topicData.keyConcepts && topicData.keyConcepts.length > 0 && (
+          <div className="mt-6">
+            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+              Key Concepts to Master
+            </h2>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {topicData.keyConcepts.map((concept: string, index: number) => (
+                <div
+                  key={index}
+                  className="flex items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-800 dark:bg-emerald-950"
+                >
+                  <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-emerald-600 text-xs font-semibold text-white">
+                    {index + 1}
+                  </span>
+                  <span className="text-emerald-800 dark:text-emerald-200">
+                    {concept}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Exam Tips */}
+        {topicData.introduction?.examTips && (
+          <div className="mt-6">
+            <div className="rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-950">
+              <h2 className="text-xl font-semibold text-blue-900 dark:text-blue-100">
+                💡 Exam Tips & Strategy
+              </h2>
+              <p className="mt-3 text-blue-800 dark:text-blue-200 leading-relaxed">
+                {topicData.introduction.examTips}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Quick Stats */}
+        <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div className="text-center rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+            <div className="text-2xl font-bold text-emerald-600">
+              {topicData.questionCount}
+            </div>
+            <div className="text-sm text-zinc-600 dark:text-zinc-400">Practice Questions</div>
+          </div>
+          <div className="text-center rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+            <div className="text-2xl font-bold text-emerald-600">
+              {topicData.freeQuestionCount}
+            </div>
+            <div className="text-sm text-zinc-600 dark:text-zinc-400">Free Questions</div>
+          </div>
+          <div className="text-center rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+            <div className="text-2xl font-bold text-emerald-600">
+              {certification.domains?.find((d: { slug: string }) => d.slug === topicData.domain)?.percentage || "—"}%
+            </div>
+            <div className="text-sm text-zinc-600 dark:text-zinc-400">Exam Weight</div>
+          </div>
+          <div className="text-center rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+            <div className="text-2xl font-bold text-emerald-600">
+              {certification.name}
+            </div>
+            <div className="text-sm text-zinc-600 dark:text-zinc-400">Certification</div>
+          </div>
+        </div>
+
+        {/* Practice Links */}
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            Practice & Test Your Knowledge
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Link
+              href={`/${certification.slug}/questions/${topicData.slug}`}
+              className="rounded-lg border border-zinc-200 bg-white p-6 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                All Practice Questions
+              </h3>
+              <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                {topicData.questionCount} questions with detailed explanations
+              </p>
+              <span className="mt-2 inline-block text-sm font-medium text-emerald-600">
+                Start Practicing →
+              </span>
+            </Link>
+            <Link
+              href={`/free-questions/${certification.slug}/${topicData.slug}`}
+              className="rounded-lg border border-zinc-200 bg-white p-6 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                Free Sample Questions
+              </h3>
+              <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                {topicData.freeQuestionCount} free questions to try
+              </p>
+              <span className="mt-2 inline-block text-sm font-medium text-emerald-600">
+                Try for Free →
+              </span>
+            </Link>
+            <Link
+              href={`/study-guide/${certification.slug}`}
+              className="rounded-lg border border-zinc-200 bg-white p-6 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+            >
+              <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                Full Study Guide
+              </h3>
+              <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                Complete {certification.name} preparation plan
+              </p>
+              <span className="mt-2 inline-block text-sm font-medium text-emerald-600">
+                View Guide →
+              </span>
+            </Link>
+          </div>
+        </div>
+
+        {/* Related Topics */}
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            Related Topics in {certification.name}
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {getTopicsForCertification(certification.slug)
+              .filter(t => t.slug !== topicData.slug)
+              .slice(0, 6)
+              .map((relatedTopic) => (
+                <Link
+                  key={relatedTopic.slug}
+                  href={`/learn/${relatedTopic.slug}`}
+                  className="rounded border border-zinc-200 p-3 text-sm transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  <div className="font-medium text-zinc-900 dark:text-zinc-100">
+                    {relatedTopic.name}
+                  </div>
+                  <div className="text-zinc-600 dark:text-zinc-400">
+                    {certification.domains?.find((d: { slug: string }) => d.slug === relatedTopic.domain)?.percentage || "—"}% • {relatedTopic.questionCount} questions
+                  </div>
+                </Link>
+              ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import {
   getCertificationsGroupedByCategoryWithReadiness,
   getCategoryDisplayName,
   getSortedCategories,
+  isCertificationReady,
 } from "@/lib/data";
 import CertificationCard from "@/components/CertificationCard";
 
@@ -13,8 +14,12 @@ export default function Home() {
   const certifications = getAllCertifications();
   const groupedCerts = getCertificationsGroupedByCategoryWithReadiness();
   const sortedCategories = getSortedCategories();
-  const csaQuestionCount = getTotalQuestionCount("csa");
-  const csaFreeCount = getTotalFreeQuestionCount("csa");
+  
+  // Calculate total questions across all ready certifications
+  const readyCerts = ["csa", "cis-df"];
+  const totalQuestions = readyCerts.reduce((sum, cert) => sum + getTotalQuestionCount(cert), 0);
+  const totalFreeQuestions = readyCerts.reduce((sum, cert) => sum + getTotalFreeQuestionCount(cert), 0);
+  const activeCertifications = readyCerts.length;
 
   return (
     <div className="min-h-screen">
@@ -28,7 +33,7 @@ export default function Home() {
               Certification
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-lg text-zinc-600 dark:text-zinc-400">
-              Free practice tests, exam questions, and study guides for CSA, CAD,
+              Free practice tests, exam questions, and study guides for CSA, CIS-DF, CAD,
               CIS-ITSM, and more. Join thousands of IT professionals who passed
               their exams with SNReady.
             </p>
@@ -56,7 +61,7 @@ export default function Home() {
           <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
             <div className="text-center">
               <div className="text-3xl font-bold text-emerald-600">
-                {csaQuestionCount}+
+                {totalQuestions}+
               </div>
               <div className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                 Practice Questions
@@ -64,22 +69,22 @@ export default function Home() {
             </div>
             <div className="text-center">
               <div className="text-3xl font-bold text-emerald-600">
-                {csaFreeCount}+
+                {totalFreeQuestions}+
               </div>
               <div className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                 Free Questions
               </div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-emerald-600">20+</div>
+              <div className="text-3xl font-bold text-emerald-600">25+</div>
               <div className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                 Certifications
               </div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-emerald-600">94%</div>
+              <div className="text-3xl font-bold text-emerald-600">{activeCertifications}</div>
               <div className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                Pass Rate
+                Active Certifications
               </div>
             </div>
           </div>

--- a/app/practice-tests/[cert]/page.tsx
+++ b/app/practice-tests/[cert]/page.tsx
@@ -1,0 +1,365 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getCertificationBySlug,
+  getTopicsForCertification,
+  getCertificationSlugs,
+  getTotalQuestionCount,
+  isCertificationReady,
+  getDomainsForCertification,
+} from "@/lib/data";
+import { generateBreadcrumbJsonLd } from "@/lib/breadcrumbs";
+import { getCanonicalUrl } from "@/lib/seo";
+
+interface Props {
+  params: Promise<{
+    cert: string;
+  }>;
+}
+
+export async function generateStaticParams() {
+  return getCertificationSlugs().map((slug) => ({
+    cert: slug,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { cert } = await params;
+  
+  const certification = getCertificationBySlug(cert);
+  
+  if (!certification) {
+    return {
+      title: "Certification Not Found",
+    };
+  }
+
+  const title = `${certification.name} Practice Test - Free Mock Exam | SNReady`;
+  const description = `Take a free ${certification.name} practice test. Realistic ${certification.name} exam simulation with detailed explanations to help you pass your ServiceNow certification.`;
+  
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: getCanonicalUrl(`/practice-tests/${cert}`),
+    },
+    openGraph: {
+      title,
+      description,
+      url: getCanonicalUrl(`/practice-tests/${cert}`),
+      images: ['/og-default.png'],
+    },
+    twitter: {
+      title,
+      description,
+      images: ['/og-default.png'],
+    },
+  };
+}
+
+export default async function PracticeTestPage({ params }: Props) {
+  const { cert } = await params;
+  
+  const certification = getCertificationBySlug(cert);
+  const topics = getTopicsForCertification(cert);
+  const domains = getDomainsForCertification(cert);
+  const totalQuestions = getTotalQuestionCount(cert);
+  const isReady = isCertificationReady(cert);
+  
+  if (!certification) {
+    notFound();
+  }
+
+  const breadcrumbItems = [
+    { name: "Home", url: "/" },
+    { name: "Practice Tests", url: "/practice-tests" },
+    { name: certification.name, url: `/practice-tests/${cert}` },
+  ];
+
+  const courseSchema = {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    name: `${certification.name} Practice Test`,
+    description: `Comprehensive practice test for the ${certification.name} certification exam. Includes realistic questions and detailed explanations.`,
+    provider: {
+      "@type": "Organization",
+      name: "SNReady",
+    },
+    hasCourseInstance: {
+      "@type": "CourseInstance",
+      courseMode: "online",
+      courseWorkload: "PT2H",
+    },
+  };
+
+  const faqData = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: `How many questions are in the ${certification.name} practice test?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `The ${certification.name} practice test contains ${certification.examDetails?.questionCount || 'approximately 60'} questions, matching the actual exam format.`,
+        },
+      },
+      {
+        "@type": "Question",
+        name: `How long do I have to complete the practice test?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `You have ${certification.examDetails?.duration || '90 minutes'} to complete the practice test, matching the actual exam duration.`,
+        },
+      },
+      {
+        "@type": "Question",
+        name: `What is the passing score?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `The passing score is ${certification.examDetails?.passingScore || '70%'}, which matches the actual ${certification.name} exam requirement.`,
+        },
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateBreadcrumbJsonLd(breadcrumbItems)),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(courseSchema),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqData),
+        }}
+      />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+            <Link href="/" className="hover:text-zinc-700">Home</Link>
+            <span>→</span>
+            <Link href="/practice-tests" className="hover:text-zinc-700">Practice Tests</Link>
+            <span>→</span>
+            <span>{certification.name}</span>
+          </div>
+          
+          <h1 className="mt-4 text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+            {certification.name} Practice Test
+          </h1>
+          <p className="mt-2 text-xl text-emerald-600">
+            Free Mock Exam - {certification.name}
+          </p>
+          
+          <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+            {isReady 
+              ? `Simulate the real exam with ${totalQuestions} practice questions`
+              : `Coming soon - Practice exam for ${certification.name}`
+            }
+          </p>
+        </div>
+
+        {isReady ? (
+          <>
+            {/* Exam Overview */}
+            <div className="mt-8 rounded-lg border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-700 dark:bg-zinc-900">
+              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                Exam Overview
+              </h2>
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-emerald-600">
+                    {certification.examDetails?.questionCount || '60'}
+                  </div>
+                  <div className="text-sm text-zinc-600 dark:text-zinc-400">Questions</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-emerald-600">
+                    {certification.examDetails?.duration || '90 min'}
+                  </div>
+                  <div className="text-sm text-zinc-600 dark:text-zinc-400">Duration</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-emerald-600">
+                    {certification.examDetails?.passingScore || '70%'}
+                  </div>
+                  <div className="text-sm text-zinc-600 dark:text-zinc-400">Passing Score</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-emerald-600">
+                    ${certification.examDetails?.cost || '500'}
+                  </div>
+                  <div className="text-sm text-zinc-600 dark:text-zinc-400">Exam Cost</div>
+                </div>
+              </div>
+            </div>
+
+            {/* Domain Breakdown */}
+            {domains && domains.length > 0 && (
+              <div className="mt-8">
+                <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                  Exam Domains
+                </h2>
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {domains.map((domain, index) => (
+                    <div
+                      key={index}
+                      className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-700"
+                    >
+                      <div className="flex items-center justify-between">
+                        <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                          {domain.name}
+                        </h3>
+                        <span className="text-sm font-medium text-emerald-600">
+                          {domain.percentage}%
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                        {domain.description}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Topics Overview */}
+            <div className="mt-8">
+              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                Topics Covered
+              </h2>
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {topics.map((topic) => (
+                  <div key={topic.slug} className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
+                    <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                      {topic.name}
+                    </h3>
+                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                      {topic.questionCount} questions
+                    </p>
+                    <div className="mt-2 flex gap-2">
+                      <Link
+                        href={`/${cert}/questions/${topic.slug}`}
+                        className="text-sm text-emerald-600 hover:text-emerald-700"
+                      >
+                        Practice
+                      </Link>
+                      <Link
+                        href={`/free-questions/${cert}/${topic.slug}`}
+                        className="text-sm text-emerald-600 hover:text-emerald-700"
+                      >
+                        Free Questions
+                      </Link>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Start Practice Test CTA */}
+            <div className="mt-12 text-center">
+              <div className="rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+                <h2 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
+                  Ready to Test Your Knowledge?
+                </h2>
+                <p className="mt-2 text-emerald-700 dark:text-emerald-300">
+                  Take the full practice exam or choose specific topics to focus on
+                </p>
+                
+                <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-center">
+                  <Link
+                    href={`/certifications/${cert}`}
+                    className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-8 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+                  >
+                    Start Practice Test
+                  </Link>
+                  <Link
+                    href={`/study-guide/${cert}`}
+                    className="inline-flex items-center justify-center rounded-lg border border-emerald-600 px-8 py-3 font-semibold text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950"
+                  >
+                    View Study Guide
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Coming Soon */}
+            <div className="mt-12 text-center">
+              <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-8 dark:border-zinc-700 dark:bg-zinc-900">
+                <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  Coming Soon
+                </h2>
+                <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+                  The {certification.name} practice test is currently being developed.
+                </p>
+                <p className="mt-4 text-zinc-600 dark:text-zinc-400">
+                  While you wait, try our comprehensive CSA practice test with detailed explanations and exam simulation.
+                </p>
+                
+                <div className="mt-6">
+                  <Link
+                    href="/practice-tests/csa"
+                    className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-8 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+                  >
+                    Try CSA Practice Test
+                  </Link>
+                </div>
+              </div>
+            </div>
+
+            {/* Available Certifications */}
+            <div className="mt-8">
+              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                Available Practice Tests
+              </h2>
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <Link
+                  href="/practice-tests/csa"
+                  className="rounded-lg border border-zinc-200 p-6 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                    CSA - Certified System Administrator
+                  </h3>
+                  <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                    Full practice test with 200+ questions
+                  </p>
+                  <span className="mt-2 inline-block text-sm font-medium text-emerald-600">
+                    Available Now →
+                  </span>
+                </Link>
+                <Link
+                  href="/practice-tests/cis-df"
+                  className="rounded-lg border border-zinc-200 p-6 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                >
+                  <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                    CIS-Discovery - Discovery Implementation
+                  </h3>
+                  <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                    Comprehensive discovery practice questions
+                  </p>
+                  <span className="mt-2 inline-block text-sm font-medium text-emerald-600">
+                    Available Now →
+                  </span>
+                </Link>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@ import {
   getAllQuestionIds,
   getAllDeltaSlugs,
   getActiveReleases,
+  getAllGlossaryTermSlugs,
 } from "@/lib/data";
 import { getAllComparisonSlugs } from "@/lib/comparisons";
 
@@ -22,6 +23,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const questionIds = await getAllQuestionIds();
   const deltaSlugs = getAllDeltaSlugs();
   const activeReleases = getActiveReleases();
+  const glossaryTermSlugs = getAllGlossaryTermSlugs();
 
   // Static pages
   const staticPages: MetadataRoute.Sitemap = [
@@ -129,6 +131,30 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.8,
   }));
 
+  // Study guide pages (NEW)
+  const studyGuidePages: MetadataRoute.Sitemap = certSlugs.map((slug) => ({
+    url: `${BASE_URL}/study-guide/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.8,
+  }));
+
+  // Glossary pages (NEW)
+  const glossaryPages: MetadataRoute.Sitemap = [
+    {
+      url: `${BASE_URL}/glossary`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    },
+    ...glossaryTermSlugs.map((slug) => ({
+      url: `${BASE_URL}/glossary/${slug}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    })),
+  ];
+
   return [
     ...staticPages,
     ...certPages,
@@ -141,5 +167,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...individualQuestionPages,
     ...freeQuestionPages,
     ...learnPages,
+    ...studyGuidePages,
+    ...glossaryPages,
   ];
 }

--- a/app/study-guide/[cert]/page.tsx
+++ b/app/study-guide/[cert]/page.tsx
@@ -1,0 +1,337 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getCertificationBySlug,
+  getTopicsForCertification,
+  getCertificationSlugs,
+  getTotalQuestionCount,
+  getTotalFreeQuestionCount,
+} from "@/lib/data";
+import { generateBreadcrumbJsonLd } from "@/lib/breadcrumbs";
+import { getCanonicalUrl } from "@/lib/seo";
+
+interface Props {
+  params: Promise<{
+    cert: string;
+  }>;
+}
+
+export async function generateStaticParams() {
+  return getCertificationSlugs().map((slug) => ({
+    cert: slug,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { cert } = await params;
+  
+  const certification = getCertificationBySlug(cert);
+  
+  if (!certification) {
+    return {
+      title: "Certification Not Found",
+    };
+  }
+
+  const title = `${certification.name} Study Guide 2026 - Exam Prep Plan | SNReady`;
+  const description = `Complete ${certification.name} study guide with exam overview, topic breakdown, and preparation strategy. Pass your ${certification.name} certification with our structured study plan.`;
+  
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: getCanonicalUrl(`/study-guide/${cert}`),
+    },
+    openGraph: {
+      title,
+      description,
+      url: getCanonicalUrl(`/study-guide/${cert}`),
+      images: ['/og-default.png'],
+    },
+    twitter: {
+      title,
+      description,
+      images: ['/og-default.png'],
+    },
+  };
+}
+
+export default async function StudyGuidePage({ params }: Props) {
+  const { cert } = await params;
+  
+  const certification = getCertificationBySlug(cert);
+  const topics = getTopicsForCertification(cert);
+  const totalQuestions = getTotalQuestionCount(cert);
+  const totalFreeQuestions = getTotalFreeQuestionCount(cert);
+  
+  if (!certification) {
+    notFound();
+  }
+
+  // Sort topics by domain weight (heaviest first) for recommended order
+  const getDomainWeight = (topic: typeof topics[0]) => {
+    const domain = certification.domains.find(d => d.slug === topic.domain);
+    return domain?.percentage || 0;
+  };
+  const sortedTopics = [...topics].sort((a, b) => getDomainWeight(b) - getDomainWeight(a));
+
+  const breadcrumbItems = [
+    { name: "Home", url: "/" },
+    { name: "Study Guides", url: "/study-guide" },
+    { name: certification.name, url: `/study-guide/${cert}` },
+  ];
+
+  const faqData = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: `How to pass ${certification.name}?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `To pass the ${certification.name} exam, focus on the highest-weighted topics first, practice with realistic questions, and understand key concepts thoroughly. Allow 2-3 months for preparation and take multiple practice tests.`,
+        },
+      },
+      {
+        "@type": "Question",
+        name: `What to study for ${certification.name}?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `Study ${certification.name} exam domains including: ${topics.slice(0, 3).map(t => t.name).join(', ')}, and other core platform concepts. Focus on hands-on experience and understanding of ServiceNow functionality.`,
+        },
+      },
+      {
+        "@type": "Question",
+        name: `How long to prepare for ${certification.name}?`,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: `Most candidates need 2-3 months of dedicated study for ${certification.name}. This includes studying theory, hands-on practice, and taking multiple practice exams. Your timeline may vary based on your ServiceNow experience.`,
+        },
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(generateBreadcrumbJsonLd(breadcrumbItems)),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqData),
+        }}
+      />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center">
+          <div className="flex items-center justify-center gap-2 text-sm text-zinc-500">
+            <Link href="/" className="hover:text-zinc-700">Home</Link>
+            <span>→</span>
+            <Link href="/study-guide" className="hover:text-zinc-700">Study Guides</Link>
+            <span>→</span>
+            <span>{certification.name}</span>
+          </div>
+          
+          <h1 className="mt-4 text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+            {certification.name} Study Guide
+          </h1>
+          <p className="mt-2 text-xl text-emerald-600">
+            Complete 2026 Exam Preparation Plan
+          </p>
+          
+          <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+            Strategic study plan to pass your {certification.name} certification
+          </p>
+        </div>
+
+        {/* Exam Overview */}
+        <div className="mt-8 rounded-lg border border-zinc-200 bg-zinc-50 p-6 dark:border-zinc-700 dark:bg-zinc-900">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            📋 Exam Overview
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Questions</h3>
+              <p className="text-2xl font-bold text-emerald-600">
+                {certification.examDetails?.questionCount || '60'}
+              </p>
+              <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                Multiple choice & scenario
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Duration</h3>
+              <p className="text-2xl font-bold text-emerald-600">
+                {certification.examDetails?.duration || '90 minutes'}
+              </p>
+              <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                Time to complete
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Passing Score</h3>
+              <p className="text-2xl font-bold text-emerald-600">
+                {certification.examDetails?.passingScore || '70%'}
+              </p>
+              <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                Minimum required
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Cost</h3>
+              <p className="text-2xl font-bold text-emerald-600">
+                ${certification.examDetails?.cost || '500'}
+              </p>
+              <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                Exam fee (USD)
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Preparation Strategy */}
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            🎯 Recommended Study Order
+          </h2>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            Focus on high-weight topics first for maximum impact. Topics are ordered by exam weight.
+          </p>
+          
+          <div className="mt-6 space-y-4">
+            {sortedTopics.map((topic, index) => (
+              <div
+                key={topic.slug}
+                className="rounded-lg border border-zinc-200 p-6 dark:border-zinc-700"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-100 text-sm font-semibold text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300">
+                        {index + 1}
+                      </span>
+                      <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                        {topic.name}
+                      </h3>
+                      <span className="rounded bg-emerald-100 px-2 py-1 text-sm font-medium text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300">
+                        {getDomainWeight(topic)}% weight
+                      </span>
+                    </div>
+                    
+                    <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+                      {topic.description}
+                    </p>
+
+                    {/* Key Concepts */}
+                    {topic.keyConcepts && topic.keyConcepts.length > 0 && (
+                      <div className="mt-4">
+                        <h4 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          Key Concepts to Master:
+                        </h4>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {topic.keyConcepts.slice(0, 5).map((concept: string, conceptIndex: number) => (
+                            <span
+                              key={conceptIndex}
+                              className="rounded bg-zinc-100 px-2 py-1 text-xs text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                            >
+                              {concept}
+                            </span>
+                          ))}
+                          {topic.keyConcepts.length > 5 && (
+                            <span className="text-xs text-zinc-500">
+                              +{topic.keyConcepts.length - 5} more
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Action Links */}
+                    <div className="mt-4 flex flex-wrap gap-3">
+                      <Link
+                        href={`/${cert}/questions/${topic.slug}`}
+                        className="text-sm text-emerald-600 hover:text-emerald-700"
+                      >
+                        Practice ({topic.questionCount} questions)
+                      </Link>
+                      <Link
+                        href={`/free-questions/${cert}/${topic.slug}`}
+                        className="text-sm text-emerald-600 hover:text-emerald-700"
+                      >
+                        Free Questions ({topic.freeQuestionCount})
+                      </Link>
+                      <Link
+                        href={`/learn/${topic.slug}`}
+                        className="text-sm text-emerald-600 hover:text-emerald-700"
+                      >
+                        Learn Concepts
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Practice Resources */}
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+          <div className="text-center">
+            <h2 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
+              Ready to Start Practicing?
+            </h2>
+            <p className="mt-2 text-emerald-700 dark:text-emerald-300">
+              Test your knowledge with {totalQuestions} practice questions and {totalFreeQuestions} free samples
+            </p>
+            
+            <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-center">
+              <Link
+                href={`/practice-tests/${cert}`}
+                className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-8 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+              >
+                Take Practice Test
+              </Link>
+              <Link
+                href={`/certifications/${cert}`}
+                className="inline-flex items-center justify-center rounded-lg border border-emerald-600 px-8 py-3 font-semibold text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950"
+              >
+                Browse All Topics
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Study Tips */}
+        <div className="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-950">
+          <h2 className="text-xl font-semibold text-blue-900 dark:text-blue-100">
+            💡 Study Tips & Strategy
+          </h2>
+          <div className="mt-4 space-y-3 text-blue-800 dark:text-blue-200">
+            <p>
+              <strong>1. Focus on Experience:</strong> ServiceNow exams emphasize practical knowledge. Get hands-on experience in a ServiceNow instance.
+            </p>
+            <p>
+              <strong>2. Follow the Weight:</strong> Prioritize topics with higher exam weights for maximum score impact.
+            </p>
+            <p>
+              <strong>3. Practice Regularly:</strong> Take practice tests weekly to identify weak areas and track progress.
+            </p>
+            <p>
+              <strong>4. Review Explanations:</strong> Don't just memorize answers - understand why incorrect options are wrong.
+            </p>
+            <p>
+              <strong>5. Time Management:</strong> Practice under timed conditions to ensure you can complete the exam within the time limit.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -294,6 +294,108 @@ export function getCertificationsGroupedByCategoryWithReadiness(): Record<
 }
 
 // =============================================================================
+// Glossary Helpers
+// =============================================================================
+
+export interface GlossaryTerm {
+  slug: string;
+  name: string;
+  certifications: Array<{
+    certSlug: string;
+    certName: string;
+    topics: Array<{
+      topicSlug: string;
+      topicName: string;
+    }>;
+  }>;
+}
+
+// Extract all unique key concepts from all topics across all certifications
+export function getAllGlossaryTerms(): GlossaryTerm[] {
+  const termMap = new Map<string, GlossaryTerm>();
+  
+  // Iterate through all certifications and their topics
+  for (const certSlug of Object.keys(topicsMap)) {
+    const certification = getCertificationBySlug(certSlug);
+    if (!certification) continue;
+    
+    const topics = getTopicsForCertification(certSlug);
+    
+    for (const topic of topics) {
+      if (topic.keyConcepts && Array.isArray(topic.keyConcepts)) {
+        for (const concept of topic.keyConcepts) {
+          // Create a slug from the concept name
+          const slug = concept
+            .toLowerCase()
+            .replace(/[^a-z0-9\s]/g, '')
+            .replace(/\s+/g, '-')
+            .trim();
+          
+          if (!termMap.has(slug)) {
+            termMap.set(slug, {
+              slug,
+              name: concept,
+              certifications: [],
+            });
+          }
+          
+          const term = termMap.get(slug)!;
+          
+          // Find or create certification entry
+          let certEntry = term.certifications.find(c => c.certSlug === certSlug);
+          if (!certEntry) {
+            certEntry = {
+              certSlug,
+              certName: certification.name,
+              topics: [],
+            };
+            term.certifications.push(certEntry);
+          }
+          
+          // Add topic if not already present
+          if (!certEntry.topics.find(t => t.topicSlug === topic.slug)) {
+            certEntry.topics.push({
+              topicSlug: topic.slug,
+              topicName: topic.name,
+            });
+          }
+        }
+      }
+    }
+  }
+  
+  // Convert to array and sort alphabetically
+  return Array.from(termMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Get glossary term by slug
+export function getGlossaryTermBySlug(slug: string): GlossaryTerm | undefined {
+  const allTerms = getAllGlossaryTerms();
+  return allTerms.find(term => term.slug === slug);
+}
+
+// Get glossary terms grouped alphabetically
+export function getGlossaryTermsGroupedAlphabetically(): Record<string, GlossaryTerm[]> {
+  const allTerms = getAllGlossaryTerms();
+  const grouped: Record<string, GlossaryTerm[]> = {};
+  
+  for (const term of allTerms) {
+    const firstLetter = term.name.charAt(0).toUpperCase();
+    if (!grouped[firstLetter]) {
+      grouped[firstLetter] = [];
+    }
+    grouped[firstLetter].push(term);
+  }
+  
+  return grouped;
+}
+
+// Generate static params for glossary pages
+export function getAllGlossaryTermSlugs(): string[] {
+  return getAllGlossaryTerms().map(term => term.slug);
+}
+
+// =============================================================================
 // Delta Exam Helpers
 // =============================================================================
 


### PR DESCRIPTION
## SEO Audit Implementation

All 4 phases from the SEO audit, in a single PR.

### Phase 1 — Fix Sitemap 404s
These URLs were already in `sitemap.xml` but had no route files (generating 404s for Google):

- **`/free-questions/[cert]/[topic]`** — Free question pages with CTA to unlock full access (13 pages)
- **`/practice-tests/[cert]`** — Mock exam hub pages with domain breakdown (21 pages)
- **`/learn/[topic]`** — Concept explainer pages with key concepts, exam tips, and related questions (13 pages)

### Phase 2 — Technical SEO Hardening
- WebSite + Organization JSON-LD added to layout (sitelinks search box)
- Question page titles improved: `Q#: Topic – Cert Practice | SNReady`
- Fixed `dateCreated` in question JSON-LD (was regenerating on every build)
- Expanded footer with certification links, resources, and popular comparisons
- Updated homepage stats to show total questions (271) across all certs
- Added CIS-DF to navigation bar

### Phase 3 — New pSEO Templates
- **`/study-guide/[cert]`** — Exam prep plan with weighted topic order, key concepts, and FAQs (21 pages)
- **`/glossary/[term]`** — Concept definition pages extracted from topic keyConcepts (108 pages)
- **`/glossary`** — Alphabetical index of all glossary terms
- Updated `sitemap.ts` to include all new page types

### Phase 4 — Polish
- OG image metadata on all new pages
- `<Link>` components in nav (replaces raw `<a>` tags)

### Impact
| Metric | Before | After |
|--------|--------|-------|
| Indexable pages | ~369 | ~540+ |
| Sitemap 404s | ~55 | 0 |
| Structured data types | 4 | 6 |
| New page templates | 0 | 6 |

### Build
`npm run build` passes ✅ — all pages generate successfully.