### PR TITLE
🚀 feat: CAD certification — 130 practice questions across 7 domains

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
   const sortedCategories = getSortedCategories();
   
   // Calculate total questions across all ready certifications
-  const readyCerts = ["csa", "cis-df"];
+  const readyCerts = ["csa", "cis-df", "cad"];
   const totalQuestions = readyCerts.reduce((sum, cert) => sum + getTotalQuestionCount(cert), 0);
   const totalFreeQuestions = readyCerts.reduce((sum, cert) => sum + getTotalFreeQuestionCount(cert), 0);
   const activeCertifications = readyCerts.length;
@@ -171,6 +171,50 @@ export default function Home() {
               className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400"
             >
               View all CSA topics →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Topics Preview (CAD) */}
+      <section className="py-20">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <div className="text-center">
+            <h2 className="text-3xl font-bold text-zinc-900 dark:text-zinc-50">
+              CAD Exam Topics
+            </h2>
+            <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+              Master ServiceNow application development with 130+ practice questions
+            </p>
+          </div>
+          <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              { name: "Scripting & APIs", slug: "scripting-apis", icon: "💻" },
+              { name: "Business Rules", slug: "business-rules", icon: "⚙️" },
+              { name: "Client Scripts", slug: "client-scripts", icon: "🖥️" },
+              { name: "UI Policies", slug: "ui-policies-actions", icon: "🎨" },
+              { name: "Script Includes", slug: "script-includes", icon: "📦" },
+              { name: "REST APIs", slug: "integration-rest", icon: "🔗" },
+              { name: "App Development", slug: "application-development", icon: "🏗️" },
+            ].map((topic) => (
+              <Link
+                key={topic.slug}
+                href={`/cad/questions/${topic.slug}`}
+                className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white p-4 transition-all hover:border-emerald-300 hover:shadow dark:border-zinc-800 dark:bg-zinc-800 dark:hover:border-emerald-700"
+              >
+                <span className="text-2xl">{topic.icon}</span>
+                <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                  {topic.name}
+                </span>
+              </Link>
+            ))}
+          </div>
+          <div className="mt-8 text-center">
+            <Link
+              href="/certifications/cad"
+              className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400"
+            >
+              View all CAD topics →
             </Link>
           </div>
         </div>

