### PR TITLE
fix: Clarify lifetime access includes ALL certifications

### DIFF
--- a/app/[certification]/questions/[topic]/page.tsx
+++ b/app/[certification]/questions/[topic]/page.tsx
@@ -250,7 +250,7 @@ export default async function TopicQuestionsPage({ params }: PageProps) {
 
               {/* CTA */}
               <div className="rounded-xl bg-emerald-600 p-5 text-white dark:bg-emerald-700">
-                <h3 className="font-semibold">Unlock Full {cert.name} Access</h3>
+                <h3 className="font-semibold">Unlock Full Access</h3>
                 <p className="mt-2 text-sm text-emerald-100">
                   All questions with detailed explanations.
                 </p>
@@ -260,14 +260,14 @@ export default async function TopicQuestionsPage({ params }: PageProps) {
                     plan="30day"
                     className="w-full rounded-lg bg-white/20 py-2 text-sm font-medium text-white transition-colors hover:bg-white/30"
                   >
-                    30 Days — $9
+                    {cert.name} 30 Days — $9
                   </CheckoutButton>
                   <CheckoutButton
                     certification={cert.name}
                     plan="lifetime"
                     className="w-full rounded-lg bg-white py-2 text-sm font-medium text-emerald-600 transition-colors hover:bg-emerald-50"
                   >
-                    Lifetime — $49 ⭐
+                    All Certs Lifetime — $49 ⭐
                   </CheckoutButton>
                 </div>
               </div>

--- a/app/certifications/[slug]/page.tsx
+++ b/app/certifications/[slug]/page.tsx
@@ -481,14 +481,15 @@ export default async function CertificationPage({ params }: PageProps) {
                 {/* Lifetime Plan */}
                 <div className="rounded-xl bg-white p-6 text-center relative overflow-hidden">
                   <div className="absolute top-0 right-0 bg-amber-500 text-white text-xs font-bold px-3 py-1 rounded-bl-lg">
-                    LIMITED TIME
+                    BEST VALUE
                   </div>
                   <h3 className="text-lg font-semibold text-emerald-800">Lifetime Access</h3>
                   <div className="mt-4">
                     <span className="text-4xl font-bold text-emerald-700">$49</span>
                   </div>
                   <ul className="mt-6 space-y-2 text-sm text-emerald-700">
-                    <li>✓ All {cert.name} questions</li>
+                    <li className="font-semibold text-emerald-800">✓ ALL certifications included</li>
+                    <li>✓ All practice questions</li>
                     <li>✓ Detailed explanations</li>
                     <li>✓ Practice tests</li>
                     <li className="font-semibold">✓ Lifetime access — never expires</li>

--- a/app/checkout/success/SuccessContent.tsx
+++ b/app/checkout/success/SuccessContent.tsx
@@ -225,12 +225,20 @@ export default function SuccessContent() {
               )}
             </li>
             {isLifetime && (
-              <li className="flex items-start gap-2">
-                <svg className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                </svg>
-                <span><strong>Future updates included</strong></span>
-              </li>
+              <>
+                <li className="flex items-start gap-2">
+                  <svg className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                  <span><strong>All certifications</strong> — CSA, CIS-DF, CAD, CIS-ITSM &amp; more</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <svg className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                  <span><strong>Future updates included</strong></span>
+                </li>
+              </>
             )}
           </ul>
         </div>

--- a/app/free-questions/[cert]/[topic]/page.tsx
+++ b/app/free-questions/[cert]/[topic]/page.tsx
@@ -104,7 +104,7 @@ export default async function FreeQuestionsPage({ params }: Props) {
         name: "How can I access the full question bank?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: `Full access to all ${certification.name} practice questions starts at $9 for 30-day access or $49 for lifetime access. This includes detailed explanations, source references, and comprehensive coverage of all exam topics.`,
+          text: `Full access starts at $9 for 30-day access to ${certification.name}, or $49 for lifetime access to ALL certifications. This includes detailed explanations, source references, and comprehensive coverage of all exam topics.`,
         },
       },
     ],
@@ -217,10 +217,10 @@ export default async function FreeQuestionsPage({ params }: Props) {
             </div>
             <div className="rounded-lg bg-emerald-600 dark:bg-emerald-700 p-4 text-center shadow-sm relative">
               <div className="absolute -top-2 left-1/2 -translate-x-1/2 bg-amber-500 text-white text-xs font-bold px-2 py-0.5 rounded">
-                BEST VALUE
+                ALL CERTS
               </div>
               <div className="text-2xl font-bold text-white">$49</div>
-              <div className="text-sm text-emerald-100">Lifetime access</div>
+              <div className="text-sm text-emerald-100">Lifetime — all certifications</div>
               <CheckoutButton
                 certification={certification.name}
                 plan="lifetime"

--- a/components/QuestionsWithPaywall.tsx
+++ b/components/QuestionsWithPaywall.tsx
@@ -156,7 +156,7 @@ export function QuestionsWithPaywall({
                   plan="lifetime"
                   className="w-full rounded-lg bg-emerald-600 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
                 >
-                  Lifetime — $49 ⭐
+                  Lifetime All Certs — $49 ⭐
                 </CheckoutButton>
               </div>
 

--- a/functions/api/checkout.ts
+++ b/functions/api/checkout.ts
@@ -15,8 +15,8 @@ const PLANS = {
   },
   "lifetime": {
     price: 4900, // $49.00 in cents
-    name: "Lifetime Access (Limited Time)",
-    description: "Lifetime access to all practice questions — never expires",
+    name: "Lifetime Access — All Certifications",
+    description: "Lifetime access to ALL certifications and practice questions — never expires",
   },
 };
 


### PR DESCRIPTION
Updates messaging across the site to make it clear that the $49 lifetime access covers **all** certifications, not just the one you're viewing.

## Changes
- **Stripe checkout**: Product name now "Lifetime Access — All Certifications"
- **Certification pricing cards**: Feature list leads with "✓ ALL certifications included"
- **Paywall component**: Button now says "Lifetime All Certs — $49 ⭐"
- **Free questions page**: Badge says "ALL CERTS" and subtitle "Lifetime — all certifications"
- **Topic sidebar CTA**: Button clarifies "All Certs Lifetime — $49 ⭐"
- **Success page**: Confirms "All certifications — CSA, CIS-DF, CAD, CIS-ITSM & more"
- **FAQ**: Updated to mention all certifications

## Why
Jesse flagged that it wasn't clear lifetime = all certs, not just the cert being viewed.