### PR TITLE
feat: Magic link authentication with Resend

### DIFF
--- a/app/auth/verify/VerifyContent.tsx
+++ b/app/auth/verify/VerifyContent.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { storeAccess } from "@/lib/access";
+import { useAccess } from "@/components/AccessProvider";
+
+type Status = "loading" | "success" | "error" | "expired" | "not-found";
+
+export default function VerifyContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState<Status>("loading");
+  const [error, setError] = useState<string>("");
+  const [email, setEmail] = useState<string>("");
+  const { refresh } = useAccess();
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("error");
+      setError("No login token provided");
+      return;
+    }
+
+    fetch(`/api/auth/verify?token=${encodeURIComponent(token)}`)
+      .then((res) => res.json())
+      .then(async (data) => {
+        if (data.success && data.email && data.expiresAt) {
+          // Store access and refresh the provider
+          storeAccess(data.email, data.expiresAt, data.plan);
+          await refresh();
+          setEmail(data.email);
+          setStatus("success");
+          
+          // Redirect to certifications after 2 seconds
+          setTimeout(() => {
+            router.push("/certifications");
+          }, 2000);
+        } else if (data.error?.includes("expired")) {
+          setStatus("expired");
+          setError(data.error);
+        } else if (data.error?.includes("No active subscription")) {
+          setStatus("not-found");
+          setError(data.error);
+        } else {
+          setStatus("error");
+          setError(data.error || "Verification failed");
+        }
+      })
+      .catch(() => {
+        setStatus("error");
+        setError("Failed to verify login link");
+      });
+  }, [token, refresh, router]);
+
+  if (status === "loading") {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 sm:px-6">
+        <div className="text-center">
+          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-emerald-200 border-t-emerald-600"></div>
+          <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+            Verifying your login...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "success") {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 sm:px-6">
+        <div className="text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900">
+            <svg
+              className="h-8 w-8 text-emerald-600 dark:text-emerald-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+          <h1 className="mt-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            You&apos;re logged in!
+          </h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            Welcome back, <span className="font-medium">{email}</span>
+          </p>
+          <p className="mt-4 text-sm text-zinc-500">
+            Redirecting you to practice questions...
+          </p>
+          <Link
+            href="/certifications"
+            className="mt-6 inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+          >
+            Start Practicing Now
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "expired") {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 sm:px-6">
+        <div className="text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900">
+            <svg
+              className="h-8 w-8 text-amber-600 dark:text-amber-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <h1 className="mt-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            Link Expired
+          </h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            This login link has expired. Please request a new one.
+          </p>
+          <Link
+            href="/"
+            className="mt-6 inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+          >
+            Request New Link
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "not-found") {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 sm:px-6">
+        <div className="text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+            <svg
+              className="h-8 w-8 text-zinc-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
+            </svg>
+          </div>
+          <h1 className="mt-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            No Subscription Found
+          </h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            We couldn&apos;t find an active subscription for this email.
+          </p>
+          <div className="mt-6 flex flex-col gap-3">
+            <Link
+              href="/certifications/csa"
+              className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+            >
+              Get Access — Starting at $9
+            </Link>
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-lg border border-zinc-300 px-6 py-3 font-semibold text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300"
+            >
+              Try Different Email
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  return (
+    <div className="mx-auto max-w-md px-4 py-16 sm:px-6">
+      <div className="text-center">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900">
+          <svg
+            className="h-8 w-8 text-red-600 dark:text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </div>
+        <h1 className="mt-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+          Verification Failed
+        </h1>
+        <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+          {error || "Something went wrong. Please try again."}
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-flex items-center justify-center rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-700"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import { Metadata } from "next";
+import VerifyContent from "./VerifyContent";
+
+export const metadata: Metadata = {
+  title: "Verifying Login | SNReady",
+  description: "Verifying your magic link login.",
+};
+
+function LoadingState() {
+  return (
+    <div className="mx-auto max-w-md px-4 py-16 sm:px-6">
+      <div className="text-center">
+        <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-emerald-200 border-t-emerald-600"></div>
+        <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+          Verifying your login...
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthVerifyPage() {
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <VerifyContent />
+    </Suspense>
+  );
+}

--- a/components/LoginModal.tsx
+++ b/components/LoginModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useAccess } from "./AccessProvider";
 
 interface LoginModalProps {
   isOpen: boolean;
@@ -13,7 +12,7 @@ export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const { login } = useAccess();
+  const [sent, setSent] = useState(false);
 
   if (!isOpen) return null;
 
@@ -22,25 +21,97 @@ export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
     setError("");
     setLoading(true);
 
-    const success = await login(email);
-    setLoading(false);
+    try {
+      const response = await fetch("/api/auth/send-magic-link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
 
-    if (success) {
-      onClose();
-    } else {
-      setError("No active subscription found for this email. Purchase access to continue.");
+      const data = await response.json();
+
+      if (data.success) {
+        setSent(true);
+      } else {
+        setError(data.error || "Failed to send login link");
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
     }
+
+    setLoading(false);
   };
+
+  const handleClose = () => {
+    setEmail("");
+    setError("");
+    setSent(false);
+    onClose();
+  };
+
+  // Success state - email sent
+  if (sent) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="mx-4 w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900">
+          <div className="text-center">
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900">
+              <svg
+                className="h-7 w-7 text-emerald-600 dark:text-emerald-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <h2 className="mt-4 text-xl font-bold text-zinc-900 dark:text-zinc-100">
+              Check Your Email
+            </h2>
+            <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+              We sent a login link to:
+            </p>
+            <p className="mt-1 font-medium text-zinc-900 dark:text-zinc-100">
+              {email}
+            </p>
+            <p className="mt-4 text-sm text-zinc-500">
+              Click the link in the email to log in. The link expires in 15 minutes.
+            </p>
+            <button
+              onClick={handleClose}
+              className="mt-6 w-full rounded-lg border border-zinc-300 py-3 font-semibold text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              Close
+            </button>
+            <button
+              onClick={() => {
+                setSent(false);
+                setEmail("");
+              }}
+              className="mt-2 text-sm text-emerald-600 hover:text-emerald-700"
+            >
+              Try a different email
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="mx-4 w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
-            Access Your Account
+            Log In
           </h2>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className="text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
           >
             <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -50,7 +121,7 @@ export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
         </div>
 
         <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-          Enter the email you used to purchase access.
+          Enter your email and we&apos;ll send you a login link.
         </p>
 
         <form onSubmit={handleSubmit} className="mt-4">
@@ -72,7 +143,7 @@ export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
             disabled={loading}
             className="mt-4 w-full rounded-lg bg-emerald-600 py-3 font-semibold text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
           >
-            {loading ? "Checking..." : "Access My Account"}
+            {loading ? "Sending..." : "Send Login Link"}
           </button>
         </form>
 
@@ -84,7 +155,7 @@ export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
             onClick={onPurchase}
             className="mt-2 w-full rounded-lg border border-emerald-600 py-3 font-semibold text-emerald-600 transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950"
           >
-            Get 30-Day Access — $9
+            Get Access — Starting at $9
           </button>
         </div>
       </div>

--- a/functions/api/auth/send-magic-link.ts
+++ b/functions/api/auth/send-magic-link.ts
@@ -1,0 +1,115 @@
+interface Env {
+  RESEND_API_KEY: string;
+  MAGIC_LINK_SECRET: string;
+  SITE_URL: string;
+  SNREADY_ACCESS: KVNamespace;
+}
+
+// Simple HMAC-like signature using Web Crypto
+async function createToken(email: string, expiresAt: number, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = `${email}:${expiresAt}`;
+  
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(data));
+  const signatureBase64 = btoa(String.fromCharCode(...new Uint8Array(signature)));
+  
+  // Token format: base64(email):expiresAt:signature
+  const emailBase64 = btoa(email);
+  return `${emailBase64}:${expiresAt}:${signatureBase64}`;
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+
+  try {
+    const { email } = await request.json() as { email: string };
+
+    if (!email || !email.includes("@")) {
+      return new Response(
+        JSON.stringify({ error: "Valid email required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Check if this email has access
+    const accessData = await env.SNREADY_ACCESS.get(normalizedEmail);
+    if (!accessData) {
+      return new Response(
+        JSON.stringify({ error: "No active subscription found for this email" }),
+        { status: 404, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Create magic link token (valid for 15 minutes)
+    const expiresAt = Date.now() + 15 * 60 * 1000;
+    const token = await createToken(normalizedEmail, expiresAt, env.MAGIC_LINK_SECRET);
+    
+    const magicLink = `${env.SITE_URL}/auth/verify?token=${encodeURIComponent(token)}`;
+
+    // Send email via Resend
+    const resendResponse = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${env.RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "SNReady <login@snready.com>",
+        to: normalizedEmail,
+        subject: "Your SNReady Login Link",
+        html: `
+          <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h1 style="color: #059669; margin-bottom: 24px;">SNReady</h1>
+            <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+              Click the button below to log in to your SNReady account:
+            </p>
+            <div style="margin: 32px 0;">
+              <a href="${magicLink}" 
+                 style="background-color: #059669; color: white; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; display: inline-block;">
+                Log in to SNReady
+              </a>
+            </div>
+            <p style="font-size: 14px; color: #6b7280; line-height: 1.6;">
+              This link expires in 15 minutes. If you didn't request this, you can safely ignore this email.
+            </p>
+            <p style="font-size: 14px; color: #6b7280; margin-top: 24px;">
+              Or copy this link: <br/>
+              <a href="${magicLink}" style="color: #059669; word-break: break-all;">${magicLink}</a>
+            </p>
+          </div>
+        `,
+        text: `Log in to SNReady\n\nClick this link to log in: ${magicLink}\n\nThis link expires in 15 minutes.`,
+      }),
+    });
+
+    if (!resendResponse.ok) {
+      const errorData = await resendResponse.text();
+      console.error("Resend error:", errorData);
+      return new Response(
+        JSON.stringify({ error: "Failed to send email" }),
+        { status: 500, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, message: "Magic link sent" }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  } catch (error) {
+    console.error("Magic link error:", error);
+    return new Response(
+      JSON.stringify({ error: "Failed to send magic link" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};

--- a/functions/api/auth/verify.ts
+++ b/functions/api/auth/verify.ts
@@ -1,0 +1,96 @@
+interface Env {
+  MAGIC_LINK_SECRET: string;
+  SNREADY_ACCESS: KVNamespace;
+}
+
+// Verify HMAC signature
+async function verifyToken(token: string, secret: string): Promise<{ valid: boolean; email?: string; error?: string }> {
+  try {
+    const parts = token.split(":");
+    if (parts.length !== 3) {
+      return { valid: false, error: "Invalid token format" };
+    }
+
+    const [emailBase64, expiresAtStr, signatureBase64] = parts;
+    const email = atob(emailBase64);
+    const expiresAt = parseInt(expiresAtStr, 10);
+
+    // Check expiration
+    if (Date.now() > expiresAt) {
+      return { valid: false, error: "Link has expired" };
+    }
+
+    // Verify signature
+    const encoder = new TextEncoder();
+    const data = `${email}:${expiresAt}`;
+    
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"]
+    );
+
+    const signature = Uint8Array.from(atob(signatureBase64), c => c.charCodeAt(0));
+    const isValid = await crypto.subtle.verify("HMAC", key, signature, encoder.encode(data));
+
+    if (!isValid) {
+      return { valid: false, error: "Invalid signature" };
+    }
+
+    return { valid: true, email };
+  } catch (error) {
+    console.error("Token verification error:", error);
+    return { valid: false, error: "Invalid token" };
+  }
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const { request, env } = context;
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+
+  if (!token) {
+    return new Response(
+      JSON.stringify({ error: "Token required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const result = await verifyToken(token, env.MAGIC_LINK_SECRET);
+
+  if (!result.valid || !result.email) {
+    return new Response(
+      JSON.stringify({ error: result.error || "Invalid token" }),
+      { status: 401, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Get access data from KV
+  const accessData = await env.SNREADY_ACCESS.get(result.email);
+  if (!accessData) {
+    return new Response(
+      JSON.stringify({ error: "No active subscription found" }),
+      { status: 404, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  try {
+    const access = JSON.parse(accessData);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        email: result.email,
+        expiresAt: access.expiresAt,
+        plan: access.plan,
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Invalid access data" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};


### PR DESCRIPTION
Replaces email-only login with secure magic links.

## Flow
1. User clicks 'Log in' → enters email
2. System sends magic link email via Resend
3. User clicks link → verified and logged in
4. Auto-redirects to /certifications

## New endpoints
- `POST /api/auth/send-magic-link` - sends email
- `GET /api/auth/verify` - verifies token

## Security
- HMAC-SHA256 signed tokens
- 15-minute expiration
- Only sends link if email has active subscription

## Required env vars (Cloudflare Pages)
```
RESEND_API_KEY=re_xxx
MAGIC_LINK_SECRET=<random-32-char-string>
SITE_URL=https://snready.com
```

## Resend setup
1. Create account at resend.com
2. Add domain `snready.com` and verify DNS
3. Create API key
4. Add to Cloudflare env vars