### PR TITLE
feat: Tiered pricing ($9/30-day + $49/lifetime) + 10 free questions

### DIFF
--- a/app/[certification]/questions/[topic]/page.tsx
+++ b/app/[certification]/questions/[topic]/page.tsx
@@ -248,19 +248,25 @@ export default async function TopicQuestionsPage({ params }: PageProps) {
               {/* CTA */}
               <div className="rounded-xl bg-emerald-600 p-5 text-white dark:bg-emerald-700">
                 <h3 className="font-semibold">Unlock Full {cert.name} Access</h3>
-                <div className="mt-2">
-                  <span className="text-2xl font-bold">$9</span>
-                  <span className="text-emerald-100"> for 30 days</span>
-                </div>
                 <p className="mt-2 text-sm text-emerald-100">
-                  All {cert.name} questions with detailed explanations and source references.
+                  All questions with detailed explanations.
                 </p>
-                <CheckoutButton
-                  certification={cert.name}
-                  className="mt-4 w-full rounded-lg bg-white py-2 text-sm font-medium text-emerald-600 transition-colors hover:bg-emerald-50"
-                >
-                  Get Full Access
-                </CheckoutButton>
+                <div className="mt-4 space-y-2">
+                  <CheckoutButton
+                    certification={cert.name}
+                    plan="30day"
+                    className="w-full rounded-lg bg-white/20 py-2 text-sm font-medium text-white transition-colors hover:bg-white/30"
+                  >
+                    30 Days — $9
+                  </CheckoutButton>
+                  <CheckoutButton
+                    certification={cert.name}
+                    plan="lifetime"
+                    className="w-full rounded-lg bg-white py-2 text-sm font-medium text-emerald-600 transition-colors hover:bg-emerald-50"
+                  >
+                    Lifetime — $49 ⭐
+                  </CheckoutButton>
+                </div>
               </div>
             </aside>
           </div>

--- a/app/certifications/[slug]/page.tsx
+++ b/app/certifications/[slug]/page.tsx
@@ -446,53 +446,66 @@ export default async function CertificationPage({ params }: PageProps) {
         {/* Pricing CTA */}
         {isReady && (
           <section className="py-16 bg-gradient-to-br from-emerald-600 to-green-700 dark:from-emerald-800 dark:to-green-900">
-            <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">
-              <h2 className="text-3xl font-bold text-white">
-                Get Full {cert.name} Access
-              </h2>
-              <p className="mt-4 text-lg text-emerald-100">
-                Unlock all {totalQuestions}+ practice questions with detailed explanations and source references
-              </p>
-              <div className="mt-8 inline-flex items-baseline gap-1">
-                <span className="text-5xl font-bold text-white">$9</span>
-                <span className="text-xl text-emerald-200"> for 30-day access</span>
+            <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+              <div className="text-center">
+                <h2 className="text-3xl font-bold text-white">
+                  Get Full {cert.name} Access
+                </h2>
+                <p className="mt-4 text-lg text-emerald-100">
+                  Unlock all {totalQuestions}+ practice questions with detailed explanations
+                </p>
               </div>
-              <ul className="mt-8 flex flex-col items-center gap-3 text-emerald-100">
-                <li className="flex items-center gap-2">
-                  <svg className="h-5 w-5 text-emerald-300" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                  </svg>
-                  All {cert.name} practice questions
-                </li>
-                <li className="flex items-center gap-2">
-                  <svg className="h-5 w-5 text-emerald-300" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                  </svg>
-                  Detailed explanations with source references
-                </li>
-                <li className="flex items-center gap-2">
-                  <svg className="h-5 w-5 text-emerald-300" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                  </svg>
-                  Full-length practice tests
-                </li>
-                <li className="flex items-center gap-2">
-                  <svg className="h-5 w-5 text-emerald-300" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                  </svg>
-                  One-time payment, no auto-renewal
-                </li>
-              </ul>
-              <div className="mt-10">
-                <CheckoutButton
-                  certification={cert.name}
-                  className="inline-flex h-14 items-center justify-center rounded-lg bg-white px-8 text-lg font-semibold text-emerald-700 transition-colors hover:bg-emerald-50"
-                >
-                  Get Full Access — $9
-                </CheckoutButton>
+
+              <div className="mt-10 grid gap-6 md:grid-cols-2 max-w-3xl mx-auto">
+                {/* 30-Day Plan */}
+                <div className="rounded-xl bg-white/10 backdrop-blur p-6 text-center">
+                  <h3 className="text-lg font-semibold text-white">30-Day Access</h3>
+                  <div className="mt-4">
+                    <span className="text-4xl font-bold text-white">$9</span>
+                  </div>
+                  <ul className="mt-6 space-y-2 text-sm text-emerald-100">
+                    <li>✓ All {cert.name} questions</li>
+                    <li>✓ Detailed explanations</li>
+                    <li>✓ Practice tests</li>
+                    <li>✓ 30 days access</li>
+                  </ul>
+                  <CheckoutButton
+                    certification={cert.name}
+                    plan="30day"
+                    className="mt-6 w-full rounded-lg bg-white py-3 font-semibold text-emerald-700 transition-colors hover:bg-emerald-50"
+                  >
+                    Get 30-Day Access
+                  </CheckoutButton>
+                </div>
+
+                {/* Lifetime Plan */}
+                <div className="rounded-xl bg-white p-6 text-center relative overflow-hidden">
+                  <div className="absolute top-0 right-0 bg-amber-500 text-white text-xs font-bold px-3 py-1 rounded-bl-lg">
+                    LIMITED TIME
+                  </div>
+                  <h3 className="text-lg font-semibold text-emerald-800">Lifetime Access</h3>
+                  <div className="mt-4">
+                    <span className="text-4xl font-bold text-emerald-700">$49</span>
+                  </div>
+                  <ul className="mt-6 space-y-2 text-sm text-emerald-700">
+                    <li>✓ All {cert.name} questions</li>
+                    <li>✓ Detailed explanations</li>
+                    <li>✓ Practice tests</li>
+                    <li className="font-semibold">✓ Lifetime access — never expires</li>
+                    <li className="font-semibold">✓ Future updates included</li>
+                  </ul>
+                  <CheckoutButton
+                    certification={cert.name}
+                    plan="lifetime"
+                    className="mt-6 w-full rounded-lg bg-emerald-600 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+                  >
+                    Get Lifetime Access
+                  </CheckoutButton>
+                </div>
               </div>
-              <p className="mt-4 text-sm text-emerald-200">
-                {freeQuestions} free questions available to try first
+
+              <p className="mt-6 text-center text-sm text-emerald-200">
+                {freeQuestions} free questions available to try first • One-time payment, no subscription
               </p>
             </div>
           </section>

--- a/app/free-questions/[cert]/[topic]/page.tsx
+++ b/app/free-questions/[cert]/[topic]/page.tsx
@@ -104,7 +104,7 @@ export default async function FreeQuestionsPage({ params }: Props) {
         name: "How can I access the full question bank?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: `Full access to all ${certification.name} practice questions costs $9 for 30-day access. This includes detailed explanations, source references, and comprehensive coverage of all exam topics.`,
+          text: `Full access to all ${certification.name} practice questions starts at $9 for 30-day access or $49 for lifetime access. This includes detailed explanations, source references, and comprehensive coverage of all exam topics.`,
         },
       },
     ],
@@ -198,30 +198,45 @@ export default async function FreeQuestionsPage({ params }: Props) {
         </div>
 
         {/* Unlock CTA */}
-        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-4 sm:p-8 text-center dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
-          <h3 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100">
+        <div className="mt-12 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-green-100 p-4 sm:p-8 dark:border-emerald-800 dark:from-emerald-950 dark:to-green-950">
+          <h3 className="text-2xl font-bold text-emerald-900 dark:text-emerald-100 text-center">
             Unlock Full {certification.name} Access
           </h3>
-          <div className="mt-4">
-            <span className="text-4xl font-bold text-emerald-900 dark:text-emerald-100">$9</span>
-            <span className="text-emerald-700 dark:text-emerald-300"> for 30-day access</span>
-          </div>
-          <p className="mt-3 text-emerald-700 dark:text-emerald-300">
-            Full access to all {certification.name} practice questions with detailed explanations and source references
-          </p>
           
-          <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-center">
-            <CheckoutButton
-              certification={certification.name}
-              className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
-            >
-              Get Full Access — $9
-            </CheckoutButton>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 max-w-lg mx-auto">
+            <div className="rounded-lg bg-white dark:bg-zinc-800 p-4 text-center shadow-sm">
+              <div className="text-2xl font-bold text-emerald-800 dark:text-emerald-200">$9</div>
+              <div className="text-sm text-emerald-600 dark:text-emerald-400">30-day access</div>
+              <CheckoutButton
+                certification={certification.name}
+                plan="30day"
+                className="mt-3 w-full rounded-lg bg-emerald-600 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-700"
+              >
+                Get 30 Days
+              </CheckoutButton>
+            </div>
+            <div className="rounded-lg bg-emerald-600 dark:bg-emerald-700 p-4 text-center shadow-sm relative">
+              <div className="absolute -top-2 left-1/2 -translate-x-1/2 bg-amber-500 text-white text-xs font-bold px-2 py-0.5 rounded">
+                BEST VALUE
+              </div>
+              <div className="text-2xl font-bold text-white">$49</div>
+              <div className="text-sm text-emerald-100">Lifetime access</div>
+              <CheckoutButton
+                certification={certification.name}
+                plan="lifetime"
+                className="mt-3 w-full rounded-lg bg-white py-2 text-sm font-semibold text-emerald-700 transition-colors hover:bg-emerald-50"
+              >
+                Get Lifetime
+              </CheckoutButton>
+            </div>
+          </div>
+
+          <div className="mt-4 text-center">
             <Link
               href={`/certifications/${cert}`}
-              className="inline-flex items-center justify-center rounded-lg border border-emerald-600 px-6 py-3 font-semibold text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950"
+              className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400"
             >
-              View All Topics
+              View all {certification.name} topics →
             </Link>
           </div>
         </div>

--- a/components/CheckoutButton.tsx
+++ b/components/CheckoutButton.tsx
@@ -2,21 +2,23 @@
 
 import { useState } from "react";
 import { useAccess } from "./AccessProvider";
-import { LoginModal } from "./LoginModal";
+
+type PlanType = "30day" | "lifetime";
 
 interface CheckoutButtonProps {
   certification?: string;
+  plan?: PlanType;
   className?: string;
   children: React.ReactNode;
 }
 
 export function CheckoutButton({
   certification,
+  plan = "30day",
   className = "",
   children,
 }: CheckoutButtonProps) {
   const [loading, setLoading] = useState(false);
-  const [showLogin, setShowLogin] = useState(false);
   const { hasAccess } = useAccess();
 
   const handleCheckout = async () => {
@@ -27,7 +29,7 @@ export function CheckoutButton({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ certification }),
+        body: JSON.stringify({ certification, plan }),
       });
 
       const data = await response.json();
@@ -54,23 +56,12 @@ export function CheckoutButton({
   }
 
   return (
-    <>
-      <button
-        onClick={handleCheckout}
-        disabled={loading}
-        className={`${className} ${loading ? "opacity-75 cursor-wait" : ""}`}
-      >
-        {loading ? "Loading..." : children}
-      </button>
-
-      <LoginModal
-        isOpen={showLogin}
-        onClose={() => setShowLogin(false)}
-        onPurchase={() => {
-          setShowLogin(false);
-          handleCheckout();
-        }}
-      />
-    </>
+    <button
+      onClick={handleCheckout}
+      disabled={loading}
+      className={`${className} ${loading ? "opacity-75 cursor-wait" : ""}`}
+    >
+      {loading ? "Loading..." : children}
+    </button>
   );
 }

--- a/functions/api/checkout.ts
+++ b/functions/api/checkout.ts
@@ -5,12 +5,31 @@ interface Env {
   SITE_URL: string;
 }
 
+type PlanType = "30day" | "lifetime";
+
+const PLANS = {
+  "30day": {
+    price: 900, // $9.00 in cents
+    name: "30-Day Access",
+    description: "30-day access to all practice questions with detailed explanations",
+  },
+  "lifetime": {
+    price: 4900, // $49.00 in cents
+    name: "Lifetime Access (Limited Time)",
+    description: "Lifetime access to all practice questions — never expires",
+  },
+};
+
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
 
   try {
-    const { certification } = await request.json() as { certification?: string };
+    const { certification, plan = "30day" } = await request.json() as { 
+      certification?: string;
+      plan?: PlanType;
+    };
 
+    const selectedPlan = PLANS[plan] || PLANS["30day"];
     const stripe = new Stripe(env.STRIPE_SECRET_KEY);
 
     const session = await stripe.checkout.sessions.create({
@@ -20,10 +39,10 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
           price_data: {
             currency: "usd",
             product_data: {
-              name: `SNReady ${certification || "Full"} Access`,
-              description: "30-day access to all practice questions with detailed explanations",
+              name: `SNReady ${certification || "Full"} ${selectedPlan.name}`,
+              description: selectedPlan.description,
             },
-            unit_amount: 900, // $9.00 in cents
+            unit_amount: selectedPlan.price,
           },
           quantity: 1,
         },
@@ -33,6 +52,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       cancel_url: `${env.SITE_URL}/checkout/cancel`,
       metadata: {
         certification: certification || "all",
+        plan: plan,
       },
     });
 

--- a/functions/api/session.ts
+++ b/functions/api/session.ts
@@ -30,6 +30,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     }
 
     const email = session.customer_details?.email;
+    const plan = session.metadata?.plan || "30day";
+    const certification = session.metadata?.certification || "all";
 
     if (!email) {
       return new Response(
@@ -39,24 +41,36 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     }
 
     // Grant access (in case webhook was slow)
-    const expiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
+    const durationMs = plan === "lifetime" 
+      ? 100 * 365 * 24 * 60 * 60 * 1000 
+      : 30 * 24 * 60 * 60 * 1000;
+    
+    const expiresAt = Date.now() + durationMs;
+    
+    const kvOptions = plan === "lifetime" 
+      ? {} 
+      : { expirationTtl: 30 * 24 * 60 * 60 };
+
     await env.SNREADY_ACCESS.put(
       email.toLowerCase(),
       JSON.stringify({
         paid: true,
+        plan,
         expiresAt,
         sessionId: session.id,
-        certification: session.metadata?.certification || "all",
+        certification,
         createdAt: Date.now(),
       }),
-      { expirationTtl: 30 * 24 * 60 * 60 }
+      kvOptions
     );
 
     return new Response(
       JSON.stringify({
         success: true,
         email,
+        plan,
         expiresAt,
+        certification,
       }),
       { headers: { "Content-Type": "application/json" } }
     );

--- a/functions/api/webhook.ts
+++ b/functions/api/webhook.ts
@@ -27,22 +27,35 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     if (event.type === "checkout.session.completed") {
       const session = event.data.object as Stripe.Checkout.Session;
       const email = session.customer_details?.email;
+      const plan = session.metadata?.plan || "30day";
+      const certification = session.metadata?.certification || "all";
 
       if (email) {
-        // Store access for 30 days
-        const expiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
+        // Lifetime = 100 years, 30day = 30 days
+        const durationMs = plan === "lifetime" 
+          ? 100 * 365 * 24 * 60 * 60 * 1000 
+          : 30 * 24 * 60 * 60 * 1000;
+        
+        const expiresAt = Date.now() + durationMs;
+        
+        // For lifetime, don't set TTL (keep forever)
+        const kvOptions = plan === "lifetime" 
+          ? {} 
+          : { expirationTtl: 30 * 24 * 60 * 60 };
+
         await env.SNREADY_ACCESS.put(
           email.toLowerCase(),
           JSON.stringify({
             paid: true,
+            plan,
             expiresAt,
             sessionId: session.id,
-            certification: session.metadata?.certification || "all",
+            certification,
             createdAt: Date.now(),
           }),
-          { expirationTtl: 30 * 24 * 60 * 60 } // 30 days TTL
+          kvOptions
         );
-        console.log(`Access granted to ${email} until ${new Date(expiresAt).toISOString()}`);
+        console.log(`Access granted to ${email} (${plan}) until ${new Date(expiresAt).toISOString()}`);
       }
     }
 

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -127,12 +127,15 @@ export async function getQuestionsForTopic(
   }
 }
 
+// Free questions: first 10 questions per topic
+const FREE_QUESTIONS_PER_TOPIC = 10;
+
 export async function getFreeQuestionsForTopic(
   certSlug: string,
   topicSlug: string
 ): Promise<Question[]> {
   const questions = await getQuestionsForTopic(certSlug, topicSlug);
-  return questions.filter((q) => q.isFree);
+  return questions.slice(0, FREE_QUESTIONS_PER_TOPIC);
 }
 
 // Domain helpers
@@ -149,7 +152,8 @@ export function getTotalQuestionCount(certSlug: string): number {
 
 export function getTotalFreeQuestionCount(certSlug: string): number {
   const topics = getTopicsForCertification(certSlug);
-  return topics.reduce((sum, topic) => sum + topic.freeQuestionCount, 0);
+  // Free questions: min of FREE_QUESTIONS_PER_TOPIC or topic.questionCount
+  return topics.reduce((sum, topic) => sum + Math.min(FREE_QUESTIONS_PER_TOPIC, topic.questionCount), 0);
 }
 
 // Category helpers


### PR DESCRIPTION
## Changes

### Pricing Tiers
- **$9 for 30-day access** — per certification
- **$49 for lifetime access** — limited time deal, per certification

### Free Questions
- Changed from 5 marked questions to **first 10 questions per topic**
- Simpler logic: `questions.slice(0, 10)`

### UI Updates
- **Certification pages:** Side-by-side pricing cards with "LIMITED TIME" badge on lifetime
- **Free questions page:** Compact two-column pricing
- **Question sidebar:** Stacked buttons for both options

### Backend
- Checkout endpoint accepts `plan: '30day' | 'lifetime'` 
- Webhook stores plan type in KV
- Lifetime access stored without TTL (never expires)

### Screenshots
Certification page pricing section now shows:
```
┌─────────────────┐  ┌─────────────────┐
│  30-Day Access  │  │ Lifetime Access │
│      $9         │  │  $49  ⭐        │
│ [Get 30 Days]   │  │ [Get Lifetime]  │
└─────────────────┘  └─────────────────┘
```