--- a/data/questions/cad/application-development.json
+++ b/data/questions/cad/application-development.json
@@ -1,0 +1,3333 @@
+{
+  "questions": [
+    {
+      "id": "cad-application-development-001",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Where can ServiceNow developers find vetted partner applications that include vendor support and quality assurance?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The Developer Share on developer.servicenow.com"
+        },
+        {
+          "id": "b",
+          "text": "The ServiceNow Store on store.servicenow.com"
+        },
+        {
+          "id": "c",
+          "text": "The ServiceNow documentation site at docs.servicenow.com"
+        },
+        {
+          "id": "d",
+          "text": "The Plugins module within the ServiceNow instance"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The ServiceNow Store at store.servicenow.com hosts partner applications that follow a vendor license agreement, include support, and are quality tested by ServiceNow before being published. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/servicenow-store/concept/servicenow-store.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The Developer Share on developer.servicenow.com is a community-driven repository where individuals share content for free, but it does not come with guaranteed support or quality assurance.",
+            "reference": "https://developer.servicenow.com/dev.do#!/share"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "docs.servicenow.com is the official documentation site for ServiceNow product documentation, not a marketplace for partner applications.",
+            "reference": "https://docs.servicenow.com"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The Plugins module allows activation of ServiceNow-provided platform plugins, not third-party partner applications from the store.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/plugins/concept/c_PluginManagement.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - ServiceNow Store"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-overview.md",
+        "excerpt": "on store.servicenow.com, there are additional applications ready for sale. Sometimes the sale price is nothing. And sometimes it's a lot more than nothing. But the point is, even if you have to make a corporate purchase there, it might be cheaper than paying for a whole development cycle of building a custom app. Check to see what experts out there have already built. And the things that are on store.servicenow.com follow a vendor license agreement. They agree to provide some form of support. And generally, these things are vetted. They are quality tested to make sure that ServiceNow does not place lemons up upon their virtual shelves."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "servicenow-store",
+          "partner-applications",
+          "application-marketplace"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-002",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the system name of the table where custom application records are stored in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "sys_scope"
+        },
+        {
+          "id": "b",
+          "text": "sys_app"
+        },
+        {
+          "id": "c",
+          "text": "sys_application"
+        },
+        {
+          "id": "d",
+          "text": "sys_custom_app"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Custom application records are stored on the sys_app table (Custom Apps table). When you create an application in ServiceNow Studio, the application record is created on this table. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "sys_scope is the Application Scope table, which stores scope records but is not the primary table for custom application records created through Studio.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "sys_application is the Application Menus table used for navigation modules, not the table for custom application records.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-user-interface/page/administer/navigation-and-ui/concept/c_NavigationAndModules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "sys_custom_app is not a valid ServiceNow system table. Custom applications are stored on the sys_app table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Custom Application Development"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-tools-overview-and-create-a-cust.md",
+        "excerpt": "This is tantamount to accessing the loaner request record on the Custom Apps table, whose system name is sys_app."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "sys_app",
+          "custom-applications",
+          "tables"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-003",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "How does the ServiceNow Developer Share differ from the ServiceNow Store?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Developer Share applications are pre-installed on all ServiceNow instances"
+        },
+        {
+          "id": "b",
+          "text": "Developer Share provides community-contributed content without guaranteed support or quality"
+        },
+        {
+          "id": "c",
+          "text": "Developer Share applications include vendor license agreements and dedicated support"
+        },
+        {
+          "id": "d",
+          "text": "Developer Share requires a paid enterprise subscription to access"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The Developer Share at developer.servicenow.com is a community-driven repository where ServiceNow developers share applications and utilities for free, but unlike the ServiceNow Store, it does not come with any guarantee of support or quality. See https://developer.servicenow.com/dev.do#!/share",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Developer Share applications are not pre-installed. They must be manually downloaded and imported into an instance by the developer.",
+            "reference": "https://developer.servicenow.com/dev.do#!/share"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Vendor license agreements and dedicated support are characteristics of the ServiceNow Store (store.servicenow.com), not the Developer Share. The Developer Share explicitly does not guarantee support or quality.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/servicenow-store/concept/servicenow-store.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The Developer Share is free to access. Anyone in the ServiceNow community can share and download content without a paid subscription.",
+            "reference": "https://developer.servicenow.com/dev.do#!/share"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Developer Share"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-overview.md",
+        "excerpt": "unlike the ServiceNow store, the Developer Share that's at developer.servicenow.com doesn't come with any guarantee of support or equality. But boy, there's some great stuff out there. And it's an active community with new stuff being added every day."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "developer-share",
+          "community",
+          "servicenow-store"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-004",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "When creating a new custom application in ServiceNow Studio, which configurations are compulsory during the initial creation process?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Application name, user roles, and at least one data table"
+        },
+        {
+          "id": "b",
+          "text": "Application name, user roles, data tables, and navigation modules"
+        },
+        {
+          "id": "c",
+          "text": "Application name and user roles only"
+        },
+        {
+          "id": "d",
+          "text": "Application name, scope, and an update set"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "When creating a custom application in ServiceNow Studio, only the Application Configurations (including the name and scope) and User Roles are compulsory. Tables, navigation records, and other elements are created as subsequent steps. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_CreateCustomApplication.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "While creating at least one table is a recommended next step after application creation, it is not required during the initial creation process in Studio.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_CreateCustomApplication.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Tables and navigation modules are important parts of application development but are not compulsory during the initial app creation wizard in Studio. They are typically added afterward.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_CreateCustomApplication.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "While scope selection is part of the application configuration, update sets are not created as a compulsory step during initial app creation. The application scope is determined but a separate update set is not explicitly required at creation time.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_CreateCustomApplication.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Create a Custom Application"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-tools-overview-and-create-a-cust.md",
+        "excerpt": "really only these first two panels that we see on this slide, Application Configurations and User Roles, are all that's compulsory. ServiceNow doesn't really force you to do anything else."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "ServiceNow Studio IDE",
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "studio",
+          "application-creation",
+          "roles",
+          "custom-application"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-005",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A company wants to consolidate their employee laptop loan process into ServiceNow. Currently, employees send an email to IT, and someone manually tracks requests in a spreadsheet. The process follows a clear request-to-fulfillment workflow. Is this a good candidate for a ServiceNow custom application?",
+      "options": [
+        {
+          "id": "a",
+          "text": "No, because equipment tracking involves unstructured data that doesn't fit a relational database"
+        },
+        {
+          "id": "b",
+          "text": "No, because loan management requires proprietary hardware-integration libraries"
+        },
+        {
+          "id": "c",
+          "text": "Yes, because it follows a request-fulfill pattern with structured data and a defined process flow"
+        },
+        {
+          "id": "d",
+          "text": "Yes, but only if implemented using Application Engine Studio instead of ServiceNow Studio"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "An equipment loan process that follows a request-fulfill pattern with structured data (requester, item, dates, status) is an ideal candidate for a ServiceNow custom application. The data maps well to a relational database, it follows a clear process flow, and it benefits from automation and reporting. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Equipment loan data (requester, device type, loan dates, approval status) is highly structured and maps perfectly to a relational database model, making it an excellent fit for ServiceNow.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "A laptop loan tracking system does not require proprietary hardware libraries. It primarily involves data management, approvals, and workflow automation — all native ServiceNow capabilities.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Both ServiceNow Studio and Application Engine Studio can be used to build custom applications. The choice of development environment does not determine whether the use case is a good fit for the platform.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Development"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-overview.md",
+        "excerpt": "the process follows a request-fulfill pattern, to me, that's the big one. And if you think about it, so much that we do in day-to-day life meets that pattern. Someone wants something, and it's someone else's job to make that thing happen."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "custom-application",
+          "request-fulfill",
+          "use-case-evaluation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-006",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_select",
+      "question": "Which of the following are application development tools or environments available on the ServiceNow platform? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "ServiceNow Studio"
+        },
+        {
+          "id": "b",
+          "text": "Flow Designer"
+        },
+        {
+          "id": "c",
+          "text": "Eclipse IDE with ServiceNow plugin"
+        },
+        {
+          "id": "d",
+          "text": "Application Engine Studio"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "ServiceNow Studio is the integrated development environment for pro-code application development. Application Engine Studio provides a guided, low-code environment for building applications. Flow Designer enables building automated workflows and processes. All three are native ServiceNow platform tools. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "Eclipse IDE is not a ServiceNow-native development tool. ServiceNow provides its own browser-based development environments (Studio and Application Engine Studio) rather than requiring external IDE installations.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Development Tools"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-tools-overview-and-create-a-cust.md",
+        "excerpt": "ServiceNow Studio... is kind of your one-stop shop for doing development, including more Pro code development like we'll be doing. Not covered in this class is Application Engine Studio, which is more of a guided environment, more of a low-code environment for getting simpler apps off the ground quickly... we're going to use the Flow Designer to create a nice flow that will automate a fulfillment process"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "ServiceNow Studio IDE"
+        ],
+        "tags": [
+          "studio",
+          "flow-designer",
+          "application-engine-studio",
+          "development-tools"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-007",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "In ServiceNow Studio, how are application development changes managed when external source control repository integration is not available?",
+      "options": [
+        {
+          "id": "a",
+          "text": "By automatically syncing to a built-in Git repository"
+        },
+        {
+          "id": "b",
+          "text": "By using update sets to track and manage changes"
+        },
+        {
+          "id": "c",
+          "text": "By exporting XML backup files after each save operation"
+        },
+        {
+          "id": "d",
+          "text": "By creating system clone snapshots at regular intervals"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When ServiceNow Studio does not connect to an external source control repository, update sets are used to manage development changes. Update sets capture and group configuration changes, allowing them to be moved between instances. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "ServiceNow Studio does not include a built-in Git repository. Source control integration is a separate capability, and when unavailable, update sets serve as the change management mechanism.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "While XML export is possible for individual records, Studio does not automatically export XML backup files as its change management approach. Update sets are the standard mechanism.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "System clones copy an entire instance and are used for refreshing sub-production environments, not for tracking individual development changes within Studio.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/managing-data/concept/c_SystemClone.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Update Sets"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-tools-overview-and-create-a-cust.md",
+        "excerpt": "In this release, ServiceNow Studio does not connect to an external source control repository, so we'll be using update sets to manage our development."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Source control integration"
+        ],
+        "tags": [
+          "update-sets",
+          "source-control",
+          "studio",
+          "change-management"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-008",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A development team is evaluating several project ideas for custom ServiceNow applications. Which of the following scenarios would NOT be a good fit for a custom ServiceNow application? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "A video streaming platform for distributing corporate training media content"
+        },
+        {
+          "id": "b",
+          "text": "A multi-player game application requiring a real-time graphics rendering engine"
+        },
+        {
+          "id": "c",
+          "text": "A facility maintenance request system where employees report issues and technicians resolve them"
+        },
+        {
+          "id": "d",
+          "text": "An application that depends on a proprietary code library with no available API"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "ServiceNow is not well suited for streaming media platforms (unstructured data), multi-player games requiring graphics engines, or applications dependent on proprietary libraries without APIs. These fall outside ServiceNow's core strengths as a business automation platform built on a relational database. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "A facility maintenance request system is an excellent fit for ServiceNow because it follows a request-fulfill pattern with structured data, clear process flows, and benefits from workflow automation and reporting.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Development"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-application-development-overview.md",
+        "excerpt": "if the data is unstructured, stuff that doesn't really line up well with being broken down into categories and relationships like we expect in a relational database... you're not going to build a replacement for Netflix or for TikTok... requires access to proprietary libraries that do not have an application programming interface, or API... Multi-player games or applications requiring some sort of graphic or gameplay engine, eh, no, not so much."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "custom-application",
+          "use-case-evaluation",
+          "platform-capabilities",
+          "application-fit"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-14T18:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-009",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What prefix identifies a scoped application's namespace in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "s_"
+        },
+        {
+          "id": "b",
+          "text": "x_"
+        },
+        {
+          "id": "c",
+          "text": "app_"
+        },
+        {
+          "id": "d",
+          "text": "sn_"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "All scoped application namespaces in ServiceNow begin with the prefix 'x_'. This is the definitive indicator that an application is a scoped application, followed by the company code and application name.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The prefix 's_' is not used for scoped application namespaces in ServiceNow.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The prefix 'app_' is not a valid scoped application namespace prefix. ServiceNow uses 'x_' exclusively for scoped apps.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The prefix 'sn_' is used for ServiceNow-built applications from the ServiceNow Store, not for customer-created scoped applications.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application scope"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "all scope application namespaces start with an x_. That's the telltale sign. That is the shibboleth. That is how you know they are a scoped app."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "scope",
+          "namespace",
+          "scoped-application"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-010",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which statement about an application's scope in ServiceNow is correct?",
+      "options": [
+        {
+          "id": "a",
+          "text": "An application scope can be changed by a system administrator at any time"
+        },
+        {
+          "id": "b",
+          "text": "An application scope is never changeable once it has been set"
+        },
+        {
+          "id": "c",
+          "text": "An application scope can be updated during platform upgrades"
+        },
+        {
+          "id": "d",
+          "text": "An application scope can be modified through the sys_properties table"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "An application scope is immutable — once set, it cannot be changed. This is by design to prevent breaking dependencies and other applications that rely on the scope's namespace.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "System administrators cannot change an application's scope. This restriction is enforced by the platform to maintain integrity.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Platform upgrades do not alter application scopes. The scope remains fixed regardless of upgrade activity.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "While the glide.appcreator.company.code property exists in sys_properties, modifying it does not change existing application scopes. Application scopes are permanently set at creation.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application scope"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "an application scope is never changeable. Yeah, that's right. It is indelible. It is sacrosanct. It is something that is meant to be set and stayed there, etched in stone."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "scope",
+          "immutable",
+          "application-scope"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-011",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What is a key benefit of developing applications in their own private scope rather than in the global scope?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Scoped applications execute server-side scripts faster than global applications"
+        },
+        {
+          "id": "b",
+          "text": "Scoped applications provide a separate namespace that prevents unintended interactions between applications"
+        },
+        {
+          "id": "c",
+          "text": "Scoped applications automatically bypass access control rules for easier development"
+        },
+        {
+          "id": "d",
+          "text": "Scoped applications do not require update sets when being promoted between instances"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A primary benefit of scoped applications is the separate namespace they provide. ServiceNow enforces this separation strictly, ensuring that one application's scripts and data cannot inadvertently affect another application.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Application scope does not affect script execution speed. Performance is determined by script efficiency, not whether the application is scoped or global.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Scoped applications do not bypass access controls. In fact, scoped applications have additional access restrictions that enforce the principle of least privilege.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Scoped applications still use update sets or other deployment mechanisms when being promoted between instances. Scope does not eliminate the need for deployment management.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application scope"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "a separate namespace. Our scoped applications are tagged in such a way that we know what belongs to them, and ServiceNow enforces that separation quite strictly."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "scope",
+          "namespace",
+          "benefits",
+          "scoped-application"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-012",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are tenets of the scoped application philosophy in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Applications should be self-contained"
+        },
+        {
+          "id": "b",
+          "text": "Applications should have unrestricted access to all platform data for maximum flexibility"
+        },
+        {
+          "id": "c",
+          "text": "An application should neither break other applications nor the platform itself"
+        },
+        {
+          "id": "d",
+          "text": "Applications should have clearly defined dependencies"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c",
+        "d"
+      ],
+      "explanation": {
+        "correct": "The scoped application philosophy includes several key tenets: applications should be self-contained, they should not break other applications or the platform, they should be easily uninstalled, they should only access what they need (least privilege), and they should have clearly defined dependencies.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "The scoped application philosophy enforces the principle of least privilege — applications should only access what they need, not have unrestricted access to all platform data.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application scope"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "apps should be self-contained... an application should neither break other applications, nor should it break the platform itself... apps only accessing what they need, this idea of least privilege, and apps having clearly defined dependencies."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "scope",
+          "philosophy",
+          "least-privilege",
+          "dependencies"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-013",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer at a company with the app creator company code 'acme' creates a new scoped application called 'Book Rooms.' Following ServiceNow naming conventions, what would the application's scope namespace most likely be?",
+      "options": [
+        {
+          "id": "a",
+          "text": "sn_acme_book_rooms"
+        },
+        {
+          "id": "b",
+          "text": "x_acme_book_rooms"
+        },
+        {
+          "id": "c",
+          "text": "global.acme.book_rooms"
+        },
+        {
+          "id": "d",
+          "text": "scope_acme_book_rooms"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Scoped application namespaces follow the pattern x_[company_code]_[app_name] in snake_case. With the company code 'acme' and application name 'Book Rooms,' the namespace would be x_acme_book_rooms.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'sn_' prefix is reserved for ServiceNow-built applications, not customer-created scoped applications. Customer scoped apps always use 'x_'.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "ServiceNow scope namespaces use underscores in snake_case format (x_company_app), not dot notation. The 'global' prefix is not used in scope naming.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The prefix for scoped application namespaces is 'x_', not 'scope_'. The 'x_' prefix is what uniquely identifies a customer-created scoped application.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application scope naming"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "So it could be that we've got this fictitious organization called Acme. And since the name of their company is short to begin with, their company code might be just Acme... this application might be named x_acme_book_rooms."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "scope",
+          "namespace",
+          "naming-convention",
+          "snake-case"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-014",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which system property stores the company code used as part of a scoped application's namespace?",
+      "options": [
+        {
+          "id": "a",
+          "text": "glide.app.scope.prefix"
+        },
+        {
+          "id": "b",
+          "text": "glide.appcreator.company.code"
+        },
+        {
+          "id": "c",
+          "text": "sn.scope.company.identifier"
+        },
+        {
+          "id": "d",
+          "text": "glide.namespace.company.name"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The system property glide.appcreator.company.code stores the company code that is used as the second component of a scoped application's namespace (after the x_ prefix). This is a maintained-only property unique to each instance stack.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "There is no system property named glide.app.scope.prefix. The company code for scope namespaces is stored in glide.appcreator.company.code.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "This is not a valid ServiceNow system property. The correct property is glide.appcreator.company.code.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "This is not a valid ServiceNow system property. The company code used in scope namespaces is stored in glide.appcreator.company.code.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application scope"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "every instance stack of ServiceNow is glued together from a maint only-- that means a very strictly guarded-- app creator company code system property. And you can go find the value of this property in your instance just by going to the sys properties table and looking for the system property called glide.appcreator.company.code."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "scope",
+          "system-property",
+          "company-code",
+          "namespace"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-015",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following accurately describe the distinction between application development and application deployment in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Development focuses on storing and documenting incremental contributions to an application"
+        },
+        {
+          "id": "b",
+          "text": "Deployment involves moving a stable version of an application from one environment to another"
+        },
+        {
+          "id": "c",
+          "text": "Development and deployment are the same process managed entirely through a single update set"
+        },
+        {
+          "id": "d",
+          "text": "Deployment is concerned with promoting a solid version of the application through the instance stack"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "Application development and deployment are two separate processes. Development is about managing incremental contributions — storing and documenting changes. Deployment is about moving a stable, identified version of the application from one environment to another (e.g., from development to test to production).",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "Development and deployment are explicitly described as two disparate processes. While update sets may be used in both, they serve different purposes and are not the same process managed by a single update set.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDeployment.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application deployment"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/03-adf-application-development-vs-application-deployment.md",
+        "excerpt": "Developers are interested in managing development in terms of storing and documenting incremental contributions to the application... that's more about moving a solid version of your application after who knows how many little bits of development from one environment to another."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle",
+          "Update sets management"
+        ],
+        "tags": [
+          "development",
+          "deployment",
+          "promotion",
+          "instance-stack"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-016",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A lead developer wants to grant specific team members access to develop components of a scoped application in ServiceNow Studio, without configuring complex group and role assignments. Which feature should the lead developer use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Application access controls"
+        },
+        {
+          "id": "b",
+          "text": "Delegated development"
+        },
+        {
+          "id": "c",
+          "text": "Update set permissions"
+        },
+        {
+          "id": "d",
+          "text": "Domain separation"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Delegated development provides an easy way to add a roster of users to the development list of a scoped application. It simplifies granting development access and controlling what developers can modify, without needing to manage complex group and role configurations.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Application access controls govern runtime data access for end users, not development-time access for developers working in ServiceNow Studio.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_DelegatedDevelopment.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Update set permissions control who can create and manage update sets, but they do not provide granular development access to specific application components in Studio.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_DelegatedDevelopment.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Domain separation is used to separate data and administration between different organizational entities on the same instance, not to manage developer access to application components.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_DelegatedDevelopment.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Delegated development"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-scoped-application-model.md",
+        "excerpt": "delegated development. It's an easy way to add a roster of users to the development list of your application to ensure that they're able to access said application in our development tools like ServiceNow Studio... something easier than trying to deal with groups and roles and so on, to figure out exactly who can do exactly what to your application from a development standpoint."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "ServiceNow Studio IDE",
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "delegated-development",
+          "studio",
+          "developer-access",
+          "scoped-application"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-017",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In the Automated Test Framework (ATF), what syntax is used to reference the output of previous test steps within subsequent steps?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Dollar sign curly brace syntax (e.g., ${variable_name})"
+        },
+        {
+          "id": "b",
+          "text": "Angular-like expression syntax"
+        },
+        {
+          "id": "c",
+          "text": "Jelly template tag syntax"
+        },
+        {
+          "id": "d",
+          "text": "GlideRecord dot-walk notation"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "ATF uses a syntax that resembles Angular expressions to reference the output of previous test steps. Unlike the dollar sign curly brace syntax commonly used elsewhere in ServiceNow (e.g., notifications, mail scripts), ATF steps use this distinct angular-like expression syntax to pass values dynamically between steps. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/concept/automated-test-framework.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The dollar sign curly brace syntax (${...}) is used in many areas of ServiceNow such as notifications and mail scripts, but ATF specifically does NOT use this syntax for referencing step outputs.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/concept/automated-test-framework.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Jelly template tags are used in legacy ServiceNow UI pages and UI macros, not in ATF test step variable references.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/jelly/concept/c_Jelly.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideRecord dot-walk notation is used in server-side scripts to traverse reference fields in database queries. It is not the syntax used to pass values between ATF test steps.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_GlideRecordAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Automated Test Framework"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-test-with-automated-test-framework-atf.md",
+        "excerpt": "Interestingly, it uses a syntax that looks a lot more like an angular expression, for those of you that know your angular JavaScript. It doesn't use the dollar sign, curly brace syntax that we've been used to."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Automated Test Framework (ATF)"
+        ],
+        "tags": [
+          "atf",
+          "test-steps",
+          "variable-syntax",
+          "automated-testing"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-018",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "When developing a new scoped application, what is the recommended way to create an initial baseline of your application in an update set?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create a named update set before creating the scoped application"
+        },
+        {
+          "id": "b",
+          "text": "Use 'Publish to Update Set' after the application and initial table are created"
+        },
+        {
+          "id": "c",
+          "text": "Export all application records to an XML file"
+        },
+        {
+          "id": "d",
+          "text": "Clone the development instance to preserve the initial state"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The recommended approach is to use 'Publish to Update Set' after creating the application and its first table. This serves as an initial commit that captures everything created so far. Creating an update set before creating the application would not capture the app records because the app is created in a new application scope. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_PublishAnApplicationToAnUpdateSet.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Creating a named update set before creating the scoped application will not capture the application creation records. This is because the new application is created in its own scope, so the previously created update set (in a different scope) would not track those changes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "While XML export is a method for moving records between instances, it is not the recommended approach for creating an initial development baseline of a scoped application. Publish to Update Set is the purpose-built mechanism for this.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_PublishAnApplicationToAnUpdateSet.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Instance cloning is a heavyweight operation used for refreshing entire environments, not for creating a development baseline of a single application. It would be excessive and impractical for this purpose.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/managing-data/concept/c_InstanceCloning.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Publish an Application to an Update Set"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/10-adf-update-set-usage-in-application-development.md",
+        "excerpt": "Once you create the new app, maybe once you get that first table created or something, use Publish to Update set. And that's kind of your initial commit that captures everything you've gotten so far."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "update-sets",
+          "publish-to-update-set",
+          "initial-commit",
+          "scoped-application"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-019",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer creates a new update set and sets it as the current update set. They then create a new scoped application and its first table, but notice the update set contains no customer updates. What is the most likely explanation?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The developer did not have the admin role required to track update set changes"
+        },
+        {
+          "id": "b",
+          "text": "The application was created in a new scope, so the update set in the previous scope did not capture those records"
+        },
+        {
+          "id": "c",
+          "text": "Update sets do not track table creation records by default"
+        },
+        {
+          "id": "d",
+          "text": "The update set must be marked as complete before records appear in the customer updates list"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When a new scoped application is created, it establishes a new application scope. The update set that was created before the application belongs to a different scope, so it does not capture the records created within the new application scope. This is why the recommended practice is to use 'Publish to Update Set' after creating the application rather than relying on a pre-existing update set. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "While roles affect what a developer can do, the issue here is about application scope, not role permissions. A developer with rights to create applications and update sets would still encounter this scope mismatch behavior.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Update sets do track table creation records and other metadata changes. The issue is specifically about scope boundaries — the update set was in a different scope than the newly created application.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Customer updates appear in an update set as changes are made, not after marking the update set as complete. Marking an update set complete finalizes it and prevents further changes from being tracked in it.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Scope",
+        "ServiceNow Docs - Update Sets"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/10-adf-update-set-usage-in-application-development.md",
+        "excerpt": "if you had started an update set before creating the app, the update set wouldn't have captured it because you started something in a new application scope."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "update-sets",
+          "application-scope",
+          "scoped-application",
+          "troubleshooting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-020",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are capabilities of the Automated Test Framework (ATF) in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Pre-built test steps that can be configured without writing JavaScript"
+        },
+        {
+          "id": "b",
+          "text": "Automatic rollback of test data after test execution"
+        },
+        {
+          "id": "c",
+          "text": "Screenshots captured at each step during test execution"
+        },
+        {
+          "id": "d",
+          "text": "Automatic generation of test cases from application business rules"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "ATF provides pre-built test steps that can be used without JavaScript (though JavaScript can be added for enhancement), supports rolling back test data after execution to maintain a clean environment, and captures screenshots at each step during test runs. These capabilities make ATF a powerful tool for automating repetitive validation test cases. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/concept/automated-test-framework.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "d",
+            "explanation": "ATF does not automatically generate test cases from business rules. Test cases and their steps must be manually created by the developer or test engineer. ATF provides the framework for building and executing tests, not for auto-generating them from existing configurations.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/concept/automated-test-framework.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Automated Test Framework"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-test-with-automated-test-framework-atf.md",
+        "excerpt": "the Automated Test framework offers loads of different pre-built test steps, that you can come up with in a range, and even pass values back and forth between dynamically, without using any JavaScript... these tests that are run can be rolled back... you'll see how it executes every step of the way, saving a screenshot"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Automated Test Framework (ATF)"
+        ],
+        "tags": [
+          "atf",
+          "test-steps",
+          "rollback",
+          "screenshots",
+          "automated-testing"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-021",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A development team is building a scoped application over a two-week sprint. They need to track incremental code changes during development and deploy a stable version to a test instance at the end of the sprint. Which approach aligns with ServiceNow best practices?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create a single update set for the entire sprint and publish to the application repository when development is finished"
+        },
+        {
+          "id": "b",
+          "text": "Use named update sets organized by story or feature for incremental development, then publish to the application repository when a stable version is ready for testing"
+        },
+        {
+          "id": "c",
+          "text": "Publish to the application repository after each individual change to ensure no work is lost"
+        },
+        {
+          "id": "d",
+          "text": "Use 'Publish to Update Set' at the end of each day to create daily snapshots for deployment"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Named update sets should be used as smaller chunks for managing incremental development, organized by story, sprint, or feature. Publishing to the application repository should happen when the application reaches a stable version that is viable for testing or deployment. This separates the concerns of managing development (update sets) from managing deployment (application repository). See: https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Using a single update set for an entire sprint goes against best practices. The key is not letting a single update set run for the whole development cycle, as this makes it difficult to organize, review, and troubleshoot changes. Named update sets should be broken into manageable chunks.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Publishing to the application repository after every individual change is excessive. The application repository is meant for stable, deployable versions of the application, not for tracking each incremental change. Named update sets serve the purpose of incremental tracking.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationRepository.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "'Publish to Update Set' captures the entire application state at a point in time and is primarily used for an initial commit or for deploying outside the instance stack (e.g., to the ServiceNow Store or developer share). It is not intended for daily incremental change tracking.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/t_PublishAnApplicationToAnUpdateSet.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Development",
+        "ServiceNow Docs - Update Sets"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/10-adf-update-set-usage-in-application-development.md",
+        "excerpt": "your named update sets are smaller chunks for managing your development. Step three here is saying, OK, after so many update sets after a certain amount of work is done and you've got a new version of the app that's considered viable and different enough for another test cycle, that's when you might publish to the app repo. Step two-- managing development-- step three-- managing deployment."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "update-sets",
+          "application-repository",
+          "deployment",
+          "development-lifecycle",
+          "best-practices"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-022",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What must be enabled on a ServiceNow instance before Automated Test Framework (ATF) tests can be executed?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The ATF Test Designer plugin"
+        },
+        {
+          "id": "b",
+          "text": "Test runners"
+        },
+        {
+          "id": "c",
+          "text": "The Test Management application"
+        },
+        {
+          "id": "d",
+          "text": "Scheduled job execution for the ATF scope"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Test runners must be enabled (switched on) on the instance before ATF tests can be executed. Test runners are the components that actually carry out the automated test steps by interacting with the ServiceNow instance. Without active test runners, ATF tests cannot run. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/concept/automated-test-framework.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "There is no separate 'ATF Test Designer' plugin that needs to be enabled. The Automated Test Framework is included with the platform, and the key requirement for execution is enabling test runners, not installing an additional plugin.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/task/enable-test-runner.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The Test Management application is a separate tool for organizing test plans, test suites, and test cases. While useful for test planning, it is not a prerequisite for executing ATF tests. Test runners are what enable ATF execution.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/concept/automated-test-framework.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "While ATF tests can be scheduled, the prerequisite for running tests is enabling test runners, not configuring scheduled jobs. Test runners are the mechanism that processes and executes the test steps on the instance.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/auto-test-framework/task/enable-test-runner.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Enable a Test Runner"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-test-with-automated-test-framework-atf.md",
+        "excerpt": "You'll see, during the lab, how to switch on the so-called test runners that make this possible."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Automated Test Framework (ATF)"
+        ],
+        "tags": [
+          "atf",
+          "test-runners",
+          "automated-testing",
+          "instance-configuration"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-023",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are recommended practices when using update sets during scoped application development? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Use 'Publish to Update Set' after creating the application as an initial commit"
+        },
+        {
+          "id": "b",
+          "text": "Create named update sets organized by story, sprint, or feature"
+        },
+        {
+          "id": "c",
+          "text": "Let a single update set run for the entire development cycle to capture all changes"
+        },
+        {
+          "id": "d",
+          "text": "Mark update sets as complete at the end of each day, sprint, or completed story"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "Best practices for update set management include: using 'Publish to Update Set' as an initial commit after app creation, creating named update sets organized by meaningful development units (story, sprint, feature), and marking update sets as complete at logical boundaries (end of day, sprint, or story). This approach provides organized version control and clear change tracking throughout development. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "Letting a single update set run for the entire development cycle is explicitly discouraged. The key is not starting an update set every five minutes, but also not letting it run for the whole development cycle. Properly chunked, named update sets provide better organization and change management.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Update Sets",
+        "ServiceNow Docs - Application Development Best Practices"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/10-adf-update-set-usage-in-application-development.md",
+        "excerpt": "Once you create the new app, maybe once you get that first table created or something, use Publish to Update set. And that's kind of your initial commit... you might mark an update set that you had started at the beginning of that period as complete. The key here is not necessarily starting an update set every five minutes, but also not letting it run for the whole development cycle."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "update-sets",
+          "best-practices",
+          "development-lifecycle",
+          "scoped-application"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-09T17:45:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-024",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What type of record is captured by an update set in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Data records such as incidents or task entries"
+        },
+        {
+          "id": "b",
+          "text": "Configuration and customization records such as business rules"
+        },
+        {
+          "id": "c",
+          "text": "User login and session history records"
+        },
+        {
+          "id": "d",
+          "text": "Reporting and dashboard usage analytics"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Update sets capture configuration and customization changes — records that define the behavior of an application, such as business rules, UI policies, and client scripts. Plain data records (e.g., incident records, custom table rows) are not tracked by update sets. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Data records are regular application data and are not captured by update sets. Only metadata/configuration changes are tracked.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "User login and session records are transactional system data, not configuration changes, and are not captured by update sets.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Reporting usage analytics are runtime data, not configuration artifacts. Update sets track changes to system configuration, not usage metrics.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Update Sets"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-update-set-usage-during-app-development-demo.md",
+        "excerpt": "a business rule is considered a configuration or customization. It's considered part and parcel to the behavior of the application. So, no surprise, it's captured here... It didn't capture that and for good reason. That's just a plain old data record. Update sets don't care about that."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management"
+        ],
+        "tags": [
+          "update-sets",
+          "configuration",
+          "customization"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-025",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the recommended method for promoting a scoped application between instances within the same organizational stack?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Publish to Update Set and export as XML"
+        },
+        {
+          "id": "b",
+          "text": "Publish to the ServiceNow Store"
+        },
+        {
+          "id": "c",
+          "text": "Publish to the Application Repository"
+        },
+        {
+          "id": "d",
+          "text": "Clone the source instance to the target instance"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Publishing to the Application Repository is the recommended method for promoting applications between instances in the same organizational stack. It provides a secure, streamlined process for install, update, rollback, and uninstall operations. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-app-repo.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Publish to Update Set exports the application as an XML file, which is useful for sharing outside your instance stack (e.g., developer share) or for backup/compliance, but is not the recommended approach for standard instance-to-instance promotion within the same stack.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/task/export-update-set.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Publishing to the ServiceNow Store is for distributing applications commercially to the broader ServiceNow community and requires a vendor agreement. It is not used for internal organizational deployment.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/servicenow-store.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Instance cloning copies an entire instance (often production to sub-production) for testing purposes. It is not a method for promoting individual applications between instances.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/managing-clones/concept/clone-overview.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Repository"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-application-management.md",
+        "excerpt": "our second option to publish to the application repository is a secure way to make sure that only folks in our organization have access to that application. And this is the typical way. This is our recommended way for promoting it, say, amongst different instances in your stack"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "application-repository",
+          "deployment",
+          "promotion"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-026",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer is working in the SatcheGobu application scope with an active named update set. They then create a brand new application called Red Panda Pandering using ServiceNow Studio. What happens to the developer's current update set?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The active update set captures the new application creation along with all previous changes"
+        },
+        {
+          "id": "b",
+          "text": "The active update set is automatically deleted when a new application scope is created"
+        },
+        {
+          "id": "c",
+          "text": "The developer's scope switches to the new application, and the previous update set does not capture the new application"
+        },
+        {
+          "id": "d",
+          "text": "The active update set is merged into the new application's default update set"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "When a new application is created, the developer's scope changes to the new application scope, and the original update set (belonging to the previous scope) does not capture the new application. Update sets are subservient to application scope — they belong to a specific scope and cannot capture changes outside of it. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "An update set belongs to a specific application scope. It cannot capture the creation of an entirely new application in a different scope because application scope is the larger container.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/app-scope.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "The original update set is not deleted. It remains intact with whatever changes were already captured. The developer simply moves out of that scope context.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Update sets from different application scopes are not merged. Each scope maintains its own update sets independently.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Scope",
+        "ServiceNow Docs - Update Sets"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-update-set-usage-during-app-development-demo.md",
+        "excerpt": "the application I just created about red pandas supersedes this update set. Application scope is the larger of the containers. My SatcheGobu update set has no business capturing an entire new application. Update sets belong to applications. They are subservient to application scope."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "update-sets",
+          "application-scope",
+          "scope-change"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-027",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following statements about the Publish to Update Set feature on an application record are true? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "It only captures changes made since the last publish operation"
+        },
+        {
+          "id": "b",
+          "text": "It packages the entire application into a completed update set"
+        },
+        {
+          "id": "c",
+          "text": "It moves application file records into the sys_update_xml table"
+        },
+        {
+          "id": "d",
+          "text": "It automatically deploys the application to all connected instances"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The Publish to Update Set related link takes all records from the application files related list and packages them into a completed update set stored in the sys_update_xml table. It captures the entire application — not just deltas since the last publish. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-update-set.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Publish to Update Set does not work on a delta/incremental basis. It sweeps the entire application into the update set package every time it is used, regardless of what was previously published.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-update-set.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Publish to Update Set only creates a local completed update set. It does not automatically deploy to other instances. The update set must be manually exported and imported into target instances.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/task/export-update-set.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Publish Application to Update Set"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-application-management.md",
+        "excerpt": "this doesn't just only grab the files or the records that you've done since the last time you used this. It's not like the deltas. It's not an update, despite the name Update Set. Publish to Update set sweeps your entire application into a tidy little package."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle",
+          "Update sets management"
+        ],
+        "tags": [
+          "publish-to-update-set",
+          "deployment",
+          "sys-update-xml"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-028",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to share a custom scoped application with a colleague who has a separate personal developer instance that is not part of the developer's organizational instance stack. Which deployment method should the developer use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Publish to the Application Repository"
+        },
+        {
+          "id": "b",
+          "text": "Publish to Update Set and export as XML"
+        },
+        {
+          "id": "c",
+          "text": "Use the Application Manager Install button on the colleague's instance"
+        },
+        {
+          "id": "d",
+          "text": "Publish to the ServiceNow Store"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When sharing an application outside of your organizational instance stack — such as to a personal developer instance or the developer share — Publish to Update Set and export as XML is the appropriate method. The XML file can be imported into any ServiceNow instance regardless of organizational affiliation. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/task/export-update-set.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The Application Repository is restricted to instances sharing the same app creator company code. A colleague's personal developer instance outside the organization would not have access to the repository.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-app-repo.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The Application Manager Install button is used to install applications already available in the Application Repository. Since the colleague's instance is outside the organization's stack, the application would not appear in their Application Manager.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/app-manager.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Publishing to the ServiceNow Store requires a vendor agreement with ServiceNow and a formal vetting process. It is intended for commercial distribution, not casual sharing between colleagues.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/servicenow-store.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Export Update Sets"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-application-management.md",
+        "excerpt": "Using Publish to Update set basically puts it all into an XML file. And you can export that out of your instance, which means it can go into any other instance stack. This might be good for compliance or backup. But there are times we might want to share our application out to people whose instances aren't shared with ours, maybe, say, putting it up on the developer share"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "publish-to-update-set",
+          "xml-export",
+          "deployment",
+          "sharing"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-029",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_select",
+      "question": "Which of the following are true about the ServiceNow Application Repository? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Only instances sharing the same app creator company code can see available applications"
+        },
+        {
+          "id": "b",
+          "text": "It requires a vendor agreement with ServiceNow before applications can be published"
+        },
+        {
+          "id": "c",
+          "text": "It makes it easier to update, rollback, and uninstall deployed applications compared to update sets"
+        },
+        {
+          "id": "d",
+          "text": "The Application Manager interface shows available and installed applications from the repository"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c",
+        "d"
+      ],
+      "explanation": {
+        "correct": "The Application Repository restricts visibility based on the app creator company code, making it a secure internal distribution mechanism. It provides streamlined lifecycle management including update, rollback, and uninstall capabilities. The Application Manager is the interface for viewing and managing applications from the repository. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-app-repo.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "A vendor agreement is required for publishing to the ServiceNow Store, not the Application Repository. The Application Repository is designed for internal organizational use and does not require a vendor agreement.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/servicenow-store.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Repository",
+        "ServiceNow Docs - Application Manager"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-application-management.md",
+        "excerpt": "Only instances that share that app creator company code... can kind of, quote, unquote, 'see' the available applications in the application repository... when we deploy using the application repository, it's a lot easier to update, rollback, and uninstall your application also... when you're in your Application Manager, you'll see available applications that are not installed"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "application-repository",
+          "app-creator-company-code",
+          "application-manager"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-030",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What is the relationship between update sets and application scope in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Update sets are the parent container that can hold multiple application scopes"
+        },
+        {
+          "id": "b",
+          "text": "Update sets and application scopes are independent and unrelated constructs"
+        },
+        {
+          "id": "c",
+          "text": "Update sets belong to an application scope and are subservient to it"
+        },
+        {
+          "id": "d",
+          "text": "Application scope is automatically determined by whichever update set is currently active"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Update sets belong to application scopes and are subservient to them. Application scope is the larger container, and an application scope can contain multiple update sets. An update set in one scope cannot capture changes made in a different scope. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "This is the inverse of the actual relationship. Application scope is the larger container, and update sets exist within a scope. An update set cannot contain multiple application scopes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/app-scope.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Update sets and application scopes are closely related. Every update set belongs to a specific application scope, and the scope determines which changes the update set can capture.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Application scope is not determined by the active update set. Rather, the update set is selected within the context of the current application scope. Changing scope changes which update sets are available.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/app-scope.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Update Sets",
+        "ServiceNow Docs - Application Scope"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-update-set-usage-during-app-development-demo.md",
+        "excerpt": "Update sets belong to applications. They are subservient to application scope. That's what I'd like you to take away here."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Update sets management",
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "update-sets",
+          "application-scope",
+          "scope-hierarchy"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-031",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What happens when the Roles field on an Application Menu record is left empty in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Only administrators can see the application menu in the Application Navigator"
+        },
+        {
+          "id": "b",
+          "text": "The application menu is hidden from all users until a role is specified"
+        },
+        {
+          "id": "c",
+          "text": "All authenticated users can see the application menu in the Application Navigator"
+        },
+        {
+          "id": "d",
+          "text": "Only users with the itil role can see the application menu"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "When no role is listed in the Roles field of an Application Menu record, all authenticated users can see it. As the source states, 'if there's not a role listed in the Roles field, then everyone's invited to the party.' This is how the Self-Service application menu works — it has no role specified, so even self-service users with no roles can see it. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "An empty Roles field does not restrict visibility to administrators. It opens visibility to all authenticated users.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "The opposite is true — an empty Roles field makes the application menu visible to everyone, not hidden from everyone.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The itil role is not a default requirement for application menu visibility. An empty Roles field grants visibility to all authenticated users regardless of their roles.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Menus"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-configure-application-security.md",
+        "excerpt": "you should also know that the way that these records work is that if there's not a role listed in the Roles field, then everyone's invited to the party. That's how our Self-Service application menu works. There's just not a role in there."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "application-menu",
+          "roles",
+          "visibility",
+          "navigation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-032",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the default behavior when no access control rules (ACLs) exist for a table in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "All authenticated users have full CRUD access to the table"
+        },
+        {
+          "id": "b",
+          "text": "Only users with the admin role can access the table"
+        },
+        {
+          "id": "c",
+          "text": "Access is denied by default"
+        },
+        {
+          "id": "d",
+          "text": "Read access is granted to all users, but write access is denied"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "When no access control rules exist for a table, access is denied by default. As stated in the source, 'if there's not some means of governing the access, then access would be denied by default.' This is why it is critical to create ACLs when building custom tables. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Without ACLs, access is denied, not granted. ServiceNow follows a secure-by-default approach where missing ACLs result in no access.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "While admins may bypass ACL checks depending on system properties, the default behavior for tables without ACLs is that access is denied to all users, not restricted only to admins.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "ServiceNow does not differentiate between read and write access when no ACLs exist. All access is denied by default when no access control rules are defined.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Access Control Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-configure-application-security.md",
+        "excerpt": "It's really important that they exist because if they don't, if there's not some means of governing the access, then access would be denied by default."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "access-control",
+          "ACL",
+          "security",
+          "default-behavior"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-033",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What level of access does a table.none access control rule control in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Access to individual fields on the table"
+        },
+        {
+          "id": "b",
+          "text": "Row-level access to the table's records"
+        },
+        {
+          "id": "c",
+          "text": "Access to all fields not covered by other ACLs"
+        },
+        {
+          "id": "d",
+          "text": "Administrative access to modify the table schema"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A table.none access control rule controls row-level access to the table. As explained in the source, 'those grant access at the row level. And you have to pass one of those in order to do anything on the table at all.' This is the foundational ACL — like a front door key — that must be passed before any field-level ACLs are evaluated. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Individual field access is controlled by table.field ACLs (field-level rules), not table.none rules. The table.none rule governs whether you can access the table's records at all.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Access to fields not covered by other ACLs is the purpose of the table.* (wildcard) rule, not the table.none rule. The wildcard acts as a field-level ACL where no field-specific rule already exists.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Table.none rules control data access (CRUD operations on records), not the ability to modify the table structure or schema.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Access Control Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-configure-application-security.md",
+        "excerpt": "And not only can we choose a specific field, but we could leave this in the value of none. And in that case, we have a so-called table dot none access control rule. And those grant access at the row level."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "access-control",
+          "ACL",
+          "table-none",
+          "row-level-access"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-034",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which statements are true about how roles work on Application Menu and Module records in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "If multiple roles are listed on an Application Menu, the user must have all of them to see the menu"
+        },
+        {
+          "id": "b",
+          "text": "If a Module's Role field is left empty, the module is visible to anyone who can see the parent Application Menu"
+        },
+        {
+          "id": "c",
+          "text": "If multiple roles are listed on an Application Menu, the user needs only one of them to see the menu"
+        },
+        {
+          "id": "d",
+          "text": "Roles on Application Menu and Module records provide the same level of data security as access control rules"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "When multiple roles are listed on an Application Menu, the user only needs one of them — 'Think of it as like there being more than one key that opens the lock.' Additionally, when a Module's Role field is empty, it inherits visibility from the parent Application Menu — 'it means that as long as you can see the parent application menu, then so too can you see the module.' See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Multiple roles on an Application Menu act as alternative keys, not cumulative requirements. The user needs only one of the listed roles to see the menu.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Application Menu and Module roles only control navigation visibility (whether a UI link appears in the Application Navigator). They do not secure data access — that is the role of access control rules (ACLs). As stated, 'these records are just navigational convenience.'",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_Modules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Menus",
+        "ServiceNow Docs - Modules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-configure-application-security.md",
+        "excerpt": "if there's more than one role listed, the user need only have one of them. Think of it as like there being more than one key that opens the lock. ... If the Role field is left unchecked here, it doesn't mean that everybody can see it. It means that as long as you can see the parent application menu, then so too can you see the module."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "application-menu",
+          "modules",
+          "roles",
+          "visibility",
+          "navigation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-035",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer has a custom table with a table.none read ACL requiring the 'x_app_user' role. All internal fields are currently accessible to users with that role. The developer needs to restrict the 'confidential_notes' field so that only users with the 'x_app_manager' role can view it. What should the developer do?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Add the x_app_manager role to the existing table.none read ACL"
+        },
+        {
+          "id": "b",
+          "text": "Create a table.confidential_notes field-level read ACL requiring the x_app_manager role"
+        },
+        {
+          "id": "c",
+          "text": "Create a deny unless ACL that blocks x_app_user from the confidential_notes field"
+        },
+        {
+          "id": "d",
+          "text": "Remove the x_app_user role from the table.none ACL and create individual field ACLs for every field"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The developer should create a field-level ACL (table.confidential_notes) requiring the x_app_manager role. This is the standard approach for restricting access to a specific field — like putting a special lock on one room. The field-specific ACL will override the more general access, restricting that field to only users who pass its check. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Modifying the table.none ACL would affect row-level access for the entire table, not restrict a single field. This would prevent x_app_user from accessing any records unless they also have x_app_manager.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "While deny unless ACLs exist in ServiceNow, they are more complex and not the standard approach for this scenario. A simple field-level ACL requiring the x_app_manager role is the correct and recommended solution.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Creating individual field ACLs for every field is unnecessary and does not scale. This is the approach the wildcard rule or simply adding a single field-specific ACL is designed to avoid.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Access Control Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-super-access-control-world-acl-basics.md",
+        "excerpt": "Lucas cannot see room number two... we're going to do it like this. Only Marco gets the key. So just as if these were locks on a door, Marco sees all. Lucas can't see room two."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "access-control",
+          "ACL",
+          "field-level-security",
+          "scenario"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-036",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Besides create, read, write, and delete, which additional operation type can be controlled through access control rules in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Import"
+        },
+        {
+          "id": "b",
+          "text": "Reporting"
+        },
+        {
+          "id": "c",
+          "text": "Cloning"
+        },
+        {
+          "id": "d",
+          "text": "Archiving"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Access control rules can control operations beyond basic CRUD, including reporting. As stated in the source, 'we might also be controlling for operations such as reporting on or reading reports or even list editing records or the columns therein on a table.' See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Import operations are managed through import sets and data source configurations, not through the ACL operation types on access control rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Instance cloning is an administrative function managed through system clone settings, not through access control rule operation types.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Archiving is managed through table rotation and archive rules, not through the ACL operation types on access control rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Access Control Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-configure-application-security.md",
+        "excerpt": "we might also be controlling for operations such as reporting on or reading reports or even list editing records or the columns therein on a table."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "access-control",
+          "ACL",
+          "operations",
+          "reporting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-037",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "How does a table.* (wildcard) access control rule behave when a field-specific ACL also exists for a field on the same table?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The wildcard rule overrides the field-specific ACL"
+        },
+        {
+          "id": "b",
+          "text": "Both the wildcard and field-specific rules are evaluated together, and the user must pass both"
+        },
+        {
+          "id": "c",
+          "text": "The field-specific ACL takes precedence, and the wildcard rule does not apply to that field"
+        },
+        {
+          "id": "d",
+          "text": "The wildcard rule applies first, and the field-specific rule is only checked if the wildcard fails"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "A table.* (wildcard) ACL acts as a field-level access control only 'where there is no field-specific rule already.' When a field-specific ACL exists, it takes precedence and the wildcard does not apply to that field. As the source explains, 'often in the world of computers, the more specific situation is the one that wins.' See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The wildcard rule does not override field-specific ACLs. The opposite is true — field-specific rules are more specific and take precedence over the wildcard.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "The wildcard and field-specific rules are not evaluated together. When a field-specific ACL exists, only that rule is evaluated for that field — the wildcard is excluded from consideration.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The evaluation does not fall through from wildcard to field-specific. When a field-specific ACL exists, only the field-specific rule applies to that field. The wildcard is not evaluated for fields that have their own ACL.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Access Control Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-super-access-control-world-acl-basics.md",
+        "excerpt": "A table.star or wildcard rule... it's stated very clearly that that acts as a field-level access control... where there is no field-specific rule already. In other words, often in the world of computers, the more specific situation is the one that wins."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "access-control",
+          "ACL",
+          "wildcard",
+          "field-level-security",
+          "precedence"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-038",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A developer has a custom table with 30 fields. Most fields should be readable by users with the 'viewer' role, but the 'salary' field should only be readable by users with the 'hr_manager' role. Which combination of ACLs should the developer create to achieve this efficiently? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "A table.none read ACL requiring the viewer role for row-level access"
+        },
+        {
+          "id": "b",
+          "text": "A table.* (wildcard) read ACL requiring the viewer role for default field access"
+        },
+        {
+          "id": "c",
+          "text": "A table.salary field-level read ACL requiring the hr_manager role"
+        },
+        {
+          "id": "d",
+          "text": "Individual field-level read ACLs for each of the 29 non-salary fields requiring the viewer role"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "This scenario requires three ACLs working together: (1) A table.none ACL for row-level access (the 'front door'), (2) a table.* wildcard ACL to grant the viewer role access to all fields by default (this also causes all fields to require an ACL check), and (3) a field-specific table.salary ACL for the hr_manager role, which overrides the wildcard for that field. This is the efficient approach demonstrated in the source's house metaphor. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "d",
+            "explanation": "Creating 29 individual field-level ACLs is the inefficient approach the table.* wildcard rule is specifically designed to eliminate. As the source illustrates, without the wildcard you would need to 'Slap a lock on room four. Give the key to Marco. Slap a lock on room five...' — which does not scale.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Access Control Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/02-adf-super-access-control-world-acl-basics.md",
+        "excerpt": "the house.* or table.* Rule, as soon as it's created, switches the game up. Now, all those internal doors are closed and locked... If I give this skeleton key... to Marco. Then what happens is Marco gets into the front door, and then he's got these 30 rooms. But his special key opens them all... I just have to figure out how to get Lucas into his room, room number two."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "access-control",
+          "ACL",
+          "wildcard",
+          "field-level-security",
+          "scenario",
+          "best-practice"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:30:01.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-039",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "When creating a user record specifically for integration purposes, what does enabling the 'Web service access only' option accomplish?",
+      "options": [
+        {
+          "id": "a",
+          "text": "It restricts the user to read-only operations on all tables"
+        },
+        {
+          "id": "b",
+          "text": "It prevents the user from logging into ServiceNow through a web browser while still allowing authentication for integrations"
+        },
+        {
+          "id": "c",
+          "text": "It automatically grants the user the web_service_admin role"
+        },
+        {
+          "id": "d",
+          "text": "It limits the user to REST API access only, excluding SOAP requests"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Enabling 'Web service access only' on a user record forbids that user from logging into the ServiceNow GUI through a web browser (an interactive session). The user's credentials can only be used for providing authentication for integrations or web service access. The user is still treated like any other user regarding groups, roles, and ACLs. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/users-and-groups/concept/c_WebServiceAccessOnly.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'Web service access only' setting does not restrict database operations. The user's permissions are still governed by roles and ACLs, just like any other user.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/users-and-groups/concept/c_WebServiceAccessOnly.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "No role is automatically granted by this setting. The user can be placed in groups and assigned roles through the normal process, just like any other user record.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/users-and-groups/concept/c_WebServiceAccessOnly.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The setting does not distinguish between REST and SOAP protocols. It simply prevents interactive browser-based login while allowing the credentials to be used for any type of web service or integration authentication.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/users-and-groups/concept/c_WebServiceAccessOnly.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Web service access only users"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-application-access.md",
+        "excerpt": "you can create records on the user table and specify that they are for web service access only, by ticking this box here... it forbids that user from logging into the ServiceNow GUI through a web browser. In other words, they can't actually log into ServiceNow from the login screen and surf around. That's what's called an interactive session, and it forbids them. Instead, that user record and its credentials can only be used for providing authentication for integrations or web service access."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application security and access controls"
+        ],
+        "tags": [
+          "web-service-access",
+          "user-record",
+          "integrations",
+          "authentication"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-040",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A scoped application's table is configured to allow access from all application scopes, but only the Read and Update database operations are enabled. A script running in a different application scope attempts to insert a new record and then update an existing record on this table. What is the expected outcome?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Both operations succeed because access from all scopes is allowed"
+        },
+        {
+          "id": "b",
+          "text": "The insert is denied but the update succeeds"
+        },
+        {
+          "id": "c",
+          "text": "Both operations are denied because cross-scope access requires caller restriction approval"
+        },
+        {
+          "id": "d",
+          "text": "The insert succeeds but is logged in the restricted caller access table for review"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When cross-scope access is granted, the specific database operations (Create, Read, Update, Delete) that are enabled determine what actions are permitted. Since only Read and Update are checked, the insert (create) operation is denied while the update operation is allowed. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Allowing access from all scopes does not automatically enable all database operations. Each operation (Create, Read, Update, Delete) must be individually enabled for cross-scope access.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Caller restriction is a separate feature that controls case-by-case approval. The table is already configured to allow access from all scopes, so operations that are enabled (Read and Update) will succeed without caller restriction approval.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The insert operation is simply denied because the Create permission is not enabled for cross-scope access. It does not get logged to the restricted caller access table; that behavior is specific to caller tracking and caller restriction settings.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application access settings"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-application-access.md",
+        "excerpt": "it can be accessed from all scopes. But if you notice, only for the read and update operations. Can create and Can delete are unchecked. Therefore, if a script in our Loaner Request application busted out a GlideRecord query... and it tried to loop through the records on this claims table and perform these operations here of insert and update, and delete record... We'll create, not allowed. Delete, not allowed. Read or query, sure, heck yeah. Update? Mmhm."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "cross-scope-access",
+          "database-operations",
+          "application-scope",
+          "GlideRecord"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-041",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer is building a scoped application that contains sensitive data. They want to be notified when out-of-scope applications attempt to access their table and require each access attempt to be manually approved before it is permitted. Which caller access setting should the developer configure?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Caller tracking"
+        },
+        {
+          "id": "b",
+          "text": "None"
+        },
+        {
+          "id": "c",
+          "text": "Caller restriction"
+        },
+        {
+          "id": "d",
+          "text": "Set the application access to 'No application scopes'"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Caller restriction ensures that every time something from out of scope tries to access the table, a record is created in the restricted caller access table with a status of unapproved. The developer must then manually approve each access request before it is permitted. This is the 'ask for permission' approach. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_CallerAccessForApplications.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Caller tracking creates records in the restricted caller access table but automatically sets them to 'allowed.' It is an 'ask for forgiveness' approach that permits access first and lets you deny it afterward, which does not meet the requirement for pre-approval.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_CallerAccessForApplications.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Setting caller access to 'None' means no case-by-case access tracking occurs. The table access is strictly governed by the all-or-nothing application access setting (all scopes or none).",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_CallerAccessForApplications.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Setting application access to no scopes blocks all cross-scope access entirely. While this is restrictive, it does not provide the granular approve/deny workflow the developer needs to selectively grant access on a case-by-case basis.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_CallerAccessForApplications.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Caller access for applications"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-application-access.md",
+        "excerpt": "if you want to be stricter, you can use the caller restriction approach. And that means that every time something from out of scope tries to access your table, that record gets created on the restricted caller access table and is set to unapproved. And you have to manually go in and approve it."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "caller-access",
+          "caller-restriction",
+          "cross-scope-access",
+          "restricted-caller-access"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-042",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_select",
+      "question": "When publishing an application to the ServiceNow Store, which protection policy options can be applied to individual application artifacts to protect intellectual property? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "No protection — the artifact can be read and edited by the installer"
+        },
+        {
+          "id": "b",
+          "text": "Read-only — the artifact can be read but not modified"
+        },
+        {
+          "id": "c",
+          "text": "Black box — the artifact appears as an essentially empty record to the installer"
+        },
+        {
+          "id": "d",
+          "text": "Encrypted — the artifact source code is stored with AES-256 encryption at rest"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "ServiceNow provides three protection policy options for application artifacts published to the Store: no protection (read and edit), read-only (read but cannot modify), and black box (appears as an empty record). These are applied on a record-by-record basis. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ProtectionPolicy.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "d",
+            "explanation": "AES-256 encryption at rest is not a protection policy option for application artifacts. Protection policies control visibility and editability of artifacts for consumers who install the application, not the encryption method used for storage.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ProtectionPolicy.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Protection policy for scoped applications"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-application-access.md",
+        "excerpt": "You can protect your scripts and other artifacts and treat them as your intellectual property on a record-by-record basis, and say, hey, for this particular record, if someone installs my app from the ServiceNow store... you might say, OK, there's no protection. They can read it, they can edit it. Or they can read it, but they can't touch it. Or it shows up more or less like an empty record. It's a black box."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application deployment lifecycle"
+        ],
+        "tags": [
+          "protection-policy",
+          "servicenow-store",
+          "intellectual-property",
+          "app-repository"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-application-development-043",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What is the purpose of the 'Allow configuration' setting on a scoped application's table?",
+      "options": [
+        {
+          "id": "a",
+          "text": "It allows administrators to modify the table schema from any application scope"
+        },
+        {
+          "id": "b",
+          "text": "It permits out-of-scope applications to create configurations such as client scripts or form buttons that affect the table"
+        },
+        {
+          "id": "c",
+          "text": "It enables automatic configuration of field-level ACL rules across all scopes"
+        },
+        {
+          "id": "d",
+          "text": "It allows the table to inherit configuration settings from its parent application"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The 'Allow configuration' setting controls whether out-of-scope applications can create configuration artifacts — such as client scripts, UI actions (buttons), or other customizations — that target the table. For example, a private application could own a button on the globally scoped incident form by leveraging this setting. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'Allow configuration' setting does not control table schema modifications. It specifically governs whether other scopes can create configuration records like client scripts or UI actions that reference the table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "ACL rules are managed through the Access Control system, not through the 'Allow configuration' field. This setting is about permitting other scopes to own configuration artifacts that affect your table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "There is no concept of inheriting configuration settings from a parent application through this field. The 'Allow configuration' setting is about cross-scope configuration artifact ownership.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application access settings"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-application-access.md",
+        "excerpt": "One of the main use cases I'm aware of is so that your scope can own a column on a table that's out of scope, or that your application, your scope, can create a button on the form of a table that's out of scope. So you might create this private application that enhances your major incident process. And there might be a button that kicks off some kind of automation that shows up on the incident table."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Application Development",
+        "domainSlug": "application-development",
+        "domainPercentage": 11,
+        "subtopics": [
+          "Application scope and scoped applications"
+        ],
+        "tags": [
+          "allow-configuration",
+          "cross-scope",
+          "client-scripts",
+          "UI-actions"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/questions/cad/business-rules.json
+++ b/data/questions/cad/business-rules.json
@@ -1,0 +1,1094 @@
+{
+  "questions": [
+    {
+      "id": "cad-business-rules-001",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Where do business rules execute in the ServiceNow architecture?",
+      "options": [
+        {
+          "id": "a",
+          "text": "In the user's web browser (client-side)"
+        },
+        {
+          "id": "b",
+          "text": "On the ServiceNow server (server-side)"
+        },
+        {
+          "id": "c",
+          "text": "In the MID Server"
+        },
+        {
+          "id": "d",
+          "text": "In the browser's service worker"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Business rules execute on the server side, not in the browser. They deal primarily with interaction with the database table itself. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Business rules run on the server, not the client. Client-side scripts such as Client Scripts and UI Policies run in the browser.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "MID Servers are used for integrations and discovery, not for executing business rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-servicenow-platform/page/product/mid-server/concept/mid-server-landing.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Service workers are a browser technology unrelated to ServiceNow business rule execution.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Business Rules"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "And these business rules execute on the server side, not in the browser. So they are faster, but they generally don't work on things like the form that you see in your browser or a list. They are dealing primarily with interaction with the table itself."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule types (before, after, async, display)"
+        ],
+        "tags": [
+          "business-rules",
+          "server-side",
+          "execution"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-002",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_select",
+      "question": "Which of the following are types of business rules based on when they execute in the transaction lifecycle? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Before"
+        },
+        {
+          "id": "b",
+          "text": "After"
+        },
+        {
+          "id": "c",
+          "text": "Concurrent"
+        },
+        {
+          "id": "d",
+          "text": "Async"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "ServiceNow business rules can be configured as before, after, display, before query, or async (asynchronous) types. Before, After, and Async are all valid business rule execution types. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "There is no 'Concurrent' business rule type in ServiceNow. The valid types are before, after, async, display, and before query.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Business Rules"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "before rules, before we do something like a database update. After rules. After we have done a database update. And lastly, asynchronous rules are where it is not tied to the user's UI that's executing this."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule types (before, after, async, display)"
+        ],
+        "tags": [
+          "business-rules",
+          "types",
+          "before",
+          "after",
+          "async"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-003",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What is the primary purpose of an asynchronous business rule?",
+      "options": [
+        {
+          "id": "a",
+          "text": "To execute before a record is displayed to the user"
+        },
+        {
+          "id": "b",
+          "text": "To run non-time-sensitive logic without blocking the user's session"
+        },
+        {
+          "id": "c",
+          "text": "To validate field values before a record is saved to the database"
+        },
+        {
+          "id": "d",
+          "text": "To pass server-side data to client-side scripts using g_scratchpad"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Asynchronous business rules are used for operations that are not time-sensitive. They are added to the job queue and execute at the next available moment, returning control to the user's UI immediately. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Executing before a record is displayed describes a display business rule, not an asynchronous one.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Validating field values before saving describes a before business rule. Async rules run after the database operation and are queued as scheduled jobs.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Passing data to the client side via g_scratchpad is a feature of display business rules, not asynchronous rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/reference/r_DisplayBusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Business Rules"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "If something is not time sensitive and we don't want our user to be waiting around to get control of their resources again, their UI, we can create something as an asynchronous rule. Means it gets added to our job queue, and it executes when the next available spot is there."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule types (before, after, async, display)"
+        ],
+        "tags": [
+          "business-rules",
+          "async",
+          "asynchronous",
+          "job-queue"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-004",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Which type of business rule supports the use of g_scratchpad to pass data from the server to the client?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Before business rule"
+        },
+        {
+          "id": "b",
+          "text": "After business rule"
+        },
+        {
+          "id": "c",
+          "text": "Display business rule"
+        },
+        {
+          "id": "d",
+          "text": "Async business rule"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The g_scratchpad object is only available in display business rules. It provides a mechanism to pass server-side data to client-side scripts. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/reference/r_DisplayBusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Before business rules execute before a database operation and do not have access to g_scratchpad. They use the current and previous objects for field manipulation.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "After business rules execute after the database operation completes. They do not support g_scratchpad for passing data to the client.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Async business rules run as scheduled jobs separate from the user's session and have no mechanism to pass data to the client UI.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Display Business Rules"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "we have this thing called g_scratchpad, which only works with display business rules. And it allows us to take data from the server side and pass it to the client side."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule types (before, after, async, display)",
+          "current and previous objects"
+        ],
+        "tags": [
+          "business-rules",
+          "display",
+          "g_scratchpad",
+          "server-to-client"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-005",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to automatically populate a calculated field value on an Incident record before it is written to the database, without the user explicitly setting it. Which type of business rule should the developer use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Display business rule"
+        },
+        {
+          "id": "b",
+          "text": "Before business rule"
+        },
+        {
+          "id": "c",
+          "text": "After business rule"
+        },
+        {
+          "id": "d",
+          "text": "Async business rule"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A before business rule runs after the form is submitted but before the record is written to the database, making it ideal for populating or modifying field values before the save occurs. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Display business rules run when a record is read and before it is displayed. They are used for passing data to the client via g_scratchpad, not for modifying field values before a save.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/reference/r_DisplayBusinessRules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "After business rules run after the record is already saved to the database, so they cannot populate field values before the write occurs.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Async business rules are queued as scheduled jobs and run independently of the current transaction, making them unsuitable for modifying field values before a record is saved.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Business Rules"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "Before we do a record update. So maybe we have submitted the record, but before it actually gets written to the database, we're going to execute this rule. Maybe we need to populate fields that are not populated by the user. Populate a field in that record."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule types (before, after, async, display)",
+          "When to use business rules vs other methods"
+        ],
+        "tags": [
+          "business-rules",
+          "before",
+          "field-population",
+          "scenario"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-006",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Why are the current and previous objects NOT available in scheduled script executions?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Scheduled scripts run on the client side where these objects are not supported"
+        },
+        {
+          "id": "b",
+          "text": "Scheduled scripts are not associated with a specific table record"
+        },
+        {
+          "id": "c",
+          "text": "Scheduled scripts only support GlideForm (g_form) APIs"
+        },
+        {
+          "id": "d",
+          "text": "The current and previous objects are deprecated in the Yokohama release"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The current and previous objects are only available in server-side scripts that are associated with a specific table record (i.e., scripts with a table field on the trigger). Scheduled scripts have no table association, so GlideRecord or GlideQuery must be used instead. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_ScheduledJobs.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Scheduled scripts run on the server side, not the client side. The reason current/previous are unavailable is the lack of a table record context, not the execution environment.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_ScheduledJobs.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "GlideForm (g_form) is a client-side API and is not available in scheduled scripts. Scheduled scripts use server-side APIs like GlideRecord and GlideQuery.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_ScheduledJobs.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The current and previous objects are not deprecated. They remain fully supported in business rules and other table-associated server-side scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Scheduled Script Executions"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-scheduled-script-execution-and-email.md",
+        "excerpt": "we cannot use the current or previous object... Generally speaking, the current and previous objects are only available in server-side script that are associated with a specific table record. And that means, generally, that there is a table field on the trigger. No table field on this trigger."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "current and previous objects",
+          "Scheduled script execution"
+        ],
+        "tags": [
+          "scheduled-scripts",
+          "current-object",
+          "previous-object",
+          "gliderecord"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-007",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer writes the expression current.caller_id.department.name in a business rule on the Incident table. What technique is being used and what value is returned?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Dot-walking — returns the name of the department of the caller on the incident"
+        },
+        {
+          "id": "b",
+          "text": "GlideRecord chaining — returns the sys_id of the caller's department"
+        },
+        {
+          "id": "c",
+          "text": "Reference querying — returns the caller's user name"
+        },
+        {
+          "id": "d",
+          "text": "Object inheritance — returns the incident's department field"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "This is dot-walking, which traverses reference fields across tables. Starting from the current Incident record, it follows caller_id to the User table, then department to the Department table, and retrieves the Name field value. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DotWalkingInScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "This is dot-walking, not GlideRecord chaining. Dot-walking resolves the display value (the name), not the sys_id, when accessing the .name field.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DotWalkingInScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The expression navigates to the department's name, not the caller's user name. Reference querying is not a ServiceNow term for this technique.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DotWalkingInScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Object inheritance is a general programming concept unrelated to traversing reference fields in ServiceNow. The expression returns the caller's department name, not a field on the incident itself.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DotWalkingInScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Dot-Walking"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "current.caller_id.department.name is going to give us sales because that's what that callers department's name is. And we're going from table to table to table. This is Dot-walking."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule conditions and scripts"
+        ],
+        "tags": [
+          "dot-walking",
+          "reference-fields",
+          "current-object",
+          "scripting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-008",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_select",
+      "question": "Which of the following are valid database operations that can trigger a business rule in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Insert"
+        },
+        {
+          "id": "b",
+          "text": "Update"
+        },
+        {
+          "id": "c",
+          "text": "Export"
+        },
+        {
+          "id": "d",
+          "text": "Delete"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "Business rules can be triggered on insert, update, delete, and query operations against a table. Export is not a database operation that triggers business rules. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "Export is a UI/reporting operation, not a database operation. Business rules are triggered by database-level operations such as insert, update, delete, and query.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Business Rules"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/07-ssnf-business-rules.md",
+        "excerpt": "business rule is a record that we create that contains JavaScript to do something related to a table. We want to display a record, we want to insert a record, update a record, or delete a record, or just query the table. We can run the business rule when any of these things happen."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule conditions and scripts"
+        ],
+        "tags": [
+          "business-rules",
+          "triggers",
+          "insert",
+          "update",
+          "delete",
+          "database-operations"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-009",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In an onChange client script, what does the 'oldValue' parameter represent?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The value of the field immediately before the most recent user edit on the client side"
+        },
+        {
+          "id": "b",
+          "text": "The value stored on the server when the form was loaded"
+        },
+        {
+          "id": "c",
+          "text": "The default value defined in the field's dictionary entry"
+        },
+        {
+          "id": "d",
+          "text": "The value from the same field on the previously viewed record"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The oldValue parameter in an onChange client script represents the value that was stored on the server when the form loaded. It does not track intermediate client-side edits — if a user changes the field 20 times before saving, oldValue still reflects the original server-side value. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "oldValue does not track each intermediate client-side change. It specifically reflects the server-side stored value at form load time, regardless of how many times the field has been edited in the current session.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "oldValue is not the dictionary default value. It is the actual value stored in the database when the form loaded. For a new record, oldValue would be null or blank, which may coincide with a default but is not derived from the dictionary definition.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "oldValue has no relation to previously viewed records. It is scoped to the current record and form session, representing only the server-side stored value at load time.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-scripting-demo-part-2-of-4.md",
+        "excerpt": "Know that 'oldValue' is equivalent to the previous value when the form loaded, not what was previously there if you've edited the field 20 times before saving it, but rather, you can think of it as what's stored there on the server."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "When to use business rules vs other methods"
+        ],
+        "tags": [
+          "client-script",
+          "onChange",
+          "oldValue",
+          "client-side-scripting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:32.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-010",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the purpose of the 'Execute if false' script section in a UI policy?",
+      "options": [
+        {
+          "id": "a",
+          "text": "It runs validation logic before the UI policy condition is evaluated"
+        },
+        {
+          "id": "b",
+          "text": "It defines scripted actions to perform when the UI policy condition is no longer true"
+        },
+        {
+          "id": "c",
+          "text": "It prevents the UI policy from executing on specific form views"
+        },
+        {
+          "id": "d",
+          "text": "It logs diagnostic information when the UI policy condition fails to evaluate"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The 'Execute if false' script section in a UI policy allows developers to define actions that should occur when the UI policy condition evaluates to false (i.e., is no longer met). This is essential for undoing scripted changes such as clearing field messages when the triggering condition changes. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'Execute if false' script does not run validation before condition evaluation. It is triggered after the condition is evaluated and found to be false, allowing the developer to reverse previously applied scripted changes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Restricting a UI policy to specific form views is controlled by the View field on the UI policy record, not the 'Execute if false' script. The script is exclusively for defining reversal logic when the condition is no longer met.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The 'Execute if false' script does not provide logging or diagnostic capabilities. It is a scripting area for defining what should happen when the UI policy condition evaluates to false, such as removing field messages or resetting styles.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/06-adf-scripting-demo-part-1-of-4.md",
+        "excerpt": "That's what the execute if false field is for. And, remember, during my lecture, I said that, at least at present, despite all the advances in Now Assist and GenAI and stuff like that, ServiceNow can't parse this and figure out the opposite of what you intended it to do and then just do that."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule conditions and scripts"
+        ],
+        "tags": [
+          "ui-policy",
+          "execute-if-false",
+          "client-side-scripting",
+          "form-configuration"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:32.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-011",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer creates a scripted UI policy that uses g_form.showFieldMessage() to display an informational message beneath a field when a condition is met. After testing, the developer notices the message remains visible even after the condition is no longer true. What is the most likely cause?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The showFieldMessage() method requires a form save before it can be cleared"
+        },
+        {
+          "id": "b",
+          "text": "The developer did not add a corresponding script in the 'Execute if false' section to clear the message"
+        },
+        {
+          "id": "c",
+          "text": "UI policy scripts cannot interact with field messages and a client script should be used instead"
+        },
+        {
+          "id": "d",
+          "text": "The UI policy's 'Reverse if false' checkbox is not selected on the UI policy record"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When a UI policy uses scripting (such as g_form.showFieldMessage()) to modify the form, the platform cannot automatically reverse those scripted changes when the condition becomes false. The developer must explicitly add reversal logic in the 'Execute if false' script section — for example, calling g_form.hideFieldMessage() to remove the message. UI policy actions auto-reverse, but scripts do not. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "g_form.showFieldMessage() is a client-side method that takes effect immediately without a form save. Clearing the message also does not require saving — it requires the corresponding clearance logic in the 'Execute if false' script.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "UI policy scripts can absolutely interact with field messages using GlideForm methods like showFieldMessage() and hideFieldMessage(). This is a common and supported pattern for scripted UI policies.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "'Reverse if false' applies to UI policy action records (such as making a field read-only or mandatory), not to scripted behavior. Scripted actions in the 'Execute if true' section must be manually reversed in the 'Execute if false' section.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/06-adf-scripting-demo-part-1-of-4.md",
+        "excerpt": "I told it indeed to create this message every time the condition became true. But I never told it to undo the message. That's what the execute if false field is for."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Script debugging techniques"
+        ],
+        "tags": [
+          "ui-policy",
+          "showFieldMessage",
+          "execute-if-false",
+          "troubleshooting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:32.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-012",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are parameters provided by the onChange client script template function? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "control"
+        },
+        {
+          "id": "b",
+          "text": "current"
+        },
+        {
+          "id": "c",
+          "text": "isLoading"
+        },
+        {
+          "id": "d",
+          "text": "previous"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The onChange client script template function provides five parameters: control, oldValue, newValue, isLoading, and isTemplate. The 'control' parameter gives access to the UI element of the field, while 'isLoading' is a boolean indicating whether the form is still loading. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "'current' is a server-side GlideRecord object available in business rules, not a client script parameter. In business rules, 'current' represents the record being inserted, updated, deleted, or queried. Client scripts use GlideForm (g_form) methods and the onChange template parameters instead.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "'previous' is a server-side GlideRecord object available in business rules that contains the record values before the current update. It is not available in client scripts. The client-side equivalent for tracking value changes is the 'oldValue' parameter in the onChange template.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-scripting-demo-part-2-of-4.md",
+        "excerpt": "I'm going to leverage a few of these values that are given to me as part of 'onChange' Template function. New value will let me grab whatever's currently in that field at any given time, and 'control' actually gives me access to that UI element of the field itself."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "When to use business rules vs other methods",
+          "current and previous objects"
+        ],
+        "tags": [
+          "client-script",
+          "onChange",
+          "control",
+          "isLoading",
+          "template-parameters"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:32.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-013",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer needs to make a field read-only when a UI policy condition is true. The developer is deciding whether to use a UI policy action record or accomplish this entirely through scripting. What is a key advantage of using a UI policy action record for this requirement?",
+      "options": [
+        {
+          "id": "a",
+          "text": "UI policy actions execute on the server side, providing better security than client-side scripts"
+        },
+        {
+          "id": "b",
+          "text": "UI policy actions automatically reverse the change when the condition is no longer met, without requiring additional scripting"
+        },
+        {
+          "id": "c",
+          "text": "UI policy actions support conditional logic that cannot be replicated in scripts"
+        },
+        {
+          "id": "d",
+          "text": "UI policy actions allow setting multiple field attributes in a single line of code"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "UI policy action records are lightweight and automatically reverse their effects when the UI policy condition is no longer true. For example, if an action sets a field to read-only, the platform automatically makes it editable again when the condition becomes false — no additional scripting required. This auto-reversal is a key advantage over scripted approaches, which require explicit 'Execute if false' logic. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "UI policy actions are client-side configurations, not server-side. They control the form presentation in the user's browser. For server-side enforcement of field values, Access Control Rules (ACLs) or business rules would be used.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "UI policy actions do not support conditional logic themselves — the condition is defined on the parent UI policy record. Scripts actually offer more flexibility for complex conditional logic than action records do.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI policy actions are configured as separate records (one per field attribute change), not as single lines of code. Each action record controls one attribute (read-only, mandatory, or visible) for one field.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/06-adf-scripting-demo-part-1-of-4.md",
+        "excerpt": "UI policy action records are so lightweight and so clear, I can make it once and never worry about it... It can parse and figure out the opposite of this true value on the read-onlyness of our original CP field, as dictated in the UI policy action record."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "When to use business rules vs other methods"
+        ],
+        "tags": [
+          "ui-policy",
+          "ui-policy-actions",
+          "read-only",
+          "best-practices"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:32.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-014",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A developer is writing an onChange client script that must replace the current value of a field with a corrected value and display an error message to the user when an invalid entry is detected. Which two GlideForm (g_form) methods should the developer use? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "g_form.setValue()"
+        },
+        {
+          "id": "b",
+          "text": "g_form.setDisplay()"
+        },
+        {
+          "id": "c",
+          "text": "g_form.addErrorMessage()"
+        },
+        {
+          "id": "d",
+          "text": "g_form.setReadOnly()"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "To programmatically replace a field value on the client side, the developer should use g_form.setValue() with the field name and new value as arguments. To display an error message banner at the top of the form, g_form.addErrorMessage() is the appropriate method. These two methods together fulfill the requirements of replacing the invalid value and notifying the user. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/c_GlideFormAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "g_form.setDisplay() controls whether a field is visible or hidden on the form. It does not replace field values or display error messages. It is used for showing/hiding fields based on conditions.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/c_GlideFormAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "g_form.setReadOnly() makes a field read-only or editable. While this might be used as an additional step to prevent further editing, it does not replace the field value or display an error message, which are the two specific requirements stated.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/c_GlideFormAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideForm (g_form)"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/07-adf-scripting-demo-part-2-of-4.md",
+        "excerpt": "When we set values client-side, we usually have to use a GlideForm method-- I bet you know this-- called 'setValue.' And in this case, I'm going to call out the field name explicitly using its system name."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Business Rules",
+        "domainSlug": "business-rules",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Business rule conditions and scripts"
+        ],
+        "tags": [
+          "GlideForm",
+          "setValue",
+          "addErrorMessage",
+          "client-script",
+          "onChange"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:32.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/questions/cad/client-scripts.json
+++ b/data/questions/cad/client-scripts.json
@@ -1,0 +1,866 @@
+{
+  "questions": [
+    {
+      "id": "cad-client-scripts-001",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which of the following is NOT one of the four types of client scripts in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "onLoad"
+        },
+        {
+          "id": "b",
+          "text": "onChange"
+        },
+        {
+          "id": "c",
+          "text": "onBefore"
+        },
+        {
+          "id": "d",
+          "text": "onSubmit"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The four types of client scripts in ServiceNow are onLoad, onChange, onSubmit, and onCellEdit. 'onBefore' is not a client script type; it relates to business rule timing (before business rules). See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "onLoad is a valid client script type that runs when a form loads and before control is given to the user.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "onChange is a valid client script type that runs when a specific field value changes on a form.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "onSubmit is a valid client script type that runs when a form is submitted, saved, or updated.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/05-ssnf-client-scripts.md",
+        "excerpt": "we're going to talk about the four different times a client script can execute"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script types (onLoad, onChange, onSubmit, onCellEdit)"
+        ],
+        "tags": [
+          "client-scripts",
+          "script-types",
+          "onLoad",
+          "onChange",
+          "onSubmit",
+          "onCellEdit"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:59.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-002",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Where do ServiceNow client scripts execute?",
+      "options": [
+        {
+          "id": "a",
+          "text": "On the ServiceNow application server"
+        },
+        {
+          "id": "b",
+          "text": "On the client's web browser"
+        },
+        {
+          "id": "c",
+          "text": "On the MID Server"
+        },
+        {
+          "id": "d",
+          "text": "On the database server"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Client scripts execute on the client's web browser. When a form loads, client scripts are loaded with the form and execute in the browser, waiting for user interaction to trigger them. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Server-side scripts such as business rules execute on the application server. Client scripts run in the user's browser.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The MID Server facilitates communication between the ServiceNow instance and external resources for integrations and discovery. It does not execute client scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-it-operations-management/page/product/mid-server/concept/mid-server-landing.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The database server stores and retrieves data. Client scripts do not execute on the database server.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/05-ssnf-client-scripts.md",
+        "excerpt": "Client Scripts are going to execute on the browser. So when you load a form, for example-- maybe I'm on an incident, I click on an incident number and I'm bringing up that form. Client Scripts are going to load with that form and are going to wait for something to happen."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script best practices"
+        ],
+        "tags": [
+          "client-scripts",
+          "browser",
+          "client-side",
+          "execution-environment"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:59.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-003",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer creates a client script on the Task table and enables the Inherited checkbox. What is the effect of this configuration?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The client script will only execute on the Task table and no other tables"
+        },
+        {
+          "id": "b",
+          "text": "The client script can also execute on child tables of Task, such as Incident, Problem, and Change Request"
+        },
+        {
+          "id": "c",
+          "text": "The client script will be automatically copied as separate records to all child tables"
+        },
+        {
+          "id": "d",
+          "text": "The client script will execute on every table in the ServiceNow instance"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When the Inherited checkbox is enabled on a client script, the script can execute on child tables that extend the selected table. For example, a client script on the Task table with Inherited enabled can execute on Incident, Problem, and Change Request tables. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "This would be the behavior if the Inherited checkbox is NOT enabled. With Inherited enabled, the script extends execution to child tables.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The Inherited checkbox does not create separate copies of the client script on child tables. The single script record executes on child tables through table hierarchy inheritance.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The Inherited checkbox only affects child tables that extend the selected table through the table hierarchy, not every table in the instance.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/05-ssnf-client-scripts.md",
+        "excerpt": "Inherited is also very nice if you're creating a client script on a table that might have child tables. So Incident, as we see here, is not a parent of any other table. But Task is. So if I was creating this client script, and I had selected the Task table, if I had inherited turned on, it could potentially execute against the Incident table or the Problem table or the Change Request table"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script best practices"
+        ],
+        "tags": [
+          "client-scripts",
+          "inherited",
+          "task-table",
+          "table-hierarchy"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:59.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-004",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following statements about the Order field on client scripts are correct? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "The Order field appears on the Client Script form by default"
+        },
+        {
+          "id": "b",
+          "text": "Client scripts with a lower Order value execute first"
+        },
+        {
+          "id": "c",
+          "text": "The Order field should be used when multiple client scripts of the same type exist on the same table"
+        },
+        {
+          "id": "d",
+          "text": "The Order field determines whether a client script is active or inactive"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Client scripts execute in order from lowest to highest Order value. The Order field should be used when multiple client scripts of the same type exist for the same table and may have conflicting logic, to control which executes first. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The Order field does not appear on the Client Script form by default (baseline). It must be added manually through Form Layout, Form Design, or Form Builder.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The Active checkbox determines whether a client script is active or inactive. The Order field only controls the execution sequence among multiple scripts of the same type.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/05-ssnf-client-scripts.md",
+        "excerpt": "Use the Order field when multiple Client Scripts for the same table have conflicting logic. Execute in order from lowest to highest. And it does not appear on the Client Script form baseline."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script best practices"
+        ],
+        "tags": [
+          "client-scripts",
+          "order-field",
+          "execution-order"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:59.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-005",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "When a user clicks 'New' to open a new incident form, which of the following can fire during the form rendering process? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Query business rules"
+        },
+        {
+          "id": "b",
+          "text": "Display business rules"
+        },
+        {
+          "id": "c",
+          "text": "onLoad client scripts"
+        },
+        {
+          "id": "d",
+          "text": "Before business rules"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "When clicking 'New' to open a form, query business rules fire when the table is queried for a new record, display business rules fire as the form renders to populate the scratchpad, and onLoad client scripts fire in the browser after the form loads but before the user gets control. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "d",
+            "explanation": "Before business rules fire when a record is being inserted or updated (e.g., when clicking Submit or Save), not when a new empty form is being opened for display.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts",
+        "ServiceNow Docs - Business Rules"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/08-adf-scripting-demo-part-3-of-4.md",
+        "excerpt": "When I click New, that's going to send a request to the server and query the table, asking for a new incident form... that's when a query business rule could fire... as the form is rendering, a display business rule may have fired by then, as well... immediately after that display business rule, an onLoad client script could fire, as well."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script types (onLoad, onChange, onSubmit, onCellEdit)"
+        ],
+        "tags": [
+          "client-scripts",
+          "onLoad",
+          "business-rules",
+          "execution-order",
+          "form-rendering"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:59.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-006",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to highlight VIP callers when the Caller field changes on the Incident form, but only when users are viewing the Self-Service (ESS) view. Which client script configuration should the developer use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "An onLoad client script with the View field set to ESS"
+        },
+        {
+          "id": "b",
+          "text": "An onChange client script on the Caller field with the View field set to ESS"
+        },
+        {
+          "id": "c",
+          "text": "An onSubmit client script with a condition that checks the current view"
+        },
+        {
+          "id": "d",
+          "text": "An onChange client script on the Caller field with no View specified"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "An onChange client script is required because the action must trigger when the Caller field value changes. Setting the View field to ESS restricts the script to execute only when users view the Self-Service view. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "An onLoad client script runs when the form loads, not when a specific field value changes. It would not respond to changes in the Caller field.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "An onSubmit client script runs when the form is submitted, saved, or updated — not when a field value changes. This would not highlight VIP callers in real time.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "While using an onChange client script on the Caller field is partially correct, not specifying a View would cause the script to execute on all views, not just the Self-Service (ESS) view as required.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/05-ssnf-client-scripts.md",
+        "excerpt": "we have onChange of the Caller field... this client script is specifically executing onChange of the Caller field when someone is looking at the ESS or self-service view. But because it's only that view, this wouldn't necessarily execute when you're on the default view, for example, or maybe another view that you created."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script types (onLoad, onChange, onSubmit, onCellEdit)"
+        ],
+        "tags": [
+          "client-scripts",
+          "onChange",
+          "view-filtering",
+          "ESS",
+          "self-service",
+          "VIP"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:59.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-007",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which GlideForm (g_form) method is used to retrieve the current value of a field on a form in a client script?",
+      "options": [
+        {
+          "id": "a",
+          "text": "g_form.getFieldValue()"
+        },
+        {
+          "id": "b",
+          "text": "g_form.getValue()"
+        },
+        {
+          "id": "c",
+          "text": "g_form.get()"
+        },
+        {
+          "id": "d",
+          "text": "g_form.readValue()"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The g_form.getValue('fieldName') method retrieves the value of a specified field on the current form. This is the standard GlideForm API method for reading field values in client scripts and UI policies.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "getFieldValue() is not a valid GlideForm method. The correct method is getValue().",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/GlideFormAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "g_form.get() is not a valid method for retrieving field values. getValue() is the correct GlideForm method for this purpose.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/GlideFormAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "readValue() is not a valid GlideForm method. The GlideForm API uses getValue() and setValue() for reading and writing field values.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/GlideFormAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideForm/concept/GlideFormAPI.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/09-adf-scripting-demo-part-4-of-4.md",
+        "excerpt": "I know that if I want to get the value of the impact field, say from a UI policy or a client script, I need to use this GlideForm method, getValue. Maybe add store it into a variable."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "g_form API methods"
+        ],
+        "tags": [
+          "g_form",
+          "getValue",
+          "client-script",
+          "GlideForm"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T20:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-008",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In which type of ServiceNow script are the 'current' and 'previous' objects available for accessing record field values?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Client scripts"
+        },
+        {
+          "id": "b",
+          "text": "UI policies"
+        },
+        {
+          "id": "c",
+          "text": "Business rules"
+        },
+        {
+          "id": "d",
+          "text": "UI scripts"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The 'current' and 'previous' objects are available in server-side scripts that are associated with a table, such as business rules. The 'current' object contains the values being submitted, while 'previous' contains the values before the update. These objects are not available client-side.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Client scripts run in the browser (client-side) and do not have access to the current or previous objects. They use the g_form API to interact with form fields.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "UI policies are client-side configurations and do not have access to the current or previous objects. They use g_form methods to get and set field values.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/ui-policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI scripts are client-side script libraries that run in the browser. They do not have access to server-side objects like current and previous.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_UIScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_BusinessRules.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/09-adf-scripting-demo-part-4-of-4.md",
+        "excerpt": "Test number one-- are you dealing with a server-side script, like a business rule? If so, you're halfway there. There is no current or previous object available client-side."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script best practices"
+        ],
+        "tags": [
+          "current",
+          "previous",
+          "business-rule",
+          "server-side"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T20:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-009",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Why are display business rules with the g_scratchpad object preferred over GlideAjax calls when server-side data is needed at form load?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Display business rules can dynamically update data when field values change on the form"
+        },
+        {
+          "id": "b",
+          "text": "Display business rules send data along with the initial form load, avoiding an additional round trip to the server"
+        },
+        {
+          "id": "c",
+          "text": "The g_scratchpad object allows client scripts to directly query the database without server involvement"
+        },
+        {
+          "id": "d",
+          "text": "Display business rules execute asynchronously and therefore do not impact form load performance"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Display business rules run on the server before the form is sent to the client. By writing values to the g_scratchpad object, the data 'rides along' with the form response, eliminating the need for a separate asynchronous server call (GlideAjax). This avoids an additional round trip and improves performance.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Display business rules only fire once when the form loads. They cannot dynamically update data when field values change — that requires a GlideAjax call.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The g_scratchpad object is simply a data-passing mechanism between a display business rule and client scripts. It does not allow direct database queries from the client side.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Display business rules are synchronous server-side scripts that execute before the form is rendered. They are not asynchronous. Their advantage is that they piggyback on the existing form load request.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/09-adf-scripting-demo-part-4-of-4.md",
+        "excerpt": "we're saying, if you're going to be there anyway, please bring back this extra thing for me so I can avoid making a round trip. That is what display business rules in scratchpad do for us. That's why we like them."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script best practices",
+          "GlideAjax from client side"
+        ],
+        "tags": [
+          "display-business-rule",
+          "g_scratchpad",
+          "GlideAjax",
+          "performance"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T20:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-010",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "In which of the following server-side script types must a developer query records using GlideRecord or GlideQuery instead of relying on the 'current' object? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Business rules"
+        },
+        {
+          "id": "b",
+          "text": "Scheduled scripts"
+        },
+        {
+          "id": "c",
+          "text": "Script includes"
+        },
+        {
+          "id": "d",
+          "text": "Script actions"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Scheduled scripts and script includes are server-side scripts that are not directly associated with a table record operation. They do not have the 'current' or 'previous' objects automatically provided. To access records, developers must explicitly query using GlideRecord or GlideQuery.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Business rules are associated with a specific table and fire in response to record operations (insert, update, delete, query). They automatically receive the 'current' and 'previous' objects.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Script actions are triggered by events that are associated with a specific record, so they do have access to the 'current' object representing the record that triggered the event.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_ScriptActions.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_ServerSideScripting.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/09-adf-scripting-demo-part-4-of-4.md",
+        "excerpt": "other types of server-side scripts, like fixed scripts, scheduled scripts, script includes, in all of those, if you want to access a particular record, you're going to have to query it with GlideRecord or GlideQuery."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client script best practices"
+        ],
+        "tags": [
+          "current",
+          "previous",
+          "GlideRecord",
+          "GlideQuery",
+          "server-side"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T20:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-011",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to display the Assigned To user's manager's email address in a field message on the Incident form. The email should appear when the form loads but does not need to update when the Assigned To field value changes. What is the recommended approach?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Use dot-walking in an onLoad client script to access current.assigned_to.manager.email"
+        },
+        {
+          "id": "b",
+          "text": "Write a GlideAjax call in an onChange client script to fetch the manager's email from the server"
+        },
+        {
+          "id": "c",
+          "text": "Use a display business rule to dot-walk to the manager's email and pass it to the client via g_scratchpad"
+        },
+        {
+          "id": "d",
+          "text": "Create a UI macro that queries the manager's email and renders it on the form"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "A display business rule can dot-walk server-side to retrieve the assigned user's manager's email (e.g., current.assigned_to.manager.email) and write it to g_scratchpad. The client script then reads the value from g_scratchpad when the form loads. This avoids an extra round trip to the server since the data is sent along with the form.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Client scripts cannot use dot-walking on the 'current' object because it is a server-side object. Client scripts do not have access to 'current' or 'previous', and dot-walking to related records is not possible client-side.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "While GlideAjax would work, it makes an additional asynchronous round trip to the server. Since the requirement only needs the data at form load and not dynamically, a display business rule with g_scratchpad is more efficient and the recommended approach.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ajax/concept/c_GlideAjax.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI macros are used for reusable UI components (Jelly-based) and are not the recommended pattern for passing server-side data to client scripts. The display business rule and scratchpad pattern is the standard approach for this use case.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/09-adf-scripting-demo-part-4-of-4.md",
+        "excerpt": "this technique, dot walking in a display business rule and writing it to the scratchpad, allows us to get this information which our client script wouldn't ordinarily be able to figure out because it involves a server call."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Client Scripts",
+        "domainSlug": "client-scripts",
+        "domainPercentage": 12,
+        "subtopics": [
+          "GlideAjax from client side",
+          "Client script best practices"
+        ],
+        "tags": [
+          "display-business-rule",
+          "g_scratchpad",
+          "dot-walking",
+          "field-message",
+          "GlideAjax"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T20:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/questions/cad/integration-rest.json
+++ b/data/questions/cad/integration-rest.json
@@ -1,0 +1,1035 @@
+{
+  "questions": [
+    {
+      "id": "cad-integration-rest-001",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What does the acronym REST stand for in the context of ServiceNow web services?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Remote Execution Service Transfer"
+        },
+        {
+          "id": "b",
+          "text": "REpresentational State Transfer"
+        },
+        {
+          "id": "c",
+          "text": "Reliable Endpoint Service Technology"
+        },
+        {
+          "id": "d",
+          "text": "Resource Exchange Standard Transport"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "REST stands for REpresentational State Transfer. It is the common web service framework used in ServiceNow for both inbound and outbound integrations, as opposed to SOAP (Simple Object Access Protocol). See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Remote Execution Service Transfer is not a real acronym. REST stands for REpresentational State Transfer.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Reliable Endpoint Service Technology is fabricated. REST is REpresentational State Transfer, a widely adopted architectural style for web services.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Resource Exchange Standard Transport is not a valid acronym. REST stands for REpresentational State Transfer.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: REST API",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/03-adf-web-services.md",
+        "excerpt": "REST, REpresentational State Transfer. It's kind of the hipper, newer kid, compared to another protocol, or framework, for conducting these web service requests called SOAP, Simple Object Access Protocol."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Outbound REST Messages"
+        ],
+        "tags": [
+          "REST",
+          "web-services",
+          "fundamentals"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-002",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which HTTP method is used to perform a partial update of a resource when working with RESTful web services in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "PUT"
+        },
+        {
+          "id": "b",
+          "text": "POST"
+        },
+        {
+          "id": "c",
+          "text": "PATCH"
+        },
+        {
+          "id": "d",
+          "text": "GET"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "PATCH is the HTTP method used for partial updates. Unlike PUT, which performs a complete overwrite of a resource, PATCH updates only the specified fields. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "PUT performs a complete overwrite of a resource, replacing all fields. PATCH is used for partial updates where only specific fields are modified.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "POST is used to create (insert) a new resource, not to update an existing one.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GET is used to read or retrieve data from a resource. It does not modify data.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: REST API",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/03-adf-web-services.md",
+        "excerpt": "there's two different kinds of updates. There's a complete overwrite. That's called a PUT. And then, there's a PATCH, which is, like, a partial update."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Outbound REST Messages"
+        ],
+        "tags": [
+          "HTTP-methods",
+          "PATCH",
+          "PUT",
+          "REST"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-003",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "When testing an outbound REST message HTTP method in ServiceNow, which HTTP response status code indicates that a GET request was successful?",
+      "options": [
+        {
+          "id": "a",
+          "text": "201 Created"
+        },
+        {
+          "id": "b",
+          "text": "200 OK"
+        },
+        {
+          "id": "c",
+          "text": "301 Moved Permanently"
+        },
+        {
+          "id": "d",
+          "text": "401 Unauthorized"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A status code of 200 indicates that the HTTP GET request was successful and the server returned the requested data. This is the expected result when testing outbound REST messages in ServiceNow. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "201 Created indicates that a new resource was successfully created, typically in response to a POST request. A successful GET request returns 200.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "301 Moved Permanently is a redirect status code indicating the resource has been permanently moved to a different URL. It does not indicate a successful data retrieval.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "401 Unauthorized means the request lacks valid authentication credentials. This indicates a failure, not a success.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: Outbound REST Messages",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/03-adf-web-services.md",
+        "excerpt": "if the request was successful, at least in the case of an HTTP GET-- we want a status code of 200."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Outbound REST Messages",
+          "RESTMessageV2 API"
+        ],
+        "tags": [
+          "HTTP-status-codes",
+          "REST",
+          "testing",
+          "outbound"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-004",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "When configuring an outbound REST message in ServiceNow, which elements are defined on the top-level REST Message record rather than on the HTTP Method record? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "The endpoint URL of the web service provider"
+        },
+        {
+          "id": "b",
+          "text": "HTTP query parameters for the specific request"
+        },
+        {
+          "id": "c",
+          "text": "Authentication type and credentials"
+        },
+        {
+          "id": "d",
+          "text": "Variable substitution test values"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The top-level REST Message record stores information common to all requests, including the endpoint URL (location of the provider) and authentication information. These are inherited by all HTTP Method records created under it. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "HTTP query parameters are defined on the individual HTTP Method records, not on the top-level REST Message record. Each method can have its own specific parameters for its particular request.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/task/t_ConfigureARESTMessageHTTPMethod.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Variable substitution test values are defined in a related list on the HTTP Method record, not the top-level REST Message record. They provide temporary test data for dynamic variables when using the Test feature.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/task/t_ConfigureARESTMessageHTTPMethod.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: Outbound REST Messages",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-web-services-demo.md",
+        "excerpt": "what I'm filling out on this top-level record is stuff that is about HolidayAPI itself and that I would want my subsequent requests to inherit... I don't need to authenticate, so I can leave this as authentication type No Authentication."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Outbound REST Messages"
+        ],
+        "tags": [
+          "REST-message",
+          "configuration",
+          "endpoint",
+          "authentication"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-005",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What must be enabled on a ServiceNow table to allow it to be accessed by inbound web service requests from external systems?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The 'REST Enabled' system property must be set to true"
+        },
+        {
+          "id": "b",
+          "text": "The 'Allow access to this table via web services' checkbox in the Application Access section of the table record"
+        },
+        {
+          "id": "c",
+          "text": "The 'Inbound Integration' module must be activated in the table definition"
+        },
+        {
+          "id": "d",
+          "text": "A Scripted REST API resource must be created for the table"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "To allow external systems to access a ServiceNow table via web services, the 'Allow access to this table via web services' checkbox must be checked in the Application Access section of the table record. Access control rules for the table will also be honored. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "There is no 'REST Enabled' system property that controls table-level web service access. Access is controlled per-table via the Application Access settings on the table record.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/table-administration/reference/r_TablesModuleAccessControls.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "There is no 'Inbound Integration' module in the table definition. Web service access is controlled by the checkbox in the Application Access section of the table record.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/table-administration/reference/r_TablesModuleAccessControls.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "A Scripted REST API is used to create custom REST endpoints with custom logic. Standard table API access only requires enabling the checkbox in the Application Access section of the table record.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/custom-web-services/concept/c_ScriptedRESTAPIs.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: Table API Access Controls",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/03-adf-web-services.md",
+        "excerpt": "we need to double-check that our table is configured to allow that kind of thing. You see the green rectangle on the slide down there? It's a field on the Application Access section of any table record. See it, there? That one. OK. We need to make sure that that's checked."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Inbound REST API (Scripted REST APIs)",
+          "Web Service authentication"
+        ],
+        "tags": [
+          "table-access",
+          "inbound-REST",
+          "application-access",
+          "web-services"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-006",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer has configured an outbound REST message with dynamic variable placeholders in the HTTP query parameters. They need to generate the server-side JavaScript code to call this REST message from a business rule. What should the developer use to obtain the starter script?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The REST API Explorer"
+        },
+        {
+          "id": "b",
+          "text": "The 'Preview Script Usage' related link on the HTTP Method record"
+        },
+        {
+          "id": "c",
+          "text": "The 'Generate Business Rule' button on the REST Message record"
+        },
+        {
+          "id": "d",
+          "text": "The Script Include template in ServiceNow Studio"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Once variables and variable substitutions are created on an HTTP Method record, the 'Preview Script Usage' related link generates ready-to-use ServiceNow JavaScript code that can be copied into any server-side script such as a business rule, scheduled script, or script include. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The REST API Explorer is used when ServiceNow is the provider, allowing developers to test and generate code for inbound REST requests against ServiceNow tables. It is not used to generate outbound REST call scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_RESTAPIExplorer.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "There is no 'Generate Business Rule' button on the REST Message record. The correct approach is to use 'Preview Script Usage' on the HTTP Method record.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "ServiceNow Studio provides templates for creating script includes but does not auto-generate outbound REST integration code. The 'Preview Script Usage' link on the HTTP Method record is the correct tool.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ServiceNowStudio.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: Outbound REST Messages",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-web-services-demo.md",
+        "excerpt": "Once we get variables and variable substitutions created, the Preview Script Usage link becomes a lot more useful. And, now, I can just copy this script to my clipboard, and I could paste it in somewhere-- so, for example, in this business rule record."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Outbound REST Messages",
+          "RESTMessageV2 API"
+        ],
+        "tags": [
+          "preview-script-usage",
+          "outbound-REST",
+          "business-rule",
+          "RESTMessageV2"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-007",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer has configured dynamic variable placeholders using ${variable_name} syntax in the HTTP query parameters of an outbound REST message method. When they click the Test link, the request fails because required parameters are empty. What must the developer do to successfully test the request?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Replace the variable placeholders with hard-coded values before testing"
+        },
+        {
+          "id": "b",
+          "text": "Provide temporary test values in the Variable Substitutions related list on the HTTP Method record"
+        },
+        {
+          "id": "c",
+          "text": "Create a business rule to pass runtime values during the test"
+        },
+        {
+          "id": "d",
+          "text": "Set default values for each variable in System Properties"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When an outbound REST message HTTP method uses dynamic variable placeholders, the developer must provide temporary test values in the Variable Substitutions related list on the HTTP Method record. These values are used only during testing and allow the Test feature to send a complete request. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/task/t_ConfigureARESTMessageHTTPMethod.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Replacing variable placeholders with hard-coded values would work for testing but defeats the purpose of having dynamic variables. The Variable Substitutions related list exists specifically to provide test values without modifying the actual configuration.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/task/t_ConfigureARESTMessageHTTPMethod.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "A business rule is not required to test the REST message. The built-in Variable Substitutions related list on the HTTP Method record provides temporary values for the Test feature without needing runtime scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/task/t_ConfigureARESTMessageHTTPMethod.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "System Properties are not used to set default values for outbound REST message variables. The Variable Substitutions related list on the HTTP Method record is the correct mechanism for providing test values.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/task/t_ConfigureARESTMessageHTTPMethod.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: Configure REST Message HTTP Methods",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-web-services-demo.md",
+        "excerpt": "if I try to test this now, what do you think might happen? Yeah. It fails. Why? Well, look. The country parameter is required, says holidayapi.com. And, yeah, I never provided a value for that variable that I just created. So how do we test these web service requests, when we've got them set up as variables? ... In the related list of the Method record, not the top-level Provider record, I've got a Variable Substitutions related list."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Outbound REST Messages"
+        ],
+        "tags": [
+          "variable-substitutions",
+          "testing",
+          "outbound-REST",
+          "HTTP-method"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-008",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A developer is configuring ServiceNow as a web service provider so that an external monitoring tool can query incident data via the Table API. Which of the following steps are necessary for this integration? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Enable the 'Allow access to this table via web services' checkbox in the Incident table's Application Access settings"
+        },
+        {
+          "id": "b",
+          "text": "Create a user account with appropriate roles for the external system to authenticate with"
+        },
+        {
+          "id": "c",
+          "text": "Configure an outbound REST message with the monitoring tool's endpoint URL"
+        },
+        {
+          "id": "d",
+          "text": "Install the Integration Hub spoke for the monitoring tool"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "When ServiceNow acts as a web service provider, the table must have 'Allow access to this table via web services' enabled in its Application Access settings, and a user account with appropriate roles must exist for the external system to authenticate. ServiceNow honors ACLs for the authenticating user, so the account needs the correct roles. A dedicated 'Web Service Access Only' user can be created for this purpose. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "Outbound REST messages are used when ServiceNow is the consumer, reaching out to external systems. When ServiceNow is the provider, the external system initiates the request inbound to ServiceNow. No outbound configuration is needed.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/integrate/outbound-rest/concept/c_OutboundRESTmsg.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Integration Hub spokes are used for flow-based integrations and are not required for basic Table API access. The external system can query the standard Table API directly once table access and authentication are properly configured.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/administer/integrationhub/concept/integrationhub.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs: Table API",
+        "ServiceNow Docs: Web Service Access",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/03-adf-web-services.md",
+        "excerpt": "we need to double-check that our table is configured to allow that kind of thing... It's a field on the Application Access section of any table record... We need to make sure that that's checked... ServiceNow is going to ask you to authenticate with a ServiceNow user record. And remember how, back in module 5, we showed you that field on the user table called Web Service Access Only, that you can tick if you want to make a user record that's just for this purpose"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Inbound REST API (Scripted REST APIs)",
+          "Web Service authentication"
+        ],
+        "tags": [
+          "provider",
+          "Table-API",
+          "authentication",
+          "application-access",
+          "inbound-REST"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T12:00:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-009",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the purpose of an import set table in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "A permanent table that stores all imported records for long-term reference"
+        },
+        {
+          "id": "b",
+          "text": "A staging table that temporarily holds imported data before it is transformed to a target table"
+        },
+        {
+          "id": "c",
+          "text": "A log table that records the history and status of all import operations"
+        },
+        {
+          "id": "d",
+          "text": "A system table used to define and schedule recurring data imports"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Import set tables serve as temporary staging tables. Source data is first loaded into the import set table, where it is converted into GlideRecords and can be validated before being transformed and moved to the target table. This intermediate step helps manage data quality challenges that arise from bringing in external data. See docs.servicenow.com — Import sets.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Import set tables are temporary staging tables, not permanent storage. Data is meant to pass through them on its way to the target table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_ImportSets.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "While import logs exist separately, the import set table itself is the staging area for the actual imported data, not an activity log.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_ImportSets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Scheduled imports are configured through scheduled import records, not the import set table itself. The import set table holds the staged data.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_ImportSets.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs — Import Sets",
+        "ServiceNow Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-import-data.md",
+        "excerpt": "Import sets are meant to bring your outside data into a staging table, called the import set table, this temporary table that accomplishes a few things. It, first of all, turns whatever the data type was of your source data into GlideRecords, right? It puts things into the ServiceNow platform in a ServiceNow table."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Import Sets and Transform Maps"
+        ],
+        "tags": [
+          "import-sets",
+          "staging-table",
+          "data-import"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-010",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the function of a Transform Map in the ServiceNow import set process?",
+      "options": [
+        {
+          "id": "a",
+          "text": "It converts imported files into XML format before processing"
+        },
+        {
+          "id": "b",
+          "text": "It defines the mapping and rules for moving data from the import set table to the target table"
+        },
+        {
+          "id": "c",
+          "text": "It validates user permissions before allowing data imports to proceed"
+        },
+        {
+          "id": "d",
+          "text": "It automatically creates new target tables for each imported file"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A Transform Map contains the set of instructions that maps columns from the import set table to fields on the target table, and provides automation for handling data quality issues during the transformation process. Multiple Transform Maps can be stacked for more sophisticated operations. See docs.servicenow.com — Transform Maps.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Transform Maps do not convert files to XML. File format conversion happens during the Load Data step when data is brought into the import set table as GlideRecords.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Permission validation is handled by ServiceNow's access control system (ACLs), not by Transform Maps. Transform Maps focus on data field mapping and transformation rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Transform Maps map data to existing target tables; they do not automatically create new tables. Target tables must be defined before or during import set table creation.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs — Transform Maps",
+        "ServiceNow Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-import-data.md",
+        "excerpt": "The set of instructions that allows us to do that is called a Transform Map. Transform Maps help us connect the dots and provide some automation for what to do in certain cases where the data isn't up to snuff."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Import Sets and Transform Maps"
+        ],
+        "tags": [
+          "transform-maps",
+          "field-mapping",
+          "data-import"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-011",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "When importing data from a spreadsheet into ServiceNow using import sets, what happens when the Auto Map Matching Fields option is used?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The import skips the Transform Map step and loads data directly into the target table"
+        },
+        {
+          "id": "b",
+          "text": "Field map records are automatically created for columns whose names match between the import set table and the target table"
+        },
+        {
+          "id": "c",
+          "text": "The platform renames the import set table columns to match the target table column names"
+        },
+        {
+          "id": "d",
+          "text": "Matching fields are merged into a single column on the target table"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The Auto Map Matching Fields feature automatically creates field map records based on matching column names between the import set table and the target table. This eliminates the need to manually drag and drop columns in the Mapping Assist tool when column names already match. See docs.servicenow.com — Auto Map Matching Fields.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Auto Map Matching Fields still uses the Transform Map process — it simply automates the creation of field map records within the Transform Map, rather than bypassing it entirely.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Auto Map Matching Fields does not rename columns. It creates field map records that link existing import set columns to their matching target table columns.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Fields are not merged. Each matching column in the import set table is mapped to its corresponding column on the target table as a one-to-one relationship via field map records.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs — Transform Map Field Mapping",
+        "ServiceNow Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-import-data.md",
+        "excerpt": "if the field names already match, you don't even have to go through this process at all. You can just click a link that says Auto Map Matching Fields, and then, bam, it creates those field map records, based on matching names."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Import Sets and Transform Maps"
+        ],
+        "tags": [
+          "auto-map",
+          "field-map-records",
+          "mapping-assist",
+          "data-import"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-012",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are functions performed by the import set table during the ServiceNow data import process? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Converts source data from its original format into GlideRecords"
+        },
+        {
+          "id": "b",
+          "text": "Automatically cleans and deduplicates all imported records"
+        },
+        {
+          "id": "c",
+          "text": "Provides a staging area to validate imported data before transformation"
+        },
+        {
+          "id": "d",
+          "text": "Permanently stores imported data as a backup copy"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The import set table serves two key functions: (1) it converts the source data from its original format (Excel, CSV, XML, etc.) into GlideRecords within the ServiceNow platform, and (2) it acts as a staging area where the data can be validated and verified before being transformed and moved to the target table. See docs.servicenow.com — Import Sets.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "Import set tables do not automatically clean or deduplicate data. Data cleaning should be done before importing, and deduplication logic must be configured separately through coalesce fields on the Transform Map.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_ImportSets.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Import set tables are temporary staging tables, not permanent storage. They hold data only until it is transformed to the target table. Import set tables can be cleaned up after the process completes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_ImportSets.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs — Import Sets",
+        "ServiceNow Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-import-data.md",
+        "excerpt": "It, first of all, turns whatever the data type was of your source data into GlideRecords, right? It puts things into the ServiceNow platform in a ServiceNow table. And that kind of import set table is a special table that's specifically meant to help you deal with some of the challenges that can come in from bringing outside data. It gives us a chance to validate what's come in."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Import Sets and Transform Maps"
+        ],
+        "tags": [
+          "import-set-table",
+          "gliderecord",
+          "staging",
+          "data-validation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-013",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer is importing employee records from an Excel spreadsheet into a custom table. Several cells in a mandatory field column are empty. The developer wants the records to still be imported but needs to control how strictly mandatory field rules are applied during the transform. Which Transform Map setting should the developer configure?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Coalesce Fields"
+        },
+        {
+          "id": "b",
+          "text": "Run Business Rules"
+        },
+        {
+          "id": "c",
+          "text": "Enforce Mandatory Fields"
+        },
+        {
+          "id": "d",
+          "text": "Choice Action"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The Enforce Mandatory Fields setting on the Transform Map controls how strictly mandatory field requirements are applied during the import process. By default, records can be imported even if mandatory fields are empty — unlike submitting through a form. This setting provides options for different levels of strictness regarding mandatory field enforcement. See docs.servicenow.com — Transform Map properties.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Coalesce Fields are used to match incoming records with existing records to determine whether to update or insert. They do not control mandatory field enforcement.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "The Run Business Rules setting controls whether business rules execute during the import transform, but it does not specifically address mandatory field enforcement on empty cells.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Choice Action determines how choice field values are handled during import (e.g., whether to create new choices). It does not relate to mandatory field enforcement.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs — Transform Map Properties",
+        "ServiceNow Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/01-adf-import-data.md",
+        "excerpt": "one thing that's nice about importing data like this is we can still get the records in anyway, even if those mandatory cells are empty. That can be a good thing. But what if you wanted to have it enforce that mandatoryness... You could probably guess that that's what this Enforce Mandatory Fields field does. And there's actually a couple options in there, that, basically, have to do with, well, how strict to be about it."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Integration & REST APIs",
+        "domainSlug": "integration-rest",
+        "domainPercentage": 15,
+        "subtopics": [
+          "Import Sets and Transform Maps"
+        ],
+        "tags": [
+          "enforce-mandatory",
+          "transform-map",
+          "data-import",
+          "mandatory-fields"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-17T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/questions/cad/script-includes.json
+++ b/data/questions/cad/script-includes.json
@@ -1,0 +1,947 @@
+{
+  "questions": [
+    {
+      "id": "cad-script-includes-001",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the primary purpose of a Script Include in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "To execute client-side scripts automatically when a form loads"
+        },
+        {
+          "id": "b",
+          "text": "To store reusable JavaScript for execution on the server"
+        },
+        {
+          "id": "c",
+          "text": "To define UI Policies that dynamically control form field behavior"
+        },
+        {
+          "id": "d",
+          "text": "To create scheduled automation jobs that run at defined intervals"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A Script Include stores reusable JavaScript for server-side execution. Script Includes follow a 'write once, use many' pattern — they are written once and can be called from anywhere server-side JavaScript is accepted. They must be explicitly called to run and do not have automatic triggers. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Client-side scripts that execute on form load are Client Scripts (onLoad type), not Script Includes. Script Includes execute on the server side.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "UI Policies are a separate no-code mechanism for controlling form field visibility, mandatory status, and read-only state. They are not Script Includes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Scheduled Jobs are used to run automation at defined time intervals. Script Includes do not run on a schedule — they must be explicitly called from other scripts or processes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/time/concept/c_ScheduledJobs.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/10-ssnf-script-includes.md",
+        "excerpt": "it stores reusable JavaScript for execution on the server... Key word here being reusable, and therefore, it must be called to run."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes"
+        ],
+        "tags": [
+          "script-include",
+          "server-side",
+          "reusable-code"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-002",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Why is the 'current' object NOT available inside a Script Include?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Script Includes only execute on the client side where current is not defined"
+        },
+        {
+          "id": "b",
+          "text": "Script Includes are not associated with a specific table, so there is no current record context"
+        },
+        {
+          "id": "c",
+          "text": "The current object was deprecated and replaced by GlideRecord in the Yokohama release"
+        },
+        {
+          "id": "d",
+          "text": "Script Includes can only access records through the previous object"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The 'current' object is only available in scripts that are associated with a specific table (such as Business Rules). Since the Script Include form has no table field or condition builder, there is no record context, and therefore the current object does not exist within a Script Include. Developers must use GlideRecord to access specific records instead. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Script Includes execute on the server side, not the client side. The reason current is unavailable is the lack of a table association, not the execution context.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The current object has not been deprecated. It remains fully functional in scripts that are associated with a table, such as Business Rules, and is available across all ServiceNow releases.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/general-scripting/concept/c_UsingGlideRecordToQueryTables.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The previous object is also unavailable in Script Includes for the same reason — there is no table association. The previous object is available in Business Rules alongside current.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/10-ssnf-script-includes.md",
+        "excerpt": "there's no access to objects like current or previous... you only really get access to that current object generally is only available to us for scripts where we have a field that says table. If we don't get to pick a table, current basically doesn't exist."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes",
+          "Script Include best practices"
+        ],
+        "tags": [
+          "script-include",
+          "current-object",
+          "server-side",
+          "gliderecord"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-003",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What must a developer do differently when creating a classless (on-demand function) Script Include compared to a class-based Script Include?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Enable the Client callable / GlideAjax checkbox so the function can be invoked"
+        },
+        {
+          "id": "b",
+          "text": "Delete the default class template code that ServiceNow places in the Script field and define a standalone function instead"
+        },
+        {
+          "id": "c",
+          "text": "Select a target table on the Script Include form so the function knows which records to process"
+        },
+        {
+          "id": "d",
+          "text": "Extend the AbstractAjaxProcessor class to make the function available server-side"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When creating a new Script Include, ServiceNow automatically populates the Script field with a class template (prototype pattern). For a classless on-demand function, the developer must manually clear out this template code and define a standalone function using the standard 'function functionName() { }' syntax. The function name must exactly match the Script Include Name field. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Classless Script Includes cannot be made client callable. The Client callable / GlideAjax checkbox is used only with Script Includes that extend the AbstractAjaxProcessor class.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Script Includes do not have a table field on their form. They are not tied to any specific table, which is why the current object is not available within them.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Extending the AbstractAjaxProcessor class is done when creating client-callable Script Includes for use with GlideAjax, not for creating simple server-side on-demand functions.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/ajax/concept/c_GlideAjax.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/10-ssnf-script-includes.md",
+        "excerpt": "when we start to work on a Script Include, ServiceNow assumes we're going to write a custom class. So ServiceNow tries to do us a solid... In this case, we're not writing a whole new class. We're just writing a single function. So what we do is we say, thank you, ServiceNow, and we just go ahead and go, but no thank you. And we clear out the script field."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes",
+          "Script Include best practices"
+        ],
+        "tags": [
+          "script-include",
+          "classless",
+          "on-demand-function",
+          "template"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-004",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are true about Script Includes in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "They must be explicitly called to execute and do not run based on table events"
+        },
+        {
+          "id": "b",
+          "text": "The Script Include record name must exactly match the function or class name defined in the Script field"
+        },
+        {
+          "id": "c",
+          "text": "They automatically have access to the current and previous objects"
+        },
+        {
+          "id": "d",
+          "text": "They can only be called from Business Rules"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "Script Includes must be explicitly called to run — they have no automatic triggers tied to table events. Additionally, the Name field of the Script Include record must exactly match the function name (for classless) or the class variable name (for class-based) defined in the Script field. This naming match is critical for the Script Include to work properly. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "Script Includes do NOT have access to the current or previous objects because they are not associated with a specific table. To access record data, developers must use GlideRecord queries or pass data as parameters.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Script Includes can be called from anywhere server-side JavaScript is accepted, not just Business Rules. This includes reference qualifiers, workflow scripts, scheduled jobs, email notifications, and more.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/10-ssnf-script-includes.md",
+        "excerpt": "these things only run when we ask them to. We write them once and reuse them as many times as we like... the name of our Script Include record exactly matches the name of our function or our class that we create down in the script include."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes",
+          "Script Include best practices"
+        ],
+        "tags": [
+          "script-include",
+          "naming",
+          "server-side",
+          "reusable-code"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-005",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the strongly observed naming convention for class-based Script Includes that contain a library of reusable methods?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Prefix the name with 'SI_' followed by the application name"
+        },
+        {
+          "id": "b",
+          "text": "Include the word 'Utils' in the Script Include name"
+        },
+        {
+          "id": "c",
+          "text": "End the name with 'Handler' to indicate server-side processing"
+        },
+        {
+          "id": "d",
+          "text": "Start the name with 'Ajax' to indicate it supports asynchronous calls"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "There is a strongly observed convention in ServiceNow to include the word 'Utils' in the name of class-based Script Includes that serve as function libraries (e.g., ClaimsUtils, LoanerUtils). These Script Includes follow JavaScript class conventions with PascalCase naming and camelCase for subsequent words. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "There is no standard convention in ServiceNow to prefix Script Include names with 'SI_'. The convention is to use descriptive PascalCase names, typically with 'Utils' for utility class libraries.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "'Handler' is not a standard Script Include naming convention in ServiceNow. While some custom Script Includes may use it, the widely observed convention for utility class libraries is to use 'Utils'.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Starting with 'Ajax' is not the standard naming convention. While Script Includes that extend AbstractAjaxProcessor for client-callable functionality may include 'Ajax' in their name, the convention for general utility class libraries is to use 'Utils'.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/ajax/concept/c_GlideAjax.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/10-adf-script-include.md",
+        "excerpt": "There's a strongly observed convention to call these kinds of function libraries Utils Script includes. Like, you can see this one is called ClaimsUtils."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include best practices",
+          "Script Include structure and extending classes"
+        ],
+        "tags": [
+          "script-include",
+          "naming-convention",
+          "utils",
+          "best-practices"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-006",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following correctly describe the initialize function in a class-based Script Include? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "It must be manually invoked each time before calling any method on the Script Include"
+        },
+        {
+          "id": "b",
+          "text": "It runs automatically when a new object of the Script Include class is created"
+        },
+        {
+          "id": "c",
+          "text": "Properties defined using the 'this' keyword in initialize are accessible to all methods in the class"
+        },
+        {
+          "id": "d",
+          "text": "It is required only when creating client-callable Script Includes that extend AbstractAjaxProcessor"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The initialize function in a class-based Script Include runs automatically when a new instance of the class is created (e.g., var obj = new MyUtils()). Properties defined using 'this.propertyName' within initialize are available throughout the entire Script Include class, accessible to all methods. This is commonly used to set up shared GlideRecord queries or property values needed across multiple methods. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The initialize function does NOT need to be manually invoked. It runs automatically when a new object of the class is instantiated, similar to a constructor in object-oriented programming.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The initialize function is part of the standard class prototype pattern used in all class-based Script Includes, not just those extending AbstractAjaxProcessor. Any Script Include using the Class.create() pattern includes an initialize function.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/10-adf-script-include.md",
+        "excerpt": "the initialize function runs automatically when the JavaScript object is created... Stuff that we define this way, in the initialize, will be available throughout the entire Script include, throughout the rest of the class."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes"
+        ],
+        "tags": [
+          "script-include",
+          "initialize",
+          "class-based",
+          "prototype"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-007",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to retrieve server-side data from a Script Include and display it on a form without reloading the page. Which approach should the developer take?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create a classless Script Include and call it directly from a Client Script using the Script Include name"
+        },
+        {
+          "id": "b",
+          "text": "Create a Script Include that extends AbstractAjaxProcessor, enable the Client callable checkbox, and invoke it from a Client Script using GlideAjax"
+        },
+        {
+          "id": "c",
+          "text": "Create a UI Script marked as global and call the server-side function from the form's Client Script"
+        },
+        {
+          "id": "d",
+          "text": "Create a synchronous Business Rule on the target table that populates a scratchpad variable for the client to read"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "To retrieve server-side data asynchronously from a client-side script, the developer should create a Script Include that extends AbstractAjaxProcessor and check the Client callable (GlideAjax enabled) checkbox. The client-side code then uses the GlideAjax API to call methods on this Script Include without reloading the page. This is the standard pattern for client-to-server communication in ServiceNow. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/ajax/concept/c_GlideAjax.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Classless Script Includes cannot be made client callable. They can only be invoked from server-side scripts. To call a Script Include from the client side, it must extend AbstractAjaxProcessor and have the Client callable checkbox enabled.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "UI Scripts run on the client side and cannot directly execute server-side logic. They are used to include reusable client-side JavaScript libraries, not to call server-side functions.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/client-scripts/concept/c_UIScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "While the g_scratchpad technique works to pass data from a display Business Rule to the client, it only executes when the form loads — it does not support dynamic, on-demand data retrieval without a page reload. GlideAjax with AbstractAjaxProcessor is the correct approach for asynchronous requests.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/business-rules/concept/c_DisplayBusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/ajax/concept/c_GlideAjax.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/10-ssnf-script-includes.md",
+        "excerpt": "we're going to see how we can extend an existing JavaScript class in ServiceNow called the AbstractAjaxProcessor class... indicate whether it is client callable. Now, the label of that client callable field on this Script Include screenshot for this form says Glide AJAX enabled."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Client-callable Script Includes",
+          "Using Script Includes with GlideAjax",
+          "AbstractAjaxProcessor"
+        ],
+        "tags": [
+          "script-include",
+          "glideajax",
+          "abstractajaxprocessor",
+          "client-callable"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:28:03.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-008",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "When creating a new Script Include in ServiceNow, what happens to the variable name in the generated template script when the Name field is populated?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The variable name is set to a system-generated unique identifier"
+        },
+        {
+          "id": "b",
+          "text": "The variable name is automatically set to match the value in the Name field"
+        },
+        {
+          "id": "c",
+          "text": "The variable name defaults to 'ScriptInclude' and must be manually changed"
+        },
+        {
+          "id": "d",
+          "text": "The variable name is set to the Name field value converted to camelCase"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When a Script Include name is entered and the user tabs out of the Name field, ServiceNow automatically generates a template script where the variable name exactly matches the Name field value. This ensures the class name and the Script Include record name stay in sync. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "ServiceNow does not generate a unique identifier for the variable name. It uses the exact Name field value to keep the Script Include identifiable and callable by that name.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The template does not default to a generic name like 'ScriptInclude'. The platform automatically populates the variable name from the Name field to reduce errors.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "ServiceNow does not convert the Name field to camelCase. The variable name is an exact match of whatever was entered in the Name field.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Script Includes"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-script-include-demo.md",
+        "excerpt": "Remember that this variable name here needs to exactly match the name in the Name field, so don't go messing with it. ServiceNow is doing you a favor by bringing that down."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes"
+        ],
+        "tags": [
+          "script-include",
+          "naming",
+          "template"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-009",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In a Script Include class, which function runs automatically when an object of the class is instantiated?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The constructor function defined in the prototype"
+        },
+        {
+          "id": "b",
+          "text": "The first function listed in the type definition"
+        },
+        {
+          "id": "c",
+          "text": "The initialize function"
+        },
+        {
+          "id": "d",
+          "text": "The onLoad function"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The initialize function in a Script Include class runs automatically when an object of that class is created. It is commonly used to store properties using the 'this' keyword and to fetch records that will be needed throughout the class methods. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "While 'constructor' is a concept in standard JavaScript ES6 classes, ServiceNow Script Includes use the 'initialize' function pattern within the prototype object, not a constructor function.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "The order of functions in the type definition does not determine which runs first. Only the 'initialize' function is automatically invoked upon instantiation.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "onLoad is not a Script Include lifecycle function. It is associated with client scripts that run when a form loads, not with server-side Script Include instantiation.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Script Includes"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-script-include-demo.md",
+        "excerpt": "Remember, the initialize runs automatically when object is created. So when we create an object of this class, in order to access these things that the class provides to us, this initialize runs right away."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes"
+        ],
+        "tags": [
+          "script-include",
+          "initialize",
+          "instantiation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-010",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Why is the 'this' keyword used inside the initialize function of a Script Include to store variable values?",
+      "options": [
+        {
+          "id": "a",
+          "text": "To make the values available to client-side scripts via GlideAjax"
+        },
+        {
+          "id": "b",
+          "text": "To make the values accessible across all methods within the Script Include class"
+        },
+        {
+          "id": "c",
+          "text": "To persist the values in the database for future Script Include executions"
+        },
+        {
+          "id": "d",
+          "text": "To override system properties with custom values during runtime"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Using 'this.' in the initialize function stores values as instance properties of the class object. This makes them accessible throughout all methods defined in the Script Include, avoiding the need to re-fetch or re-declare values in each function. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'this' keyword stores values for server-side use within the class instance. Making values available to client-side scripts requires extending AbstractAjaxProcessor and using specific methods like getAnswer().",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The 'this' keyword stores values in memory on the class instance for the duration of that execution. It does not write anything to the database. Database persistence requires explicit GlideRecord operations.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The 'this' keyword does not override system properties. System properties are managed through the sys_properties table and are accessed via gs.getProperty(), not through Script Include instance variables.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Script Includes"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-script-include-demo.md",
+        "excerpt": "So there's a better way, and that's the initialize. Remember, the initialize runs automatically when object is created... what people tend to do is store things with a keyword called 'this.' ... And, that way, we can use them all throughout."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include structure and extending classes",
+          "Script Include best practices"
+        ],
+        "tags": [
+          "script-include",
+          "this-keyword",
+          "initialize",
+          "instance-properties"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-011",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "A developer needs to call a Script Include from a different application scope. Select all that apply. Which requirements must be met for this cross-scope call to succeed?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The Script Include must have the 'Accessible from' field set to allow access from other scopes"
+        },
+        {
+          "id": "b",
+          "text": "The calling script must reference the Script Include using its full API name including the namespace"
+        },
+        {
+          "id": "c",
+          "text": "The Script Include must extend AbstractAjaxProcessor to support cross-scope calls"
+        },
+        {
+          "id": "d",
+          "text": "The calling script must import the Script Include using gs.include()"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "Two conditions must be met for cross-scope Script Include calls: (1) The Script Include's 'Accessible from' setting must allow access beyond its own application scope, and (2) the calling script must use the full API name (namespace prefix) to reference the Script Include. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "AbstractAjaxProcessor is used to make Script Includes callable from client-side scripts via GlideAjax. It is not a requirement for server-side cross-scope access between application scopes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "gs.include() is used for legacy global Script Includes that are not class-based. Scoped Script Includes do not use gs.include(); they are accessed by instantiating the class using the full API name.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Application Scope",
+        "ServiceNow Docs - Script Includes"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-script-include-demo.md",
+        "excerpt": "So what happens if I want to call it from out of scope? Well, if I decide that that's OK, then we need to use the full API name... But this only works if we've given it permission, right? The minute I switch this back to this application scope only, calling from out of scope is no good, won't work."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Scoped vs global Script Includes"
+        ],
+        "tags": [
+          "script-include",
+          "cross-scope",
+          "api-name",
+          "accessible-from"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-012",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer is building a Script Include called 'IncidentUtils' that contains multiple methods. Several of these methods need to reference the currently logged-in user's GlideRecord and a specific system property value. Where should the developer fetch and store these values to follow Script Include best practices?",
+      "options": [
+        {
+          "id": "a",
+          "text": "In a separate helper Script Include that is called by each method"
+        },
+        {
+          "id": "b",
+          "text": "At the beginning of each method that needs the values"
+        },
+        {
+          "id": "c",
+          "text": "In the initialize function using the 'this' keyword"
+        },
+        {
+          "id": "d",
+          "text": "In a global business rule that runs before the Script Include is called"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Best practice is to fetch commonly needed values in the initialize function and store them using 'this.' so they are available across all methods in the Script Include. The initialize function runs automatically when the class is instantiated, making it the ideal place for setup logic such as fetching the current user record or system properties. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Creating a separate Script Include adds unnecessary complexity. The initialize function within the same Script Include is designed for this exact purpose — centralizing shared setup logic.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Fetching the same values at the beginning of each method leads to redundant code and multiple unnecessary queries. The initialize function centralizes this logic and executes once upon instantiation.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "A global business rule runs in response to database operations, not as a setup mechanism for Script Includes. Script Include initialization logic belongs in the initialize function, not in external business rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Script Includes"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/11-adf-script-include-demo.md",
+        "excerpt": "So you'll see things like this done quite a bit in the initialize, things that you know you're going to want and things that are likely to be needed throughout more than one of the methods. Especially if both of those descriptions apply, then it's a good idea to just fetch it up here and store it to this."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Script Includes",
+        "domainSlug": "script-includes",
+        "domainPercentage": 12,
+        "subtopics": [
+          "Script Include best practices",
+          "Script Include structure and extending classes"
+        ],
+        "tags": [
+          "script-include",
+          "initialize",
+          "best-practices",
+          "this-keyword",
+          "gliderecord"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:24:19.143Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/questions/cad/scripting-apis.json
+++ b/data/questions/cad/scripting-apis.json
@@ -1,0 +1,1893 @@
+{
+  "questions": [
+    {
+      "id": "cad-scripting-apis-001",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Where do client-side scripts execute in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "On the ServiceNow application server"
+        },
+        {
+          "id": "b",
+          "text": "In the user's web browser"
+        },
+        {
+          "id": "c",
+          "text": "On the MID Server"
+        },
+        {
+          "id": "d",
+          "text": "In the ServiceNow database layer"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Client-side scripts execute in the user's web browser. They generally handle UI modifications such as hiding fields, making fields mandatory, or responding to user interactions on the form. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Server-side scripts, not client-side scripts, execute on the ServiceNow application server. Examples include business rules and script includes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The MID Server is a separate component that executes scripts in a local network environment for tasks like Discovery and integrations, not standard client-side scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/product/mid-server/concept/mid-server-landing.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The database layer stores data but does not execute JavaScript. Script execution occurs either in the browser (client-side) or the application server (server-side).",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/04-ssnf-scripting-overview.md",
+        "excerpt": "When I have client-side scripts, which generally revolve around doing something with the UI itself... that is a client-side script that executes in your browser."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "client-side",
+          "script-execution",
+          "browser"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-002",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which prefix is used to access GlideSystem methods in server-side scripts?",
+      "options": [
+        {
+          "id": "a",
+          "text": "g_system"
+        },
+        {
+          "id": "b",
+          "text": "glide"
+        },
+        {
+          "id": "c",
+          "text": "gs"
+        },
+        {
+          "id": "d",
+          "text": "g_form"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "GlideSystem methods are accessed using the 'gs' prefix in server-side scripts (e.g., gs.addInfoMessage(), gs.hasRole()). This is the standard shorthand for the GlideSystem class in ServiceNow. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "g_system is not a valid ServiceNow API prefix. The correct prefix for GlideSystem is 'gs'.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "While 'Glide' appears in many ServiceNow class names, the GlideSystem API is specifically accessed via the 'gs' shorthand, not 'glide'.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "g_form is the client-side GlideForm API used to interact with forms in the browser. It is not related to the server-side GlideSystem API.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripting/concept/c_GlideFormAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/08-ssnf-glidesystem.md",
+        "excerpt": "gs is how we access the GlideSystem methods. Do you see that just about all the JavaScript you see on this slide starts with gs?"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideSystem methods and utilities"
+        ],
+        "tags": [
+          "GlideSystem",
+          "gs",
+          "server-side",
+          "API"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-003",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which GlideSystem method returns the first and last name of the currently logged-in user concatenated together?",
+      "options": [
+        {
+          "id": "a",
+          "text": "gs.getUserName()"
+        },
+        {
+          "id": "b",
+          "text": "gs.getUserID()"
+        },
+        {
+          "id": "c",
+          "text": "gs.getUserDisplayName()"
+        },
+        {
+          "id": "d",
+          "text": "gs.getUser()"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "gs.getUserDisplayName() returns the currently logged-in user's first and last name concatenated together, providing a human-friendly display of the user's identity without requiring separate calls for first and last name. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "gs.getUserName() returns the login name (username) used to authenticate, not the concatenated first and last name.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "gs.getUserID() returns the Sys ID (a 32-character unique identifier) of the currently logged-in user record, not their display name.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "gs.getUser() returns the user object, which can then be used with additional utility methods to retrieve specific user properties. By itself, it does not return the display name string.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/08-ssnf-glidesystem.md",
+        "excerpt": "getUserDisplayName, well, I bet you know what that is. That's the human friendly way of looking at the currently logged in user, both by their first and last name put together."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideSystem methods and utilities"
+        ],
+        "tags": [
+          "GlideSystem",
+          "getUserDisplayName",
+          "user-methods"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-004",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer needs to implement a new requirement on the ServiceNow platform. According to ServiceNow customization best practices, what approach should they evaluate first?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Write a comprehensive server-side script to handle all logic"
+        },
+        {
+          "id": "b",
+          "text": "Determine whether a no-code or low-code solution can meet the requirement"
+        },
+        {
+          "id": "c",
+          "text": "Create a custom scoped application with script includes"
+        },
+        {
+          "id": "d",
+          "text": "Modify the baseline business rule to add the required functionality"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "ServiceNow customization best practices recommend first determining whether a no-code solution (configuration via the UI) can be used. If not, evaluate a low-code solution (minimal scripting). Only if neither approach works should developers resort to more complex scripting, as custom scripts can complicate upgrades between family releases. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Writing a comprehensive script should be a last resort, not the first approach. Scripts can complicate upgrades and may need rework when ServiceNow releases family updates.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Creating a scoped application with custom scripts is a valid approach for complex requirements, but it should only be considered after evaluating no-code and low-code alternatives first.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Modifying baseline records directly is generally discouraged as it creates upgrade conflicts. ServiceNow recommends evaluating no-code and low-code solutions before modifying any baseline configurations.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/04-ssnf-scripting-overview.md",
+        "excerpt": "Determine whether a no-code solution can be used... If the no-code solution will work, implement that no-code approach. If not, is there a low-code solution, meaning minimal scripting involved? If it is, use that approach."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "best-practices",
+          "customization",
+          "no-code",
+          "upgrade"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-005",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Why does ServiceNow provide the gs.nil() method when standard JavaScript already has a nil function?",
+      "options": [
+        {
+          "id": "a",
+          "text": "gs.nil() is faster and more performant than standard JavaScript nil"
+        },
+        {
+          "id": "b",
+          "text": "gs.nil() handles ServiceNow data types differently than standard JavaScript nil"
+        },
+        {
+          "id": "c",
+          "text": "Standard JavaScript nil does not work at all in ServiceNow server-side scripts"
+        },
+        {
+          "id": "d",
+          "text": "gs.nil() can only be used within business rules, unlike standard JavaScript nil"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "ServiceNow's gs.nil() method handles data types slightly differently than plain JavaScript's nil function. Due to ServiceNow's special dialect of JavaScript and the way GlideElement objects store field values, gs.nil() provides more reliable empty/null checking for ServiceNow record fields. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The difference between gs.nil() and standard nil is not about performance. It is about how each handles the unique data types used in ServiceNow's JavaScript dialect.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Standard JavaScript nil can work in ServiceNow, but gs.nil() is recommended because it handles ServiceNow-specific data types and GlideElement objects more reliably.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "gs.nil() is a general server-side method that can be used anywhere server-side JavaScript is accepted in ServiceNow, not just in business rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/08-ssnf-glidesystem.md",
+        "excerpt": "what I've come to learn about gs.nil, so ServiceNow's baked-in, special, dialectical version of the nil method, is that it handles data types just a little bit differently than plain old vanilla JavaScript does."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideSystem methods and utilities"
+        ],
+        "tags": [
+          "GlideSystem",
+          "gs.nil",
+          "data-types",
+          "server-side"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-006",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following are valid scenarios for using scripting in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Adding new functionality that cannot be achieved through configuration"
+        },
+        {
+          "id": "b",
+          "text": "Replacing an existing access control rule with a simpler script-based implementation"
+        },
+        {
+          "id": "c",
+          "text": "Automating a manual process within the platform"
+        },
+        {
+          "id": "d",
+          "text": "Interacting with third-party applications to exchange data"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c",
+        "d"
+      ],
+      "explanation": {
+        "correct": "Scripting is appropriate when adding new functionality to ServiceNow that cannot be achieved through configuration, automating manual processes to remove the human element, and interacting with third-party applications for data exchange. These are scenarios where configuration alone may not be sufficient.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "If an access control rule already performs the required function, replacing it with a script is unnecessary and goes against best practices. ServiceNow recommends using existing platform features like ACLs over custom scripts when possible.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/general-scripting/concept/c_ScriptingOverview.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/04-ssnf-scripting-overview.md",
+        "excerpt": "When we want to add new functionality to ServiceNow... We can automate that process with scripting. And then, if we want to interact with third-party applications... we can generally do that with scripting."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "scripting-scenarios",
+          "best-practices",
+          "automation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-007",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer writes a business rule on the Incident table that needs to set the incident's location to the caller's location when the location field is empty. Which server-side script correctly accomplishes this?",
+      "options": [
+        {
+          "id": "a",
+          "text": "if (gs.nil(current.location)) { current.location.setValue(current.caller_id.location); }"
+        },
+        {
+          "id": "b",
+          "text": "if (g_form.getValue('location') == '') { g_form.setValue('location', current.caller_id.location); }"
+        },
+        {
+          "id": "c",
+          "text": "if (current.location == null) { current.location = gs.getUser().getLocation(); }"
+        },
+        {
+          "id": "d",
+          "text": "if (gs.nil(current.location)) { current.location = current.caller_id.getDisplayValue(); }"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "This script uses gs.nil() to check if the location field is empty, then uses dot walking (current.caller_id.location) to traverse the reference field to the caller's user record and access their location, and setValue() to set the field value server-side. This is the exact pattern demonstrated in the GlideSystem course content. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "g_form is a client-side API (GlideForm) and cannot be used in business rules, which are server-side scripts. Business rules use the 'current' object to access and manipulate record fields.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripting/concept/c_GlideFormAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "gs.getUser().getLocation() retrieves the currently logged-in user's location, not the caller's location. The caller and the logged-in user may be different people. Additionally, comparing with == null is less reliable than gs.nil() for ServiceNow GlideElement fields.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "getDisplayValue() on caller_id returns the caller's display name (a string), not their location value. This would incorrectly set the location field to a person's name rather than an actual location.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordScopedAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/08-ssnf-glidesystem.md",
+        "excerpt": "If there's no value in the current records location field, then let's set the value of that current location field to the current records caller's location... current.caller_id.location is an example of something called dot walking."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideSystem methods and utilities",
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "GlideSystem",
+          "gs.nil",
+          "dot-walking",
+          "business-rule",
+          "setValue"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-008",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A developer is writing a business rule that needs to display an informational message showing the logged-in user's full name and verify whether they have the 'itil' role. Which GlideSystem methods should the developer use? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "gs.getUserDisplayName()"
+        },
+        {
+          "id": "b",
+          "text": "gs.hasRole('itil')"
+        },
+        {
+          "id": "c",
+          "text": "g_user.hasRole('itil')"
+        },
+        {
+          "id": "d",
+          "text": "gs.getUserName()"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "gs.getUserDisplayName() returns the user's first and last name concatenated (full name), and gs.hasRole('itil') checks if the currently logged-in user has the itil role. Both are server-side GlideSystem methods appropriate for use in business rules.",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "g_user is the client-side GlideUser API that cannot be used in business rules. Business rules are server-side scripts and must use GlideSystem (gs) methods for user information and role checks.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripting/concept/c_GlideUserAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "gs.getUserName() returns the login username (e.g., 'admin'), not the user's full display name. The requirement specifies showing the user's full name, which requires gs.getUserDisplayName().",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/app-store/dev_portal/API_reference/glideSystem/concept/c_GlideSystemScopedAPI.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/08-ssnf-glidesystem.md",
+        "excerpt": "gs.hasRole in our if statement there... getUserDisplayName, well, I bet you know what that is. That's the human friendly way of looking at the currently logged in user, both by their first and last name put together."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideSystem methods and utilities"
+        ],
+        "tags": [
+          "GlideSystem",
+          "hasRole",
+          "getUserDisplayName",
+          "business-rule",
+          "server-side"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:26:37.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-009",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the correct order of steps when building a GlideRecord query in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create the GlideRecord object, execute the query, add query conditions, process the returned records"
+        },
+        {
+          "id": "b",
+          "text": "Add query conditions, create the GlideRecord object, execute the query, process the returned records"
+        },
+        {
+          "id": "c",
+          "text": "Create the GlideRecord object, add query conditions, execute the query, process the returned records"
+        },
+        {
+          "id": "d",
+          "text": "Execute the query, create the GlideRecord object, add query conditions, process the returned records"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The four steps to creating a GlideRecord query are: (1) create the GlideRecord object by instantiating it with the table name, (2) add query conditions using methods like addQuery, (3) execute the query using the query() method, and (4) process the returned records using next() or hasNext(). See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "You must add query conditions before executing the query, not after. Executing the query sends the request to the database, so all conditions must be defined first.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "You cannot add query conditions before creating the GlideRecord object. The object must be instantiated first to provide the context for the query.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Executing the query before creating the object or adding conditions is not possible. The GlideRecord object must exist and conditions must be set before the query is executed.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecord API"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "There are four steps to creating the GlideRecord query. First, you want to create your GlideRecord object. Then add your query conditions, followed by executing your query. And then when your records get returned from the database, now you want to process through those records."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations"
+        ],
+        "tags": [
+          "gliderecord",
+          "query-building",
+          "server-side-scripting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-010",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "When using the GlideRecord addQuery method, what does the system assume if no operator is specified between the field name and the value?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The query throws a syntax error"
+        },
+        {
+          "id": "b",
+          "text": "The system assumes a CONTAINS operator"
+        },
+        {
+          "id": "c",
+          "text": "The system assumes an equality (=) operator"
+        },
+        {
+          "id": "d",
+          "text": "The system assumes a LIKE operator"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "When the operator is omitted from the addQuery method, the system automatically assumes equality. For example, addQuery('category', 'Hardware') is equivalent to addQuery('category', '=', 'Hardware'). See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Omitting the operator does not cause a syntax error. The addQuery method accepts two parameters (field, value) where equality is the default, or three parameters (field, operator, value) for other comparison types.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "CONTAINS is not the default operator. It must be explicitly specified in the addQuery method using the string 'CONTAINS' in capital letters as the operator parameter.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "LIKE is not the default operator when omitting the operator parameter. LIKE must be explicitly specified when needed for pattern matching queries.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecord addQuery"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "Now, if you don't include an operator, so if you got rid of the equal sign here, the system assumes that you are wanting to test for equality."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations"
+        ],
+        "tags": [
+          "gliderecord",
+          "addquery",
+          "query-operators"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-011",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "A developer writes a GlideRecord script using while(gr.hasNext()) to iterate through query results. What is the expected outcome?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Only the first record in the result set is processed"
+        },
+        {
+          "id": "b",
+          "text": "The script processes all records but skips every other record"
+        },
+        {
+          "id": "c",
+          "text": "The script enters an infinite loop"
+        },
+        {
+          "id": "d",
+          "text": "The script processes all returned records normally"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Using while with hasNext() causes an infinite loop because hasNext() checks if a next record exists but does not advance the pointer to it. The pointer never moves forward, so hasNext() always returns true. The correct approach is while(gr.next()), which both checks for and advances to the next record. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Processing only the first record would occur with an if(gr.next()) statement. Using while(gr.hasNext()) does not process a single record and return — it creates an infinite loop because hasNext() never advances the record pointer.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Records are not skipped. The hasNext() method does not load or advance through records at all, which is why using it in a while loop creates an infinite loop rather than a skip pattern.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The script does not process records normally. Since hasNext() returns true without advancing the pointer, the while condition is always true, resulting in an infinite loop rather than normal iteration.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecord API"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "If you use a while statement with a hasNext method, you're going to get into an infinite loop. So you would only use the while with the next and never with the hasNext, or else you're going to get into a loop."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations",
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "gliderecord",
+          "next",
+          "hasnext",
+          "infinite-loop",
+          "debugging"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-012",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following approaches can be used to determine the number of records returned by a GlideRecord query? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Use the getRowCount() method on the GlideRecord object"
+        },
+        {
+          "id": "b",
+          "text": "Use a GlideAggregate query with a COUNT aggregate"
+        },
+        {
+          "id": "c",
+          "text": "Use the getRecordCount() method on the GlideRecord object"
+        },
+        {
+          "id": "d",
+          "text": "Use the length property on the GlideRecord object"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "ServiceNow provides two approaches to count returned records: getRowCount() on the GlideRecord object, and GlideAggregate with a COUNT aggregate type. While getRowCount() requires less code, it has significant performance impact on large tables because it retrieves rows one by one. GlideAggregate is recommended for tables with more than 100 records or tables that grow continuously. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "getRecordCount() is not a valid GlideRecord method. The correct method name is getRowCount(). Using incorrect method names will result in a script error.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideRecord does not have a length property. GlideRecord is not a JavaScript array and does not expose array-like properties. The getRowCount() method or GlideAggregate must be used instead.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecord API",
+        "ServiceNow Docs - GlideAggregate API"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "There are two different ways you can confirm if records were returned. You can use the getRowCount method or you can use the GlideAggregate objects and methods to see if your query returned records."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations",
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "gliderecord",
+          "getrowcount",
+          "glideaggregate",
+          "record-counting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-013",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to build a GlideRecord query with complex conditions involving date comparisons and reference field lookups. The developer wants the fastest method to construct this query. What is the recommended approach?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Use multiple addQuery() and addOrCondition() methods chained together in the script"
+        },
+        {
+          "id": "b",
+          "text": "Use the addEncodedQuery() method with a query string copied from the list view Condition Builder"
+        },
+        {
+          "id": "c",
+          "text": "Use the get() method with the sys_id of each matching record"
+        },
+        {
+          "id": "d",
+          "text": "Use GlideAggregate with groupBy to filter the complex conditions"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The addEncodedQuery() method is the best option for complex queries, especially those involving dates and reference fields. Developers can build the query visually using the list view Condition Builder, right-click the breadcrumb to select 'Copy Query', and paste the encoded string into addEncodedQuery(). This passes all WHERE clauses as a single argument. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "While chaining addQuery() and addOrCondition() methods works for building complex queries, it is more time-consuming and error-prone for complex date and reference field conditions compared to using addEncodedQuery() with a Condition Builder-generated string.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The get() method retrieves a single specific record by sys_id or display value. It is not designed for querying multiple records based on complex conditions involving dates and reference fields.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideAggregate is designed for aggregate operations like COUNT, SUM, and AVG — not for filtering records with complex query conditions. It does not replace the need for addEncodedQuery() in this scenario.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideAggregate/concept/c_GlideAggregateAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecord addEncodedQuery"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "For complex queries, you can use what is called an addEncodedQuery method... it is the best option if you are absolutely in a hurry. This is a nice example of when an addEncodedQuery can be used, especially when you are working with dates and when you are working with those items from reference fields."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations",
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "gliderecord",
+          "addencodedquery",
+          "condition-builder",
+          "complex-queries"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-014",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the primary difference between GlideRecordSecure and GlideRecord in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "GlideRecordSecure supports client-side execution while GlideRecord is server-side only"
+        },
+        {
+          "id": "b",
+          "text": "GlideRecordSecure performs the same functions as GlideRecord but also enforces access control rules"
+        },
+        {
+          "id": "c",
+          "text": "GlideRecordSecure provides encrypted database connections while GlideRecord does not"
+        },
+        {
+          "id": "d",
+          "text": "GlideRecordSecure is used exclusively in scoped applications while GlideRecord is for global scope"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "GlideRecordSecure is inherited from GlideRecord and performs the same functions, but additionally enforces access control rules. Non-writable fields are set to null when writing, and if an element cannot be read due to ACL restrictions, a null value is created in memory for that record. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecordSecure/concept/c_GlideRecordSecureAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "GlideRecordSecure does not add client-side execution capabilities. Both GlideRecord and GlideRecordSecure are server-side APIs. While GlideRecord can be called from the client side, it is not recommended due to performance impacts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecordSecure/concept/c_GlideRecordSecureAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "GlideRecordSecure does not relate to encrypted database connections. It enforces access control list (ACL) rules on field-level read and write operations, not encryption of the underlying database communication.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecordSecure/concept/c_GlideRecordSecureAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideRecordSecure is not limited to scoped applications. It can be used in both global and scoped contexts. Its purpose is to enforce ACL rules regardless of application scope.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecordSecure/concept/c_GlideRecordSecureAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecordSecure API"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "GlideRecordSecure is inherited from GlideRecord. And it performs the same functions as GlideRecord, but it also enforces access controls."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations",
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "gliderecordsecure",
+          "gliderecord",
+          "access-controls",
+          "security"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-015",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "How does a subflow differ from a flow in ServiceNow Flow Designer?",
+      "options": [
+        {
+          "id": "a",
+          "text": "A subflow requires a trigger and at least two actions, while a flow requires only one action"
+        },
+        {
+          "id": "b",
+          "text": "A subflow is a sequence of reusable actions that can be started from a flow, another subflow, or a script, and does not require a trigger"
+        },
+        {
+          "id": "c",
+          "text": "A subflow can only be used within playbooks, while a flow can be used anywhere in the platform"
+        },
+        {
+          "id": "d",
+          "text": "A subflow is a read-only template provided by ServiceNow that cannot be customized"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "A subflow is a sequence of reusable actions that can be started from a flow, a subflow, or a script. Unlike flows, subflows do not require a trigger — they are called by other automation components. Subflows can also be used to group together common actions and brought into a flow like a template. See https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "This is incorrect. A flow requires a trigger and at least one action. A subflow does not require a trigger at all — it is invoked by other flows, subflows, or scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Subflows are not limited to playbooks. They are reusable sequences of actions that can be called from flows, other subflows, or scripts across the platform.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Subflows are not read-only templates. Developers can create custom subflows, copy existing ones, and modify them. ServiceNow delivers subflows that can also be copied and customized.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Flow Designer"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/11-ssnf-flow-designer-scripting.md",
+        "excerpt": "Subflow. A sequence of reusable actions that can be started from a flow, a subflow, or a script. So subflows don't have to have a trigger. You can actually call a subflow from a script."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Flow Designer scripting actions"
+        ],
+        "tags": [
+          "flow-designer",
+          "subflow",
+          "workflow-studio",
+          "automation"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-016",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A developer needs to count incident records matching specific criteria on a production table containing over 500,000 records. Which of the following statements about counting approaches are correct? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "getRowCount() retrieves rows one by one and increments a counter, which has a significant performance impact on large tables"
+        },
+        {
+          "id": "b",
+          "text": "GlideAggregate results in faster execution and should be used when the expected record count exceeds 100 or on continuously growing tables"
+        },
+        {
+          "id": "c",
+          "text": "getRowCount() is the recommended approach for production tables with large amounts of data"
+        },
+        {
+          "id": "d",
+          "text": "GlideAggregate requires less code to implement than getRowCount()"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "getRowCount() retrieves rows one by one and increments a counter, which causes significant performance issues on large tables. GlideAggregate results in faster execution and is the recommended method when the number of records returned is greater than 100 or for tables that grow continuously. For a production table with 500,000+ records, GlideAggregate is clearly the correct choice. See https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideAggregate/concept/c_GlideAggregateAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "getRowCount() is explicitly not recommended for tables with large amounts of data due to its significant performance impact. The GlideAggregate approach is recommended for large tables.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideAggregate actually requires more code than getRowCount(), not less. The source material states that getRowCount is less code to write, while GlideAggregate is more work for the developer but results in faster execution.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideAggregate/concept/c_GlideAggregateAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideRecord API",
+        "ServiceNow Docs - GlideAggregate API"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/09-ssnf-gliderecord.md",
+        "excerpt": "The getRowCount is a lot less code to write, but it does have a significantly larger performance impact and is not recommended for use with tables with large amounts of data. This strategy retrieves the rows one by one, and it increments a counter. Then there is the GlideAggregate, and it is more work for you as the developer, but it does result in faster execution. You will want to use this method when records returned is greater than 100 and for tables that grow continuously."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideRecord queries and operations",
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "gliderecord",
+          "glideaggregate",
+          "getrowcount",
+          "performance",
+          "best-practices"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:36.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-017",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the primary specialty of a UI policy in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Executing server-side GlideRecord queries when a form loads"
+        },
+        {
+          "id": "b",
+          "text": "Toggling field attributes such as mandatory, visible, and read-only"
+        },
+        {
+          "id": "c",
+          "text": "Sending notifications when a record is submitted"
+        },
+        {
+          "id": "d",
+          "text": "Validating records before they are saved to the database"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "UI policies specialize in toggling one or more of three field attributes: mandatory/optional, visible/hidden, and read-only/editable. They can do this without any JavaScript by using UI policy actions. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "GlideRecord queries are server-side operations. UI policies are client-side and cannot directly execute GlideRecord queries.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Sending notifications is handled by notification rules and events, not UI policies. UI policies focus on form field behavior.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Record validation before saving is typically handled by before business rules on the server side. UI policies operate client-side to control form field attributes.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-scripting-part-1-of-2.md",
+        "excerpt": "UI policies have this specialty-- toggling one or more of the following three attributes of one or more fields-- is that field mandatory or optional? Is that field visible or is it hidden? Is that field read-only or its opposite, editable?"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "ui-policy",
+          "field-attributes",
+          "client-side"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-018",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "When configuring an onChange client script, which additional trigger field must be specified that is not required by other client script types?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The table name"
+        },
+        {
+          "id": "b",
+          "text": "The field name to monitor"
+        },
+        {
+          "id": "c",
+          "text": "The view name"
+        },
+        {
+          "id": "d",
+          "text": "The application scope"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "An onChange client script requires specifying which field to monitor for changes. Without setting the field name, the script will never fire as expected. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The table name is required for all client script types, not just onChange. It defines which table's form the client script applies to.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The view name is not a required trigger field for onChange client scripts. The Global checkbox controls whether the script applies to all views or a specific one.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The application scope is determined by the application the script belongs to, not a separate trigger field specific to onChange client scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-scripting-part-2-of-2.md",
+        "excerpt": "when you choose an onChange client script, as you can see here, it sensibly asks you, OK, on which field change should this fire? This is another thing that's easy to forget to set in the trigger."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "client-script",
+          "onChange",
+          "trigger-configuration"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-019",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Why does a UI policy in advanced view provide two separate scripting fields — 'Execute if true' and 'Execute if false'?",
+      "options": [
+        {
+          "id": "a",
+          "text": "One field is for client-side script and the other is for server-side script"
+        },
+        {
+          "id": "b",
+          "text": "ServiceNow cannot determine the opposite of custom script logic, so developers must define both behaviors"
+        },
+        {
+          "id": "c",
+          "text": "One field runs during form load and the other runs on form submission"
+        },
+        {
+          "id": "d",
+          "text": "One field is for synchronous execution and the other is for asynchronous execution"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Unlike UI policy actions where ServiceNow can easily reverse a Boolean (e.g., mandatory back to optional), ServiceNow cannot read custom JavaScript and work out the opposite intent. Therefore, developers must write separate scripts for when the condition is true and when it is false. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Both scripting fields in a UI policy execute client-side. UI policies are a client-side mechanism and do not contain server-side script fields.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Both script fields are tied to the UI policy's condition evaluation, not to form lifecycle events. They fire based on whether the condition evaluates to true or false.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Both script fields execute synchronously in the client browser. The distinction between them is based on the condition's Boolean result, not execution timing.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-scripting-part-1-of-2.md",
+        "excerpt": "With scripting, ServiceNow can't read your script and work out your intent and know how to do the exact opposite of it... if we resort to scripting and we have something happen when the condition is true, that will go in the Execute if true script-- well, we're also on the hook for telling ServiceNow what to do when the condition is false."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "ui-policy",
+          "advanced-view",
+          "scripting",
+          "execute-if-true",
+          "execute-if-false"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-020",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following capabilities are exclusive to client scripts and NOT available in UI policies? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Executing script when a record is submitted"
+        },
+        {
+          "id": "b",
+          "text": "Using the filter condition builder to define conditions"
+        },
+        {
+          "id": "c",
+          "text": "Executing from a list view"
+        },
+        {
+          "id": "d",
+          "text": "Toggling field mandatory, visible, and read-only attributes without JavaScript"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Only client scripts can execute on record submission (onSubmit type) and from a list view (onCellEdit type). UI policies cannot fire on submission and do not operate on lists. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "The filter condition builder is actually a feature of UI policies, not client scripts. UI policies, unlike client scripts, give you access to the filter condition builder.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Toggling field attributes without JavaScript is a specialty of UI policies through UI policy actions. Client scripts always require JavaScript to function.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Client Scripts",
+        "ServiceNow Docs - UI Policies",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-scripting-part-2-of-2.md",
+        "excerpt": "only client scripts know how to execute on the submission of a record... And only client scripts can execute from a list. That should give you a little hint as to the fourth flavor of client script, which I've left out."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Server-side scripting patterns",
+          "Scripting best practices and debugging"
+        ],
+        "tags": [
+          "client-script",
+          "ui-policy",
+          "comparison",
+          "onSubmit",
+          "onCellEdit"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-021",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "When writing server-side scripts in ServiceNow, which API becomes available to replace the client-side GlideForm and GlideUser APIs?",
+      "options": [
+        {
+          "id": "a",
+          "text": "GlideRecord"
+        },
+        {
+          "id": "b",
+          "text": "GlideSystem"
+        },
+        {
+          "id": "c",
+          "text": "GlideAjax"
+        },
+        {
+          "id": "d",
+          "text": "GlideElement"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When switching to server-side scripting, the available APIs change. GlideForm (g_form) and GlideUser (g_user) are no longer available; instead, GlideSystem (gs) provides server-side utility methods. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/glide-server-apis/concept/c_GlideSystemAPI.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "GlideRecord is a server-side API for querying and manipulating database records, but it does not replace the utility functions of GlideForm and GlideUser. GlideSystem is the direct server-side counterpart for system utilities.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/glide-server-apis/concept/c_GlideRecordAPI.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "GlideAjax is used for client-to-server communication, allowing client scripts to call server-side script includes. It is not the server-side replacement for GlideForm and GlideUser.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ajax/concept/c_GlideAjax.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideElement represents a single field value within a GlideRecord object. It does not serve as the server-side equivalent of GlideForm and GlideUser.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/glide-server-apis/concept/c_GlideElementAPI.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideSystem API",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-scripting-part-2-of-2.md",
+        "excerpt": "when we switch to server-side script in ServiceNow, our available APIs change. No more GlideUser user. No more GlideForm. Instead, we get stuff like GlideSystem."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideSystem methods and utilities"
+        ],
+        "tags": [
+          "GlideSystem",
+          "server-side",
+          "APIs",
+          "GlideForm",
+          "GlideUser"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-022",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to display the requesting user's manager email address on an incident form, but this data is not included with the default form payload. Which approach should the developer use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Write an onChange client script to query the database directly using client-side GlideRecord"
+        },
+        {
+          "id": "b",
+          "text": "Create a display business rule that writes the data to the g_scratchpad object"
+        },
+        {
+          "id": "c",
+          "text": "Configure a before business rule to populate a custom form field"
+        },
+        {
+          "id": "d",
+          "text": "Use a UI policy action to retrieve the data from the server"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Display business rules write to the g_scratchpad object to send additional server data to the client that would not ordinarily be included with the form. The scratchpad data is then accessible to client scripts and UI policies. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_DisplayBusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Client-side GlideRecord is not available in scoped applications and is considered a bad practice. GlideRecord queries should come from server scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScriptsBestPractice.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Before business rules fire when a record is being saved to the database, not when a form is loaded. They cannot supply additional data to the form during the initial load.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI policy actions can toggle field attributes (mandatory, visible, read-only) and clear field values, but they cannot make server-side queries to retrieve additional data.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ui-policies/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Display Business Rules",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-scripting-part-2-of-2.md",
+        "excerpt": "display business rules in the scratchpad are meant to help when you anticipate extra stuff that the record's going to need that wouldn't ordinarily come with it. And that's why it's called a scratchpad. It's a place to write additional things."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "display-business-rule",
+          "scratchpad",
+          "g_scratchpad",
+          "form-data"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-023",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following correctly describe the execution timing of business rule types in ServiceNow? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Before business rules fire after a database operation is attempted but before the record is committed to the database"
+        },
+        {
+          "id": "b",
+          "text": "Display business rules fire after the database query completes but before any onLoad client scripts execute"
+        },
+        {
+          "id": "c",
+          "text": "After business rules fire before the record reaches the database"
+        },
+        {
+          "id": "d",
+          "text": "Async business rules execute synchronously in a linear fashion with other business rules"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "Before business rules fire once a database save is attempted but before the record is actually committed, making them ideal for validation. Display business rules fire after the query completes and the form begins rendering, but before onLoad client scripts fire, giving client scripts access to the scratchpad data. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "After business rules fire once the record has been saved to the database, not before. They are useful for passing values from the newly saved record to other records or tables on the server.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Async (asynchronous) business rules execute in parallel in the background, like a scheduled job. They do not execute synchronously or in a linear fashion with other business rules.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/business-rules/concept/c_BusinessRules.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Business Rules",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-scripting-part-2-of-2.md",
+        "excerpt": "before business rules take place, once we've tried to assert the database but before that record finally lands at the database... the form begins to render but before any onLoad client scripts fire-- that's key-- a display business rule can run."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "Server-side scripting patterns"
+        ],
+        "tags": [
+          "business-rules",
+          "execution-order",
+          "before-rule",
+          "display-rule",
+          "after-rule",
+          "async-rule"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-024",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer working in a scoped application needs to retrieve data from the server within a client script to populate a field on a form. Which technique should the developer use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Use a client-side GlideRecord query directly in the client script"
+        },
+        {
+          "id": "b",
+          "text": "Switch the application to global scope to enable client-side GlideRecord"
+        },
+        {
+          "id": "c",
+          "text": "Use a GlideAjax call to invoke a server-side script include"
+        },
+        {
+          "id": "d",
+          "text": "Use the g_form.getReference() method, which is unrestricted in scoped apps"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "In scoped applications, client-side GlideRecord is not available. The recommended approach for performing server-side lookups from a client script is to use GlideAjax, which calls a server-side script include and returns the results asynchronously. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ajax/concept/c_GlideAjax.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Client-side GlideRecord is not available in scoped applications. It was deprecated due to performance and security concerns and cannot be re-enabled via system properties.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScriptsBestPractice.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "Switching to global scope solely to access client-side GlideRecord is not a recommended practice. Even in global scope, client-side GlideRecord is considered a bad practice due to synchronous server calls that degrade performance.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ScopedApps.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The g_form.getReference() method makes synchronous server calls and has restrictions in scoped applications. GlideAjax is the preferred asynchronous approach for server lookups from client scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/ajax/concept/c_GlideAjax.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - GlideAjax",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/05-adf-scripting-part-2-of-2.md",
+        "excerpt": "your GlideRecord queries should come from server scripts. And if you really need to do GlideRecord style lookups from a client script, you're probably going to get stuck doing a Glide Ajax call"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "Scripting & APIs",
+        "domainSlug": "scripting-apis",
+        "domainPercentage": 25,
+        "subtopics": [
+          "GlideAjax for client-server communication"
+        ],
+        "tags": [
+          "GlideAjax",
+          "scoped-app",
+          "client-side",
+          "GlideRecord",
+          "best-practices"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-02-05T20:25:53.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/questions/cad/ui-policies-actions.json
+++ b/data/questions/cad/ui-policies-actions.json
@@ -1,0 +1,1021 @@
+{
+  "questions": [
+    {
+      "id": "cad-ui-policies-actions-001",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which field is used to identify a UI Policy instead of a Name field?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Label"
+        },
+        {
+          "id": "b",
+          "text": "Short description"
+        },
+        {
+          "id": "c",
+          "text": "Title"
+        },
+        {
+          "id": "d",
+          "text": "Display name"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "UI Policies do not have a Name field. Instead, they use the Short description field, which can hold up to 255 characters and should describe what the UI policy does (e.g., 'If category is software, then subcategory is mandatory').",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Label is used for fields/columns on tables, not as the identifying field for UI Policies.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Title is not a field on the UI Policy form. The Short description field serves as the identifier.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Display name is not a field on the UI Policy form. UI Policies are identified by their Short description.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "there is no Name field on a UI policy. Instead, we use the Short description field. And what you want to do here is provide a very robust description of what the UI policy is going to do."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "short-description",
+          "form-configuration"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-002",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In what order do UI policies execute relative to client scripts on a form?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Before client scripts"
+        },
+        {
+          "id": "b",
+          "text": "At the same time as client scripts"
+        },
+        {
+          "id": "c",
+          "text": "After client scripts"
+        },
+        {
+          "id": "d",
+          "text": "The order depends on the Order field value set on each"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "UI policies always execute after client scripts on a form. This is important to understand because if both a client script and a UI policy affect the same field, the UI policy will take effect last.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "UI policies do not execute before client scripts. Client scripts execute first, then UI policies run afterward.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "UI policies and client scripts do not execute simultaneously. Client scripts run first, followed by UI policies.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "While both UI policies and client scripts have an Order field, UI policies as a category always execute after all client scripts have completed, regardless of individual order values.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "UI policies are going to execute after your client scripts execute."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy execution order"
+        ],
+        "tags": [
+          "ui-policy",
+          "client-script",
+          "execution-order"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-003",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "What is the effect of selecting the 'Reverse if false' checkbox on a UI Policy?",
+      "options": [
+        {
+          "id": "a",
+          "text": "It prevents the UI policy from executing when conditions are false"
+        },
+        {
+          "id": "b",
+          "text": "It reverses the UI policy actions and executes the 'Execute if false' script when conditions evaluate to false"
+        },
+        {
+          "id": "c",
+          "text": "It reverses the condition logic so the UI policy triggers on the opposite condition"
+        },
+        {
+          "id": "d",
+          "text": "It automatically creates a duplicate UI policy with the inverse condition"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When the 'Reverse if false' checkbox is selected, the UI policy actions are reversed and the 'Execute if false' script runs when the UI policy conditions evaluate to false. This allows developers to define both true and false behaviors within a single UI policy.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Without 'Reverse if false' checked, the UI policy simply does nothing when conditions are false. Checking the box enables the reverse behavior, not prevention of execution.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "'Reverse if false' does not change the condition logic itself. The condition remains the same; the checkbox controls what happens when the condition evaluates to false—the UI policy actions are reversed.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "No duplicate UI policy is created. The 'Reverse if false' checkbox simply enables the reverse behavior within the same UI policy when conditions are false.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "when this gets selected, the UI policy actions are reversed, and the Execute if fail script is executed when the UI policy conditions evaluate to False."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "reverse-if-false",
+          "conditions"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-004",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "Why does ServiceNow recommend using a UI Policy instead of a client script when both can accomplish the same task?",
+      "options": [
+        {
+          "id": "a",
+          "text": "UI policies execute faster and improve page load performance"
+        },
+        {
+          "id": "b",
+          "text": "UI policies have access to more APIs than client scripts"
+        },
+        {
+          "id": "c",
+          "text": "UI policies are typically unscripted and easier to maintain"
+        },
+        {
+          "id": "d",
+          "text": "UI policies can also run on the server side for data consistency"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "ServiceNow recommends UI policies over client scripts when both can achieve the same result because UI policies are usually unscripted. They use the Condition builder and UI policy actions, making them easier to maintain—especially for less technical administrators who may not know how to script.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "There are no inherent performance advantages of UI policies over client scripts. In fact, too many UI policies can lead to long page load times. The recommendation is based on maintainability, not performance.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "UI policies do not have access to more APIs than client scripts. Both have access to GlideForm (g_form) and GlideUser (g_user). Client scripts actually have additional capabilities like accessing old field values.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI policies execute on the client side only, not on the server side. Data policies are used for server-side data consistency enforcement.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "UI policies are usually unscripted. And they're going to be easier to maintain than a client script. And so those potentially less technical people that may come after you, and they don't know about scripting, or they don't know how to script, it's far easier to build a condition, using the Condition builder"
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy vs Client Script decision criteria"
+        ],
+        "tags": [
+          "ui-policy",
+          "client-script",
+          "best-practices",
+          "maintainability"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-005",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "Which of the following scenarios require using a client script instead of a UI policy? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Making a field mandatory based on the value of another field"
+        },
+        {
+          "id": "b",
+          "text": "Executing validation logic when a form is submitted"
+        },
+        {
+          "id": "c",
+          "text": "Accessing a field's previous value before a change was made"
+        },
+        {
+          "id": "d",
+          "text": "Setting a field to read-only based on a condition"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Client scripts are required when executing logic on form save/submit (onSubmit type) and when accessing a field's old value before a change (using the oldValue parameter in onChange scripts). These capabilities are not available in UI policies.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Making a field mandatory based on another field's value is a standard UI policy action. A condition can be set on the UI policy, and a UI policy action can set the target field to mandatory—no scripting required.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Setting a field to read-only based on a condition is a core UI policy action. This can be configured using the Condition builder and UI policy actions without any script.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": true,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "if you want something to execute when the form gets saved or that form gets submitted or updated, then you have to use a client script. Or if you need to have access to what was in a field before a change-- we call that the field's old value-- then again, you have to use a client script because you won't have that in a UI policy."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy vs Client Script decision criteria"
+        ],
+        "tags": [
+          "ui-policy",
+          "client-script",
+          "onsubmit",
+          "old-value"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-006",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to ensure that when the Priority field on the Incident form is set to Critical, the Description field becomes mandatory and a message is displayed. If the Priority is not Critical, the Description should not be mandatory and no message should appear. How should the developer configure this?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create two separate UI policies—one for the Critical condition and one for the non-Critical condition"
+        },
+        {
+          "id": "b",
+          "text": "Create a single UI policy with the condition Priority is Critical, configure UI policy actions and scripts, and enable the 'Reverse if false' checkbox"
+        },
+        {
+          "id": "c",
+          "text": "Create an onLoad client script that checks the Priority field and uses g_form.setMandatory()"
+        },
+        {
+          "id": "d",
+          "text": "Create a business rule that sets the Description field mandatory attribute on the server side"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The correct approach is to create a single UI policy with the condition Priority is Critical, set the UI policy action to make Description mandatory, enable 'Run scripts' to display the message in 'Execute if true', and check 'Reverse if false' so the actions are reversed and the 'Execute if false' script handles the non-Critical scenario.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Creating two separate UI policies is unnecessary and adds maintenance overhead. The 'Reverse if false' checkbox on a single UI policy handles both the true and false conditions within one configuration.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "While an onLoad client script could achieve this, ServiceNow recommends using UI policies over client scripts when both can accomplish the same task, because UI policies are easier to maintain. Additionally, a UI policy with 'Reverse if false' handles both conditions elegantly.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "A business rule runs on the server side and cannot display client-side messages or dynamically control field behavior on the form in real time. This scenario requires client-side form manipulation, which is handled by UI policies.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "Priority is critical. You're going to apply that when the record-- when the Priority field is critical. And if it's true, you're going to get a message box that says Please describe your critical problem here. It's making the description field mandatory... However, if it comes in, and the priority is not critical... it's going to execute what is false."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "reverse-if-false",
+          "mandatory",
+          "scenario"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-007",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What does the 'Global' checkbox on a UI Policy control?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Whether the UI policy applies to all tables in the instance"
+        },
+        {
+          "id": "b",
+          "text": "Whether the UI policy applies to all form views"
+        },
+        {
+          "id": "c",
+          "text": "Whether the UI policy is available across all application scopes"
+        },
+        {
+          "id": "d",
+          "text": "Whether the UI policy inherits to all extended tables"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The Global checkbox on a UI Policy determines whether the policy applies to all form views. When checked, the UI policy applies globally across all views. When unchecked, the developer must specify the particular form view name the UI policy should execute against.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The Global checkbox does not control which tables the UI policy applies to. The table is specified separately on the UI policy record. Global only controls whether it applies to all form views of that table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Application scope is managed through the application scope settings, not the Global checkbox. The Global checkbox specifically controls form view applicability.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Table inheritance for UI policies is controlled by the 'Inherit' checkbox, not the Global checkbox. The Inherit checkbox determines if the UI policy applies to tables that extend the specified table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "the Global checkbox here, this is the UI policy is going to apply to all form views if that gets selected. Now, you can also uncheck that and specify the form view that the UI policy is going to get executed against."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "global-checkbox",
+          "form-views"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-008",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "A developer is reviewing their instance's UI Policies to optimize performance and maintainability. Which of the following are ServiceNow recommended best practices for UI Policies? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Use the Condition builder instead of scripting for UI policy conditions whenever possible"
+        },
+        {
+          "id": "b",
+          "text": "Always enable the 'On load' checkbox to ensure the UI policy fires immediately when the form opens"
+        },
+        {
+          "id": "c",
+          "text": "Provide a descriptive Short description that clearly explains what the UI policy does"
+        },
+        {
+          "id": "d",
+          "text": "Create as many UI policies as possible to handle every possible field combination on a form"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "ServiceNow recommends using the Condition builder instead of scripting whenever possible, as it is easier to maintain. Additionally, providing a clear, descriptive Short description is essential so that other administrators can quickly understand the purpose of each UI policy.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "ServiceNow recommends unchecking the 'On load' checkbox if it is not a requirement, to avoid unnecessary execution when the form loads and to help reduce page load times.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "ServiceNow warns against using too many UI policies, as they can lead to long page load times. Developers should use them judiciously rather than creating excessive policies for every scenario.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+          }
+        ]
+      },
+      "references": [
+        "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "scripting-in-servicenow-fundamentals/06-ssnf-ui-policies.md",
+        "excerpt": "You do not want to use too many UI policies, as they can lead to long page load times. Also, give a good short description for the UI policy. Make sure it provides a description of what that UI policy is doing... you can use the Condition builder versus a UI policy script. You want to try and use the Condition builder for your conditions of when your UI policy is going to execute, whenever possible."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "best-practices",
+          "performance",
+          "condition-builder"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-18T02:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-009",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What determines whether a UI policy defined on a parent table is applied to an extended (child) table?",
+      "options": [
+        {
+          "id": "a",
+          "text": "UI policies are always automatically inherited by all child tables"
+        },
+        {
+          "id": "b",
+          "text": "A field on the UI policy record controls whether it is inherited by child tables"
+        },
+        {
+          "id": "c",
+          "text": "Only UI policies with scripting enabled can be inherited"
+        },
+        {
+          "id": "d",
+          "text": "UI policies are never inherited and must be recreated on each child table"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Each UI policy record has an 'Inherit' field that determines whether the policy will be inherited by extended (child) tables. This gives administrators granular control over which client-side customizations propagate to child tables. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "UI policies are not automatically inherited. Inheritance is controlled by a specific field on each UI policy record, giving developers the choice of which policies propagate to child tables.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The inheritance behavior is not related to whether a UI policy uses scripting. It is controlled by the Inherit field on the UI policy record regardless of the policy's configuration.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI policies can be inherited by child tables when the Inherit field is set to true. They do not need to be manually recreated on each child table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-configure-the-application.md",
+        "excerpt": "UI policies and client scripts can be hereditary. They might be inherited by the child. That's actually up to you. Each of those kinds of records have a field that allows you to determine whether they're going to be hereditary or not."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "table-extension",
+          "inheritance"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T22:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-010",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "How can a developer quickly view all UI policies, business rules, client scripts, and other customizations configured on a specific table?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Navigate to System Definition > Tables & Columns and filter by table name"
+        },
+        {
+          "id": "b",
+          "text": "Right-click the form header, select Configure > All to see a page of related lists"
+        },
+        {
+          "id": "c",
+          "text": "Open the Application Navigator and search for 'table customizations'"
+        },
+        {
+          "id": "d",
+          "text": "Use the System Diagnostics > Table Inspector module"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Right-clicking the form header (or accessing the context menu) and selecting Configure > All displays a page of related lists showing the business logic and customizations on that table, including UI policies, business rules, client scripts, and more. This is valuable for troubleshooting unexpected behavior. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/table-administration.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "System Definition > Tables & Columns shows table structure and dictionary entries, not a consolidated view of all customizations like UI policies, business rules, and client scripts.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/table-administration.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The Application Navigator provides navigation to modules but does not have a built-in 'table customizations' search that consolidates all business logic for a specific table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-platform-user-interface/page/use/navigation/concept/c_ApplicationNavigator.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "There is no standard 'Table Inspector' module in ServiceNow. The Configure > All page from the form context menu is the correct way to see all customizations on a table.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/table-administration.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Table Administration",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-configure-the-application.md",
+        "excerpt": "right-click the header or enter the Context menu, and go to the Configure menu option and then the submenu option called All. And you get this. It's basically a page of related lists that show a lot of the customizations or business logic that exist on the table."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Actions (form buttons, list choices, context menus)"
+        ],
+        "tags": [
+          "configure-all",
+          "context-menu",
+          "troubleshooting",
+          "table-configuration"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T22:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-011",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_choice",
+      "question": "When extending a table in ServiceNow, how does the inheritance of server-side customizations (such as business rules) compare to client-side customizations (such as UI policies)?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Both server-side and client-side customizations are always fully inherited by child tables"
+        },
+        {
+          "id": "b",
+          "text": "Server-side customizations are inherited automatically, while client-side customizations like UI policies may or may not be inherited depending on a per-record setting"
+        },
+        {
+          "id": "c",
+          "text": "Client-side customizations are always inherited, but server-side customizations require manual configuration"
+        },
+        {
+          "id": "d",
+          "text": "Neither server-side nor client-side customizations are inherited; all must be recreated on child tables"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When extending a table, server-side customizations like business rules and access controls are automatically inherited by the child table. Client-side customizations such as UI policies and client scripts have a configurable 'Inherit' field on each record that determines whether they propagate to child tables. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "While server-side customizations are always inherited, client-side customizations like UI policies and client scripts are only inherited if their individual 'Inherit' field is set to true. This is not automatic for all records.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html"
+          },
+          {
+            "choiceId": "c",
+            "explanation": "This is the opposite of how inheritance works. Server-side logic is inherited automatically, while client-side logic (UI policies, client scripts) has a configurable inheritance setting.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/extending-a-table.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "One of the key benefits of extending a table is inheriting existing customizations. Server-side logic is always inherited, and client-side logic can be inherited when configured to do so.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/extending-a-table.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Table Extension",
+        "ServiceNow Docs - UI Policies",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-configure-the-application.md",
+        "excerpt": "when we extend a table, we get the structure, and we get all the server-side customizations, and we maybe get some of the client-side customizations all for free, making it an easy jumping-off point when we're storing some similar subset of data."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy vs Client Script decision criteria"
+        ],
+        "tags": [
+          "ui-policy",
+          "client-script",
+          "inheritance",
+          "table-extension",
+          "server-side"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T22:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-012",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "understanding",
+      "type": "multiple_select",
+      "question": "A developer is troubleshooting unexpected form behavior on a custom table that extends the Task table. Which of the following can be reviewed from the table's Configure > All page to identify the source of the issue? (Select all that apply)",
+      "options": [
+        {
+          "id": "a",
+          "text": "UI policies that may be setting field visibility or mandatory status"
+        },
+        {
+          "id": "b",
+          "text": "Business rules executing server-side logic on record changes"
+        },
+        {
+          "id": "c",
+          "text": "Client scripts running on form load or field change"
+        },
+        {
+          "id": "d",
+          "text": "The table's data rows and individual record values"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The Configure > All page displays related lists of the customizations and business logic on a table, including UI policies, business rules, client scripts, access controls, and other artifacts. This makes it a valuable troubleshooting tool for understanding what logic is acting on a table. It does not display the table's actual data records. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/table-administration.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "d",
+            "explanation": "The Configure > All page shows customizations and business logic (UI policies, business rules, client scripts, etc.), not the table's data records. To view data rows, you would use a list view or table module.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/table-administration.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - Table Administration",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-configure-the-application.md",
+        "excerpt": "if you're troubleshooting behavior on your table. It can be really handy to go to this Configure page for your table and, at a glance see, a lot of the business logic that's there on the table and quickly hunt down what might be causing the behavior that you can't explain or that you don't want."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions",
+          "UI Actions (form buttons, list choices, context menus)"
+        ],
+        "tags": [
+          "configure-all",
+          "troubleshooting",
+          "ui-policy",
+          "business-rule",
+          "client-script"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T22:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-actions-013",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer creates a new Loaner Request table by extending the Task table. Several UI policies on the Task table control field visibility and mandatory settings. The developer notices that some Task UI policies appear on the Loaner Request form but others do not. What is the most likely explanation?",
+      "options": [
+        {
+          "id": "a",
+          "text": "UI policies on extended tables are randomly inherited based on system load"
+        },
+        {
+          "id": "b",
+          "text": "Only UI policies created after the child table was created are inherited"
+        },
+        {
+          "id": "c",
+          "text": "The missing UI policies have their Inherit field set to false on the Task table, preventing propagation to child tables"
+        },
+        {
+          "id": "d",
+          "text": "The Loaner Request table's application scope blocks all parent UI policies by default"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Each UI policy record has an 'Inherit' field. When set to true, the UI policy propagates to child (extended) tables. If some Task UI policies appear on the Loaner Request form and others do not, it is because the missing policies have their Inherit field set to false. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "UI policy inheritance is deterministic, controlled by the Inherit field on each UI policy record. System load has no effect on which policies are inherited.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html"
+          },
+          {
+            "choiceId": "b",
+            "explanation": "The timing of UI policy creation relative to child table creation does not determine inheritance. Inheritance is controlled by the Inherit field on each UI policy record, regardless of when the policy or table was created.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicy.html"
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Application scope controls cross-scope access to tables and records, but UI policy inheritance from parent to child tables within the same scope hierarchy is governed by the Inherit field on individual UI policy records, not by application access settings.",
+            "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/table-administration/concept/application-access.html"
+          }
+        ]
+      },
+      "references": [
+        "ServiceNow Docs - UI Policies",
+        "ServiceNow Docs - Table Extension",
+        "Application Development Fundamentals Course"
+      ],
+      "isFree": false,
+      "source": {
+        "type": "course",
+        "path": "application-development-fundamentals-on-demand/04-adf-configure-the-application.md",
+        "excerpt": "UI policies and client scripts can be hereditary. They might be inherited by the child. That's actually up to you. Each of those kinds of records have a field that allows you to determine whether they're going to be hereditary or not."
+      },
+      "labels": {
+        "certification": "cad",
+        "domain": "UI Policies & Actions",
+        "domainSlug": "ui-policies-actions",
+        "domainPercentage": 10,
+        "subtopics": [
+          "UI Policy conditions and actions"
+        ],
+        "tags": [
+          "ui-policy",
+          "inheritance",
+          "table-extension",
+          "task-table",
+          "troubleshooting"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2025-07-16T22:30:00.000Z",
+        "version": "1.0",
+        "release": "Yokohama",
+        "reviewed": false
+      }
+    }
+  ]
+}

--- a/data/topics/cad-topics.json
+++ b/data/topics/cad-topics.json
@@ -1,0 +1,173 @@
+{
+  "certification": "cad",
+  "topics": [
+    {
+      "slug": "scripting-apis",
+      "name": "Scripting & APIs",
+      "domain": "scripting-apis",
+      "description": "Master GlideRecord, GlideSystem, GlideAjax, and server-side scripting on the ServiceNow platform. Learn essential APIs for querying, updating, and managing records programmatically.",
+      "introduction": {
+        "overview": "Server-side scripting is the core of ServiceNow application development. The platform provides powerful APIs like GlideRecord for database operations, GlideSystem for system-level utilities, and GlideAjax for client-server communication. Understanding these APIs and their proper usage is fundamental to building reliable, performant applications.",
+        "whyItMatters": "Scripting & APIs is the largest domain on the CAD exam at 25%. Questions test your ability to write effective server-side scripts, use the correct API for the right situation, and understand scripting contexts. Expect questions about GlideRecord queries, GlideSystem methods, and debugging techniques.",
+        "keyConcepts": "Focus on GlideRecord CRUD operations (query, insert, update, delete), GlideSystem utility methods (gs.log, gs.getUser, gs.addInfoMessage), and GlideAjax for asynchronous client-server communication. Understand the difference between server-side and client-side scripting contexts.",
+        "examTips": "Know the difference between getValue() and getDisplayValue(). Understand addQuery(), addEncodedQuery(), and query chaining. Be familiar with GlideAggregate for counting and summing. Remember that GlideRecord scripts run on the server while g_form scripts run on the client."
+      },
+      "keyConcepts": [
+        "GlideRecord queries and CRUD operations",
+        "GlideSystem utility methods",
+        "GlideAjax client-server communication",
+        "GlideAggregate for reporting",
+        "Script debugging and logging",
+        "Server-side scripting contexts",
+        "Flow Designer scripting actions",
+        "Scoped vs global scripting"
+      ],
+      "questionCount": 24,
+      "freeQuestionCount": 5
+    },
+    {
+      "slug": "business-rules",
+      "name": "Business Rules",
+      "domain": "business-rules",
+      "description": "Create and manage business rules for server-side automation. Understand when business rules execute, how to use conditions and scripts, and best practices for server-side logic.",
+      "introduction": {
+        "overview": "Business Rules are server-side scripts that execute when database records are displayed, inserted, updated, deleted, or queried. They are one of the most powerful automation tools in ServiceNow, allowing developers to enforce data policies, automate workflows, and implement complex business logic.",
+        "whyItMatters": "Business Rules account for 15% of the CAD exam. Questions focus on understanding the different types of business rules (before, after, async, display), when each type executes, and how to use the current and previous objects effectively.",
+        "keyConcepts": "Understand the four types of business rules and their execution order. Know how to use conditions vs scripts for rule logic. Learn when to use before rules (data validation/modification) vs after rules (related record updates) vs async rules (heavy processing).",
+        "examTips": "Remember that 'before' business rules can modify the current record without an explicit update() call, while 'after' rules require update() for changes to related records. Know that 'display' business rules run when a form loads and can set scratchpad values for client scripts."
+      },
+      "keyConcepts": [
+        "Before, after, async, and display business rules",
+        "current and previous objects",
+        "Business rule conditions and scripts",
+        "Execution order and when to run",
+        "Scheduled script execution",
+        "Script debugging techniques",
+        "g_scratchpad for display rules",
+        "Business rule best practices"
+      ],
+      "questionCount": 14,
+      "freeQuestionCount": 5
+    },
+    {
+      "slug": "client-scripts",
+      "name": "Client Scripts",
+      "domain": "client-scripts",
+      "description": "Implement client-side scripting for form customization and improved user experience. Master g_form, g_user, and g_list APIs for dynamic form behavior.",
+      "introduction": {
+        "overview": "Client Scripts run in the user's web browser and allow developers to customize form behavior dynamically. They respond to user actions like loading a form, changing a field, or submitting a record. The g_form API provides methods to manipulate form fields, while g_user gives access to the current user's information.",
+        "whyItMatters": "Client Scripts represent 12% of the CAD exam. Questions test your knowledge of different client script types, the g_form API, and when to use client scripts vs UI policies. Understanding the client-side context and its limitations is crucial.",
+        "keyConcepts": "Master the four client script types: onLoad (form display), onChange (field value change), onSubmit (form submission), and onCellEdit (list editing). Know the g_form API methods for showing/hiding fields, setting values, and making fields mandatory.",
+        "examTips": "Remember that client scripts run in the browser so they cannot use server-side APIs like GlideRecord directly \u2014 use GlideAjax instead. Know that onChange scripts receive control, oldValue, newValue, and isLoading parameters. The isLoading parameter helps prevent unwanted execution during form load."
+      },
+      "keyConcepts": [
+        "onLoad, onChange, onSubmit, onCellEdit types",
+        "g_form API methods",
+        "g_user and g_list objects",
+        "GlideAjax from client side",
+        "Client script vs UI Policy decisions",
+        "Mobile/Service Portal considerations",
+        "Client script debugging",
+        "Performance best practices"
+      ],
+      "questionCount": 11,
+      "freeQuestionCount": 5
+    },
+    {
+      "slug": "ui-policies-actions",
+      "name": "UI Policies & Actions",
+      "domain": "ui-policies-actions",
+      "description": "Dynamically change form behavior without scripting using UI Policies. Create custom buttons and menu items with UI Actions for streamlined workflows.",
+      "introduction": {
+        "overview": "UI Policies provide a no-code/low-code approach to dynamically changing form behavior based on conditions. They can make fields mandatory, read-only, or visible/hidden without writing client scripts. UI Actions extend the interface with custom buttons, links, and context menu items that trigger server-side or client-side logic.",
+        "whyItMatters": "UI Policies & Actions make up 10% of the CAD exam. Questions test your understanding of when to use UI Policies vs Client Scripts, how UI Policy conditions work, and how to create effective UI Actions for custom form buttons.",
+        "keyConcepts": "Understand UI Policy conditions (simple vs scripted), UI Policy actions (mandatory, visible, read-only), and execution order. Know how UI Actions create form buttons, list buttons, and context menu items. Learn when each approach is appropriate.",
+        "examTips": "UI Policies are preferred over client scripts for simple show/hide and mandatory behavior because they work across all interfaces (desktop, mobile, Service Portal). Remember that UI Policies execute in order and can override each other. Know the difference between client-side and server-side UI Actions."
+      },
+      "keyConcepts": [
+        "UI Policy conditions and actions",
+        "UI Policy vs Client Script decisions",
+        "UI Actions (form, list, context menu)",
+        "Data Policies for server-side enforcement",
+        "Execution order and priority",
+        "Scripted UI Policy conditions",
+        "UI Action visibility conditions",
+        "Cross-platform considerations"
+      ],
+      "questionCount": 13,
+      "freeQuestionCount": 5
+    },
+    {
+      "slug": "script-includes",
+      "name": "Script Includes",
+      "domain": "script-includes",
+      "description": "Build reusable server-side JavaScript libraries with Script Includes. Learn to extend classes, create client-callable scripts, and implement the AbstractAjaxProcessor pattern.",
+      "introduction": {
+        "overview": "Script Includes are reusable server-side JavaScript objects that are loaded on demand. They promote code reuse and maintainability by encapsulating logic in class-based structures. Client-callable Script Includes enable client-server communication through the GlideAjax framework, following the AbstractAjaxProcessor pattern.",
+        "whyItMatters": "Script Includes account for 12% of the CAD exam. Questions focus on creating and using Script Includes, extending base classes, making Script Includes client-callable, and understanding scope implications.",
+        "keyConcepts": "Master the Script Include structure with initialize() and prototype patterns. Understand how to extend AbstractAjaxProcessor for client-callable Script Includes. Know the difference between scoped and global Script Includes and when each is appropriate.",
+        "examTips": "Remember that client-callable Script Includes must extend AbstractAjaxProcessor and have the 'Client callable' checkbox selected. The getParameter() method retrieves values passed from GlideAjax. Script Includes are loaded on demand \u2014 they don't execute until called."
+      },
+      "keyConcepts": [
+        "Script Include structure and prototypes",
+        "Extending classes (AbstractAjaxProcessor)",
+        "Client-callable Script Includes",
+        "GlideAjax integration patterns",
+        "Scoped vs global Script Includes",
+        "Code reuse best practices",
+        "Script Include debugging",
+        "initialize() and type patterns"
+      ],
+      "questionCount": 12,
+      "freeQuestionCount": 5
+    },
+    {
+      "slug": "integration-rest",
+      "name": "Integration & REST APIs",
+      "domain": "integration-rest",
+      "description": "Build integrations using REST APIs, web services, and data import tools. Master inbound and outbound REST, Import Sets, and Transform Maps.",
+      "introduction": {
+        "overview": "ServiceNow provides comprehensive integration capabilities through REST APIs, SOAP web services, Import Sets, and Integration Hub. Developers can create Scripted REST APIs for inbound integrations, use RESTMessageV2 for outbound calls, and leverage Import Sets with Transform Maps for bulk data loading.",
+        "whyItMatters": "Integration & REST APIs represent 15% of the CAD exam. Questions cover building REST integrations, creating Scripted REST APIs, configuring Import Sets and Transform Maps, and understanding authentication methods for web services.",
+        "keyConcepts": "Understand the difference between inbound and outbound integrations. Know how to create Scripted REST APIs with custom endpoints. Master RESTMessageV2 for outbound REST calls. Learn Import Sets and Transform Maps for data loading workflows.",
+        "examTips": "Know the difference between Table API (standard) and Scripted REST API (custom). Understand REST authentication methods (Basic, OAuth, mutual TLS). Remember that Import Sets create staging tables and Transform Maps define the mapping to target tables. Be familiar with coalesce fields for update-or-insert logic."
+      },
+      "keyConcepts": [
+        "Scripted REST APIs",
+        "Outbound REST Messages (RESTMessageV2)",
+        "Import Sets and Transform Maps",
+        "Table API vs Scripted REST API",
+        "Authentication methods",
+        "JSON/XML parsing",
+        "Coalesce fields for upsert",
+        "Integration Hub basics"
+      ],
+      "questionCount": 13,
+      "freeQuestionCount": 5
+    },
+    {
+      "slug": "application-development",
+      "name": "Application Development",
+      "domain": "application-development",
+      "description": "Build and deploy scoped applications using ServiceNow Studio. Manage update sets, implement application security, and test with the Automated Test Framework.",
+      "introduction": {
+        "overview": "ServiceNow Studio is the IDE for building scoped applications. Scoped applications provide isolation and portability, with their own tables, scripts, and security rules. The application lifecycle includes development, testing with ATF, and deployment via update sets or the App Repository.",
+        "whyItMatters": "Application Development covers 11% of the CAD exam. Questions test your knowledge of the scoped application model, Studio IDE capabilities, update set management, and the Automated Test Framework (ATF) for testing.",
+        "keyConcepts": "Understand application scope and how it affects script access. Know how to use Studio for development. Master update sets for migration between instances. Learn ATF for automated testing of application functionality.",
+        "examTips": "Remember that scoped applications have their own namespace and cannot access global tables without explicit cross-scope access. Know the difference between application scope and update set scope. Understand that ATF tests can validate forms, workflows, and security rules. Be familiar with the application deployment lifecycle."
+      },
+      "keyConcepts": [
+        "Scoped applications and namespaces",
+        "ServiceNow Studio IDE",
+        "Update sets management",
+        "Application deployment lifecycle",
+        "Automated Test Framework (ATF)",
+        "Application security (ACLs)",
+        "Cross-scope access",
+        "Source control integration"
+      ],
+      "questionCount": 43,
+      "freeQuestionCount": 5
+    }
+  ]
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,6 +1,7 @@
 import certificationsData from "@/data/certifications.json";
 import csaTopics from "@/data/topics/csa-topics.json";
 import cisDfTopics from "@/data/topics/cis-df-topics.json";
+import cadTopics from "@/data/topics/cad-topics.json";
 import type { Certification, CertificationWithReadiness, Topic, Question, ExamDomain, CertificationCategory, ServiceNowRelease, DeltaExamInfo } from "@/types";
 
 // Category display names mapping
@@ -75,6 +76,7 @@ export function getCertificationSlugs(): string[] {
 const topicsMap: Record<string, typeof csaTopics> = {
   csa: csaTopics,
   "cis-df": cisDfTopics,
+  cad: cadTopics,
 };
 
 export function getTopicsForCertification(certSlug: string): Topic[] {


### PR DESCRIPTION
## What's New

The **#2 most popular ServiceNow certification** now has full question coverage on SNReady!

### CAD (Certified Application Developer) — 130 Questions

| Domain | Questions | Exam Weight | MC/MS | K/U/A |
|--------|-----------|-------------|-------|-------|
| Scripting & APIs | 24 | 25% | 18/6 | 9/9/6 |
| Application Development | 43 | 11% | 32/11 | 17/17/9 |
| Business Rules | 14 | 15% | 10/4 | 5/6/3 |
| Integration & REST APIs | 13 | 15% | 10/3 | 5/5/3 |
| UI Policies & Actions | 13 | 10% | 10/3 | 5/5/3 |
| Script Includes | 12 | 12% | 9/3 | 5/5/2 |
| Client Scripts | 11 | 12% | 8/3 | 4/5/2 |

### Distribution
- **Types:** ~75% multiple choice / ~25% multiple select ✅
- **Cognitive levels:** ~40% knowledge / ~40% understanding / ~20% application ✅
- **Free questions:** 5 per domain (35 total) ✅

### Source Material
Generated from 863K chars of scraped course content:
- Application Development Fundamentals (557K)
- Scripting in ServiceNow Fundamentals (306K)

### Platform Changes
- New `data/topics/cad-topics.json` with rich topic descriptions, introductions, exam tips
- 7 question JSON files in `data/questions/cad/`
- CAD added to data layer (`lib/data.ts`)
- CAD topics section added to homepage
- Ready certs count: 2 → 3
- Glossary auto-expanded (105 → 160+ terms from CAD content)
- All new pages: topic questions, free questions, practice test, study guide, learn pages

### Pages Generated
~50+ new CAD pages including:
- `/certifications/cad` — certification overview
- `/cad/questions/{topic}` — 7 topic question pages  
- `/free-questions/cad/{topic}` — 7 free question pages
- `/practice-tests/cad` — full mock exam
- `/study-guide/cad` — study guide
- `/glossary/{term}` — 55+ new glossary terms