### PR TITLE
fix: Mobile responsive layout (#4)

### DIFF
--- a/app/[certification]/questions/[topic]/page.tsx
+++ b/app/[certification]/questions/[topic]/page.tsx
@@ -179,7 +179,7 @@ export default async function TopicQuestionsPage({ params }: PageProps) {
                   />
                 ))
               ) : (
-                <div className="rounded-xl border border-zinc-200 bg-white p-12 text-center dark:border-zinc-800 dark:bg-zinc-900">
+                <div className="rounded-xl border border-zinc-200 bg-white p-6 sm:p-12 text-center dark:border-zinc-800 dark:bg-zinc-900">
                   <p className="text-zinc-500">
                     Questions for this topic are coming soon!
                   </p>

--- a/app/certifications/[slug]/page.tsx
+++ b/app/certifications/[slug]/page.tsx
@@ -416,7 +416,7 @@ export default async function CertificationPage({ params }: PageProps) {
                 ))}
               </div>
             ) : (
-              <div className="mt-8 rounded-xl border-2 border-dashed border-zinc-200 bg-zinc-50/50 p-10 text-center dark:border-zinc-700 dark:bg-zinc-800/50">
+              <div className="mt-8 rounded-xl border-2 border-dashed border-zinc-200 bg-zinc-50/50 p-6 sm:p-10 text-center dark:border-zinc-700 dark:bg-zinc-800/50">
                 <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
                   <svg className="h-6 w-6 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/app/delta/[slug]/page.tsx
+++ b/app/delta/[slug]/page.tsx
@@ -527,7 +527,7 @@ export default async function DeltaExamPage({ params }: PageProps) {
                 ))}
               </div>
             ) : (
-              <div className="mt-8 rounded-xl border-2 border-dashed border-zinc-200 bg-zinc-50/50 p-10 text-center dark:border-zinc-700 dark:bg-zinc-800/50">
+              <div className="mt-8 rounded-xl border-2 border-dashed border-zinc-200 bg-zinc-50/50 p-6 sm:p-10 text-center dark:border-zinc-700 dark:bg-zinc-800/50">
                 <p className="text-lg font-medium text-zinc-600 dark:text-zinc-300">
                   Practice questions coming soon
                 </p>

--- a/app/free-questions/[cert]/[topic]/page.tsx
+++ b/app/free-questions/[cert]/[topic]/page.tsx
@@ -197,7 +197,7 @@ export default async function FreeQuestionsPage({ params }: Props) {
         </div>
 
         {/* Unlock CTA */}
-        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-4 sm:p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
           <h3 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
             Unlock Full Access
           </h3>

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,8 +19,13 @@
   }
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  overflow-x: hidden;
 }

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -123,7 +123,7 @@ export default function GlossaryIndexPage() {
         </div>
 
         {/* Study Resources */}
-        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-4 sm:p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
           <h2 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
             Master These Concepts
           </h2>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -110,7 +110,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}
       >
         <nav className="border-b border-zinc-200 dark:border-zinc-800">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
@@ -155,7 +155,7 @@ export default function RootLayout({
             </div>
           </div>
         </nav>
-        <main>{children}</main>
+        <main className="min-w-0 overflow-x-hidden">{children}</main>
         <footer className="border-t border-zinc-200 py-12 dark:border-zinc-800">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="grid grid-cols-1 gap-8 md:grid-cols-4">

--- a/app/practice-tests/[cert]/page.tsx
+++ b/app/practice-tests/[cert]/page.tsx
@@ -270,7 +270,7 @@ export default async function PracticeTestPage({ params }: Props) {
 
             {/* Start Practice Test CTA */}
             <div className="mt-12 text-center">
-              <div className="rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+              <div className="rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-4 sm:p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
                 <h2 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
                   Ready to Test Your Knowledge?
                 </h2>
@@ -299,7 +299,7 @@ export default async function PracticeTestPage({ params }: Props) {
           <>
             {/* Coming Soon */}
             <div className="mt-12 text-center">
-              <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-8 dark:border-zinc-700 dark:bg-zinc-900">
+              <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4 sm:p-8 dark:border-zinc-700 dark:bg-zinc-900">
                 <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
                   Coming Soon
                 </h2>

--- a/app/study-guide/[cert]/page.tsx
+++ b/app/study-guide/[cert]/page.tsx
@@ -282,7 +282,7 @@ export default async function StudyGuidePage({ params }: Props) {
         </div>
 
         {/* Practice Resources */}
-        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-4 sm:p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
           <div className="text-center">
             <h2 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
               Ready to Start Practicing?

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -92,7 +92,7 @@ export default function QuestionCard({
   };
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 sm:p-6 dark:border-zinc-800 dark:bg-zinc-900">
       {/* Question Header */}
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-center gap-3">

--- a/components/TopicIntroduction.tsx
+++ b/components/TopicIntroduction.tsx
@@ -10,7 +10,7 @@ export default function TopicIntroduction({ topic }: TopicIntroductionProps) {
   const { overview, whyItMatters, keyConcepts, examTips } = topic.introduction;
 
   return (
-    <section className="mb-12 rounded-xl border border-zinc-200 bg-white p-8 dark:border-zinc-800 dark:bg-zinc-900">
+    <section className="mb-12 rounded-xl border border-zinc-200 bg-white p-4 sm:p-8 dark:border-zinc-800 dark:bg-zinc-900">
       <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-50">
         About {topic.name}
       </h2>


### PR DESCRIPTION
Fixes #4

## Problem
Pages weren't mobile responsive — content was clipping on the left edge on narrow viewports. The root cause was horizontal overflow: some elements were wider than the viewport, causing the page to scroll horizontally.

## Fix
- **overflow-x: hidden** on `html`, `body`, and `main` to prevent horizontal scroll
- **Responsive padding** on all card/section elements (`p-4 sm:p-8` instead of `p-8`)
- **QuestionCard**: `p-4 sm:p-6` (was `p-6`)
- **TopicIntroduction**: `p-4 sm:p-8` (was `p-8`)
- **CTA sections**: `p-6 sm:p-12` (was `p-12`)
- **`min-w-0`** on main element to prevent grid/flex overflow

11 files changed across layout, components, and page files.