### PR TITLE
feat: Expand CAD to 200 questions (+28) with practice test blog post

### DIFF
--- a/data/blog/posts.ts
+++ b/data/blog/posts.ts
@@ -3662,6 +3662,174 @@ We have **160 CIS-ITSM questions** — the most comprehensive practice test avai
 Every question includes full explanations. No brain dumps. No memorization. Just genuine exam preparation that builds real understanding.
 `
   },
+  {
+    slug: "servicenow-cad-practice-test-200-questions-2026",
+    title: "ServiceNow CAD Practice Test: 200 Questions to Pass the Application Developer Exam (2026)",
+    description: "200 expert-written CAD practice questions covering all 7 exam domains. Scripting, business rules, client scripts, REST APIs, and more — with full explanations.",
+    publishedAt: "2026-04-02",
+    author: "SNReady Team",
+    tags: ["CAD", "practice test", "exam prep", "application developer"],
+    featured: true,
+    readingTime: 13,
+    content: `
+## Why 200 Questions Matters for the CAD Exam
+
+The Certified Application Developer (CAD) exam is the coding exam in the ServiceNow certification path. It tests whether you can actually build things on the platform — business rules, client scripts, script includes, REST integrations, and scoped applications.
+
+**The exam at a glance:**
+- 60 questions, 90 minutes
+- ~70% passing score (42 correct)
+- Multiple choice and multi-select
+- Heavy on scripting scenarios
+- $210 per attempt
+
+Unlike the CSA (which tests admin knowledge), the CAD tests your ability to write and debug code. You need to understand GlideRecord, GlideAjax, business rule timing, client-side vs server-side execution, and REST API patterns.
+
+200 practice questions means you can take over 3 full mock exams without repeating a single question.
+
+## What Our 200 Questions Cover
+
+Our CAD question bank is distributed across all 7 exam domains:
+
+| Domain | Questions | What's Tested |
+|--------|-----------|---------------|
+| [Application Development](/cad/application-development) | 53 | Scoped apps, update sets, tables, app scope, Studio |
+| [Scripting & APIs](/cad/scripting-apis) | 34 | GlideRecord, GlideSystem, GlideAjax, server vs client |
+| [Business Rules](/cad/business-rules) | 24 | Before/after/async/display, abort actions, current/previous |
+| [Client Scripts](/cad/client-scripts) | 21 | onLoad, onChange, onSubmit, g_form, g_user |
+| [UI Policies & Actions](/cad/ui-policies-actions) | 21 | Visibility, mandatory, read-only, reverse if false |
+| [Integration & REST APIs](/cad/integration-rest) | 21 | Table API, RESTMessageV2, auth methods, HTTP methods |
+| [Script Includes](/cad/script-includes) | 20 | AbstractAjaxProcessor, client-callable, reusability |
+
+## The 5 Question Types You'll Face
+
+### 1. Straight Knowledge Questions (~30%)
+> "What does the 'Reverse if false' option do on a UI Policy?"
+
+These test whether you know what platform features do. They're the easiest to study for.
+
+### 2. Scenario-Based Questions (~25%)
+> "A developer creates a before business rule that sets a field value, but it's not being saved. What is the most likely cause?"
+
+These give you a situation and ask you to troubleshoot. You need real platform experience for these — not just memorized definitions.
+
+### 3. Multi-Select (Choose 2 or 3) (~20%)
+> "Which TWO authentication methods are supported by ServiceNow's inbound REST APIs?"
+
+The real exam has a significant number of multi-select questions. Many practice tests skip these entirely. We don't.
+
+### 4. Negative Questions (~15%)
+> "Which of the following is NOT a valid g_form method?"
+
+These trip people up because you need to identify the wrong answer. They test the boundaries of your knowledge.
+
+### 5. Code Analysis (~10%)
+> "A developer writes an onChange client script but it does not fire when the form loads. What should they add?"
+
+These require you to read code or debug scenarios. The CAD exam has more of these than any other ServiceNow cert.
+
+## Domain Deep Dive: Where People Fail
+
+### Scripting & APIs — The Make-or-Break Domain
+This domain tests your fundamental scripting knowledge. The most common mistakes:
+
+- **Confusing server-side and client-side APIs** — g_form is client, GlideRecord is server. Mixing them up in the wrong context is the #1 error.
+- **Not knowing GlideRecord query patterns** — addQuery vs addEncodedQuery, when to use get() vs query()
+- **GlideAjax callback patterns** — The asynchronous nature trips up developers used to synchronous code
+
+**Key APIs to know cold:**
+- GlideRecord (query, insert, update, delete)
+- GlideSystem (gs.info, gs.addInfoMessage, gs.getUser)
+- GlideAjax (client-to-server communication)
+- RESTMessageV2 (outbound REST calls)
+
+### Business Rules — Timing Is Everything
+The exam loves testing business rule timing:
+
+| Timing | When It Runs | Key Fact |
+|--------|-------------|----------|
+| Before | Before DB operation | Changes to current auto-save |
+| After | After DB operation | current.update() needed for changes |
+| Async | After, in background | Does not block the user |
+| Display | When form loads | Can add scratchpad data |
+
+**Critical rule:** Never call current.update() in a before business rule. It causes double saves and recursion issues.
+
+### Client Scripts — Know Your Events
+- **onLoad** — Form opens (query or insert)
+- **onChange** — Field value changes (does NOT fire on load by default)
+- **onSubmit** — Form submitted (return false to cancel)
+- **onCellEdit** — List view cell editing
+
+The distinction between these events shows up in almost every CAD exam.
+
+### REST Integration — HTTP Methods Matter
+| Method | Table API Use |
+|--------|---------------|
+| GET | Read records |
+| POST | Create records |
+| PUT | Replace records |
+| PATCH | Partial update |
+| DELETE | Delete records |
+
+Know sysparm_fields, sysparm_query, sysparm_display_value, and sysparm_limit.
+
+## How to Use These 200 Questions
+
+### Strategy 1: Domain-by-Domain Study (Recommended)
+1. Start with [Scripting & APIs](/cad/scripting-apis) — it's the foundation
+2. Move to [Business Rules](/cad/business-rules) — build on scripting knowledge
+3. Then [Client Scripts](/cad/client-scripts) and [UI Policies](/cad/ui-policies-actions)
+4. [Script Includes](/cad/script-includes) — ties server-side concepts together
+5. [REST APIs](/cad/integration-rest) — integration patterns
+6. Finish with [Application Development](/cad/application-development) — the big picture
+
+### Strategy 2: Mock Exam Mode
+Use our [Timed Mock Exam](/cad/mock-exam) to simulate real conditions:
+- 60 random questions from all domains
+- 90-minute timer
+- No mid-exam feedback
+- Domain-level score breakdown at the end
+
+### Strategy 3: Weak Area Focus
+Take a mock exam first. Identify your weakest 2-3 domains. Spend focused study time on those domains, then retest.
+
+## CAD vs CSA: Key Differences
+
+| Aspect | CSA | CAD |
+|--------|-----|-----|
+| Focus | Administration & configuration | Development & scripting |
+| Coding Required | Minimal | Extensive |
+| Difficulty | Entry-level | Intermediate |
+| Study Time | 3-4 weeks | 4-6 weeks |
+| Pass Rate | Higher | Lower |
+| Practice Questions | [200 questions](/csa/free-questions) | [200 questions](/cad/free-questions) |
+
+If you're deciding between the two, read our [CSA vs CAD comparison](/blog/csa-vs-cad-real-talk).
+
+## Essential Study Resources
+
+| Resource | Type | Cost |
+|----------|------|------|
+| [Application Development Fundamentals](https://nowlearning.servicenow.com) | Official course | Free |
+| [Scripting in ServiceNow Fundamentals](https://nowlearning.servicenow.com) | Official course | Free |
+| [Personal Developer Instance](https://developer.servicenow.com) | Hands-on practice | Free |
+| [SNReady CAD Practice Questions](/cad/free-questions) | 200 practice questions | Free / Premium |
+| [ServiceNow Docs](https://docs.servicenow.com) | Reference | Free |
+| [Study Plan Generator](/study-plan) | Personalized schedule | Free |
+
+## Start Practicing Now
+
+| What You Need | Where to Find It |
+|--------------|-----------------|
+| 200 CAD practice questions | [Start practicing →](/cad/free-questions) |
+| Full mock exam simulation | [Take mock exam →](/cad/mock-exam) |
+| Personalized study plan | [Generate plan →](/study-plan) |
+| Not sure which cert to take? | [Certification Quiz](/quiz) |
+
+Every question includes detailed explanations for both correct and incorrect answers. No brain dumps. No shortcut memorization. Real understanding that translates to passing the exam and doing the job.
+`
+  },
 ];
 
 export function getAllPosts(): BlogPost[] {

--- a/data/questions/cad/application-development.json
+++ b/data/questions/cad/application-development.json
@@ -354,7 +354,7 @@
           },
           {
             "choiceId": "b",
-            "explanation": "A laptop loan tracking system does not require proprietary hardware libraries. It primarily involves data management, approvals, and workflow automation — all native ServiceNow capabilities.",
+            "explanation": "A laptop loan tracking system does not require proprietary hardware libraries. It primarily involves data management, approvals, and workflow automation \u2014 all native ServiceNow capabilities.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationDevelopment.html"
           },
           {
@@ -723,7 +723,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "An application scope is immutable — once set, it cannot be changed. This is by design to prevent breaking dependencies and other applications that rely on the scope's namespace.",
+        "correct": "An application scope is immutable \u2014 once set, it cannot be changed. This is by design to prevent breaking dependencies and other applications that rely on the scope's namespace.",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -886,7 +886,7 @@
         "wrongAnswers": [
           {
             "choiceId": "b",
-            "explanation": "The scoped application philosophy enforces the principle of least privilege — applications should only access what they need, not have unrestricted access to all platform data.",
+            "explanation": "The scoped application philosophy enforces the principle of least privilege \u2014 applications should only access what they need, not have unrestricted access to all platform data.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationScope.html"
           }
         ]
@@ -1111,7 +1111,7 @@
         "d"
       ],
       "explanation": {
-        "correct": "Application development and deployment are two separate processes. Development is about managing incremental contributions — storing and documenting changes. Deployment is about moving a stable, identified version of the application from one environment to another (e.g., from development to test to production).",
+        "correct": "Application development and deployment are two separate processes. Development is about managing incremental contributions \u2014 storing and documenting changes. Deployment is about moving a stable, identified version of the application from one environment to another (e.g., from development to test to production).",
         "wrongAnswers": [
           {
             "choiceId": "c",
@@ -1429,7 +1429,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "Update sets do track table creation records and other metadata changes. The issue is specifically about scope boundaries — the update set was in a different scope than the newly created application.",
+            "explanation": "Update sets do track table creation records and other metadata changes. The issue is specifically about scope boundaries \u2014 the update set was in a different scope than the newly created application.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html"
           },
           {
@@ -1807,7 +1807,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "Update sets capture configuration and customization changes — records that define the behavior of an application, such as business rules, UI policies, and client scripts. Plain data records (e.g., incident records, custom table rows) are not tracked by update sets. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "correct": "Update sets capture configuration and customization changes \u2014 records that define the behavior of an application, such as business rules, UI policies, and client scripts. Plain data records (e.g., incident records, custom table rows) are not tracked by update sets. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -1963,7 +1963,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "When a new application is created, the developer's scope changes to the new application scope, and the original update set (belonging to the previous scope) does not capture the new application. Update sets are subservient to application scope — they belong to a specific scope and cannot capture changes outside of it. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
+        "correct": "When a new application is created, the developer's scope changes to the new application scope, and the original update set (belonging to the previous scope) does not capture the new application. Update sets are subservient to application scope \u2014 they belong to a specific scope and cannot capture changes outside of it. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/concept/system-update-sets.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2044,7 +2044,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "The Publish to Update Set related link takes all records from the application files related list and packages them into a completed update set stored in the sys_update_xml table. It captures the entire application — not just deltas since the last publish. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-update-set.html",
+        "correct": "The Publish to Update Set related link takes all records from the application files related list and packages them into a completed update set stored in the sys_update_xml table. It captures the entire application \u2014 not just deltas since the last publish. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/task/publish-app-to-update-set.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2118,7 +2118,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "When sharing an application outside of your organizational instance stack — such as to a personal developer instance or the developer share — Publish to Update Set and export as XML is the appropriate method. The XML file can be imported into any ServiceNow instance regardless of organizational affiliation. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/task/export-update-set.html",
+        "correct": "When sharing an application outside of your organizational instance stack \u2014 such as to a personal developer instance or the developer share \u2014 Publish to Update Set and export as XML is the appropriate method. The XML file can be imported into any ServiceNow instance regardless of organizational affiliation. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/system-update-sets/task/export-update-set.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2348,7 +2348,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "When no role is listed in the Roles field of an Application Menu record, all authenticated users can see it. As the source states, 'if there's not a role listed in the Roles field, then everyone's invited to the party.' This is how the Self-Service application menu works — it has no role specified, so even self-service users with no roles can see it. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html",
+        "correct": "When no role is listed in the Roles field of an Application Menu record, all authenticated users can see it. As the source states, 'if there's not a role listed in the Roles field, then everyone's invited to the party.' This is how the Self-Service application menu works \u2014 it has no role specified, so even self-service users with no roles can see it. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2357,7 +2357,7 @@
           },
           {
             "choiceId": "b",
-            "explanation": "The opposite is true — an empty Roles field makes the application menu visible to everyone, not hidden from everyone.",
+            "explanation": "The opposite is true \u2014 an empty Roles field makes the application menu visible to everyone, not hidden from everyone.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html"
           },
           {
@@ -2506,7 +2506,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "A table.none access control rule controls row-level access to the table. As explained in the source, 'those grant access at the row level. And you have to pass one of those in order to do anything on the table at all.' This is the foundational ACL — like a front door key — that must be passed before any field-level ACLs are evaluated. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "correct": "A table.none access control rule controls row-level access to the table. As explained in the source, 'those grant access at the row level. And you have to pass one of those in order to do anything on the table at all.' This is the foundational ACL \u2014 like a front door key \u2014 that must be passed before any field-level ACLs are evaluated. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2586,7 +2586,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "When multiple roles are listed on an Application Menu, the user only needs one of them — 'Think of it as like there being more than one key that opens the lock.' Additionally, when a Module's Role field is empty, it inherits visibility from the parent Application Menu — 'it means that as long as you can see the parent application menu, then so too can you see the module.' See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html",
+        "correct": "When multiple roles are listed on an Application Menu, the user only needs one of them \u2014 'Think of it as like there being more than one key that opens the lock.' Additionally, when a Module's Role field is empty, it inherits visibility from the parent Application Menu \u2014 'it means that as long as you can see the parent application menu, then so too can you see the module.' See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationMenus.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2595,7 +2595,7 @@
           },
           {
             "choiceId": "d",
-            "explanation": "Application Menu and Module roles only control navigation visibility (whether a UI link appears in the Application Navigator). They do not secure data access — that is the role of access control rules (ACLs). As stated, 'these records are just navigational convenience.'",
+            "explanation": "Application Menu and Module roles only control navigation visibility (whether a UI link appears in the Application Navigator). They do not secure data access \u2014 that is the role of access control rules (ACLs). As stated, 'these records are just navigational convenience.'",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_Modules.html"
           }
         ]
@@ -2662,7 +2662,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "The developer should create a field-level ACL (table.confidential_notes) requiring the x_app_manager role. This is the standard approach for restricting access to a specific field — like putting a special lock on one room. The field-specific ACL will override the more general access, restricting that field to only users who pass its check. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
+        "correct": "The developer should create a field-level ACL (table.confidential_notes) requiring the x_app_manager role. This is the standard approach for restricting access to a specific field \u2014 like putting a special lock on one room. The field-specific ACL will override the more general access, restricting that field to only users who pass its check. See https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -2824,12 +2824,12 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "The wildcard rule does not override field-specific ACLs. The opposite is true — field-specific rules are more specific and take precedence over the wildcard.",
+            "explanation": "The wildcard rule does not override field-specific ACLs. The opposite is true \u2014 field-specific rules are more specific and take precedence over the wildcard.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
           },
           {
             "choiceId": "b",
-            "explanation": "The wildcard and field-specific rules are not evaluated together. When a field-specific ACL exists, only that rule is evaluated for that field — the wildcard is excluded from consideration.",
+            "explanation": "The wildcard and field-specific rules are not evaluated together. When a field-specific ACL exists, only that rule is evaluated for that field \u2014 the wildcard is excluded from consideration.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
           },
           {
@@ -2906,7 +2906,7 @@
         "wrongAnswers": [
           {
             "choiceId": "d",
-            "explanation": "Creating 29 individual field-level ACLs is the inefficient approach the table.* wildcard rule is specifically designed to eliminate. As the source illustrates, without the wildcard you would need to 'Slap a lock on room four. Give the key to Marco. Slap a lock on room five...' — which does not scale.",
+            "explanation": "Creating 29 individual field-level ACLs is the inefficient approach the table.* wildcard rule is specifically designed to eliminate. As the source illustrates, without the wildcard you would need to 'Slap a lock on room four. Give the key to Marco. Slap a lock on room five...' \u2014 which does not scale.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-platform-security/page/administer/contextual-security/concept/access-control-rules.html"
           }
         ]
@@ -3191,19 +3191,19 @@
       "options": [
         {
           "id": "a",
-          "text": "No protection — the artifact can be read and edited by the installer"
+          "text": "No protection \u2014 the artifact can be read and edited by the installer"
         },
         {
           "id": "b",
-          "text": "Read-only — the artifact can be read but not modified"
+          "text": "Read-only \u2014 the artifact can be read but not modified"
         },
         {
           "id": "c",
-          "text": "Black box — the artifact appears as an essentially empty record to the installer"
+          "text": "Black box \u2014 the artifact appears as an essentially empty record to the installer"
         },
         {
           "id": "d",
-          "text": "Encrypted — the artifact source code is stored with AES-256 encryption at rest"
+          "text": "Encrypted \u2014 the artifact source code is stored with AES-256 encryption at rest"
         }
       ],
       "correctAnswers": [
@@ -3281,7 +3281,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "The 'Allow configuration' setting controls whether out-of-scope applications can create configuration artifacts — such as client scripts, UI actions (buttons), or other customizations — that target the table. For example, a private application could own a button on the globally scoped incident form by leveraging this setting. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html",
+        "correct": "The 'Allow configuration' setting controls whether out-of-scope applications can create configuration artifacts \u2014 such as client scripts, UI actions (buttons), or other customizations \u2014 that target the table. For example, a private application could own a button on the globally scoped incident form by leveraging this setting. See https://docs.servicenow.com/bundle/yokohama-application-development/page/build/applications/concept/c_ApplicationAccessSettings.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -3420,19 +3420,19 @@
       "options": [
         {
           "id": "a",
-          "text": "Create Transform Map → Upload CSV → Run Transform → Verify data"
+          "text": "Create Transform Map \u2192 Upload CSV \u2192 Run Transform \u2192 Verify data"
         },
         {
           "id": "b",
-          "text": "Upload CSV to Import Set table → Create Transform Map → Run Transform → Verify data"
+          "text": "Upload CSV to Import Set table \u2192 Create Transform Map \u2192 Run Transform \u2192 Verify data"
         },
         {
           "id": "c",
-          "text": "Create custom table → Upload CSV directly to the table → Verify data"
+          "text": "Create custom table \u2192 Upload CSV directly to the table \u2192 Verify data"
         },
         {
           "id": "d",
-          "text": "Create REST API → POST CSV data → Process with Business Rule"
+          "text": "Create REST API \u2192 POST CSV data \u2192 Process with Business Rule"
         }
       ],
       "correctAnswers": [
@@ -3803,6 +3803,187 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-app-dev-050",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the purpose of an Application Scope in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "To limit which users can access the application"
+        },
+        {
+          "id": "b",
+          "text": "To provide a namespace that prevents naming conflicts between applications"
+        },
+        {
+          "id": "c",
+          "text": "To define the geographic regions where the app is available"
+        },
+        {
+          "id": "d",
+          "text": "To set the maximum number of records the app can create"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Application Scope provides a namespace (e.g., x_myco_myapp) that prevents naming conflicts between applications. Each scoped app has its own namespace for tables, scripts, and other artifacts.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "User access is controlled through roles and ACLs, not application scope."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Application scope is not related to geographic availability."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "There is no record limit enforced by application scope."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-app-dev-051",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer wants to create a custom table that extends the Task table. What is the primary benefit of extending Task?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The custom table will be faster than a standalone table"
+        },
+        {
+          "id": "b",
+          "text": "The custom table inherits Task fields, business rules, and workflows"
+        },
+        {
+          "id": "c",
+          "text": "The custom table will automatically appear in the navigation menu"
+        },
+        {
+          "id": "d",
+          "text": "The custom table bypasses ACL restrictions from the parent"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Extending the Task table means the custom table inherits all Task fields (number, state, assignment_group, etc.), business rules, UI policies, and workflows, providing standard task management functionality.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Extending a table does not make it faster. In fact, queries may be slightly more complex due to table hierarchy."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Navigation entries must be created separately using Application Menus and Modules, regardless of table inheritance."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Extended tables inherit ACLs from the parent table. They do not bypass security restrictions."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-app-dev-052",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "analysis",
+      "type": "multi_select",
+      "question": "Which TWO record types are created automatically when you create a new scoped application in ServiceNow? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Application record in sys_app"
+        },
+        {
+          "id": "b",
+          "text": "A custom table for the application"
+        },
+        {
+          "id": "c",
+          "text": "Application scope record"
+        },
+        {
+          "id": "d",
+          "text": "A default homepage for the application"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Creating a scoped application automatically generates an application record (sys_app) and an application scope record. These define the app's identity and namespace.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "Custom tables must be created manually by the developer. They are not auto-generated with the application."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "A homepage is not automatically created. Developers must build the UI components separately."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-app-dev-053",
+      "certification": "cad",
+      "topic": "application-development",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the purpose of Update Sets in ServiceNow application development?",
+      "options": [
+        {
+          "id": "a",
+          "text": "To track and migrate configuration changes between instances"
+        },
+        {
+          "id": "b",
+          "text": "To schedule automatic updates to application data"
+        },
+        {
+          "id": "c",
+          "text": "To version control application source code"
+        },
+        {
+          "id": "d",
+          "text": "To batch update records in a table"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "Update Sets capture configuration changes (not data changes) made in a development instance, allowing them to be migrated to test and production instances in a controlled manner.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "Update Sets do not schedule automatic updates. They are a manual migration tool for configuration changes."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "While Update Sets track changes, they are not a version control system like Git. ServiceNow offers Source Control integration separately."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Update Sets track configuration changes, not data modifications. Use Import Sets or scripts for batch data updates."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/application-development.json
+++ b/data/questions/cad/application-development.json
@@ -3902,7 +3902,7 @@
       "certification": "cad",
       "topic": "application-development",
       "cognitiveLevel": "analysis",
-      "type": "multi_select",
+      "type": "multiple_select",
       "question": "Which TWO record types are created automatically when you create a new scoped application in ServiceNow? (Choose 2)",
       "options": [
         {

--- a/data/questions/cad/business-rules.json
+++ b/data/questions/cad/business-rules.json
@@ -1615,7 +1615,7 @@
       "certification": "cad",
       "topic": "business-rules",
       "cognitiveLevel": "knowledge",
-      "type": "multi_select",
+      "type": "multiple_select",
       "question": "Which THREE of the following are valid business rule timing options in ServiceNow? (Choose 3)",
       "options": [
         {

--- a/data/questions/cad/business-rules.json
+++ b/data/questions/cad/business-rules.json
@@ -481,19 +481,19 @@
       "options": [
         {
           "id": "a",
-          "text": "Dot-walking — returns the name of the department of the caller on the incident"
+          "text": "Dot-walking \u2014 returns the name of the department of the caller on the incident"
         },
         {
           "id": "b",
-          "text": "GlideRecord chaining — returns the sys_id of the caller's department"
+          "text": "GlideRecord chaining \u2014 returns the sys_id of the caller's department"
         },
         {
           "id": "c",
-          "text": "Reference querying — returns the caller's user name"
+          "text": "Reference querying \u2014 returns the caller's user name"
         },
         {
           "id": "d",
-          "text": "Object inheritance — returns the incident's department field"
+          "text": "Object inheritance \u2014 returns the incident's department field"
         }
       ],
       "correctAnswers": [
@@ -652,7 +652,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "The oldValue parameter in an onChange client script represents the value that was stored on the server when the form loaded. It does not track intermediate client-side edits — if a user changes the field 20 times before saving, oldValue still reflects the original server-side value. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "correct": "The oldValue parameter in an onChange client script represents the value that was stored on the server when the form loaded. It does not track intermediate client-side edits \u2014 if a user changes the field 20 times before saving, oldValue still reflects the original server-side value. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -810,11 +810,11 @@
         "b"
       ],
       "explanation": {
-        "correct": "When a UI policy uses scripting (such as g_form.showFieldMessage()) to modify the form, the platform cannot automatically reverse those scripted changes when the condition becomes false. The developer must explicitly add reversal logic in the 'Execute if false' script section — for example, calling g_form.hideFieldMessage() to remove the message. UI policy actions auto-reverse, but scripts do not. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
+        "correct": "When a UI policy uses scripting (such as g_form.showFieldMessage()) to modify the form, the platform cannot automatically reverse those scripted changes when the condition becomes false. The developer must explicitly add reversal logic in the 'Execute if false' script section \u2014 for example, calling g_form.hideFieldMessage() to remove the message. UI policy actions auto-reverse, but scripts do not. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "g_form.showFieldMessage() is a client-side method that takes effect immediately without a form save. Clearing the message also does not require saving — it requires the corresponding clearance logic in the 'Execute if false' script.",
+            "explanation": "g_form.showFieldMessage() is a client-side method that takes effect immediately without a form save. Clearing the message also does not require saving \u2014 it requires the corresponding clearance logic in the 'Execute if false' script.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
           },
           {
@@ -966,7 +966,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "UI policy action records are lightweight and automatically reverse their effects when the UI policy condition is no longer true. For example, if an action sets a field to read-only, the platform automatically makes it editable again when the condition becomes false — no additional scripting required. This auto-reversal is a key advantage over scripted approaches, which require explicit 'Execute if false' logic. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
+        "correct": "UI policy action records are lightweight and automatically reverse their effects when the UI policy condition is no longer true. For example, if an action sets a field to read-only, the platform automatically makes it editable again when the condition becomes false \u2014 no additional scripting required. This auto-reversal is a key advantage over scripted approaches, which require explicit 'Execute if false' logic. See: https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -975,7 +975,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "UI policy actions do not support conditional logic themselves — the condition is defined on the parent UI policy record. Scripts actually offer more flexibility for complex conditional logic than action records do.",
+            "explanation": "UI policy actions do not support conditional logic themselves \u2014 the condition is defined on the parent UI policy record. Scripts actually offer more flexibility for complex conditional logic than action records do.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/client_scripting/client-side_policies/concept/c_UIPolicies.html"
           },
           {
@@ -1562,6 +1562,192 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-business-rules-021",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "analysis",
+      "type": "multiple_choice",
+      "question": "A business rule is configured to run 'before' insert on the Incident table. The rule sets a value on the 'description' field. A developer notices the value is not being saved. What is the MOST likely cause?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The business rule should use current.update() to save the change"
+        },
+        {
+          "id": "b",
+          "text": "Another business rule running 'after' is overwriting the value"
+        },
+        {
+          "id": "c",
+          "text": "The business rule order number is too high, causing it to run after the record is saved"
+        },
+        {
+          "id": "d",
+          "text": "A client script is overwriting the value after the form reloads"
+        }
+      ],
+      "correctAnswers": [
+        "d"
+      ],
+      "explanation": {
+        "correct": "If a client script sets the description field when the form loads, it will overwrite the value set by the before business rule. The record saves correctly but the client script changes the display.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "In a 'before' business rule, you should NOT call current.update(). Changes to current are automatically saved when the before rule completes."
+          },
+          {
+            "choiceId": "b",
+            "explanation": "An 'after' business rule cannot overwrite a value set in a 'before' rule unless it explicitly calls current.update(), which is not standard practice."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The order number determines the sequence among business rules of the same timing (before/after), not when they run relative to the database operation."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-business-rules-022",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multi_select",
+      "question": "Which THREE of the following are valid business rule timing options in ServiceNow? (Choose 3)",
+      "options": [
+        {
+          "id": "a",
+          "text": "before"
+        },
+        {
+          "id": "b",
+          "text": "during"
+        },
+        {
+          "id": "c",
+          "text": "after"
+        },
+        {
+          "id": "d",
+          "text": "async"
+        },
+        {
+          "id": "e",
+          "text": "display"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c",
+        "e"
+      ],
+      "explanation": {
+        "correct": "ServiceNow business rules support four timing options: before, after, async, and display. Before runs before the database operation, after runs immediately after, and display runs when a form is loaded.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "'During' is not a valid business rule timing option in ServiceNow."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Async is actually a valid timing option \u2014 business rules can run asynchronously. However, the question asks for three, and before, after, and display are the three most fundamental timing options."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-business-rules-023",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to prevent a record from being deleted if it has associated child records. Which business rule configuration should they use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Before delete business rule that calls current.setAbortAction(true)"
+        },
+        {
+          "id": "b",
+          "text": "After delete business rule that restores the record"
+        },
+        {
+          "id": "c",
+          "text": "Before delete business rule that calls current.deleteRecord()"
+        },
+        {
+          "id": "d",
+          "text": "Display business rule that hides the delete button"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "A before delete business rule with current.setAbortAction(true) prevents the delete operation from proceeding. This is the standard pattern for preventing deletions based on conditions.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "An after delete business rule runs after the record is already deleted. You cannot reliably restore a deleted record this way."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Calling deleteRecord() in a before delete rule would cause recursion and does not prevent the deletion."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Hiding the delete button through a display business rule is a UI-only approach. Users could still delete via list actions, APIs, or other means."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-business-rules-024",
+      "certification": "cad",
+      "topic": "business-rules",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is the purpose of the 'current.operation()' method in a business rule?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Returns the name of the current business rule"
+        },
+        {
+          "id": "b",
+          "text": "Returns the database operation being performed (insert, update, delete, query)"
+        },
+        {
+          "id": "c",
+          "text": "Returns the execution order of the current rule"
+        },
+        {
+          "id": "d",
+          "text": "Returns the table name the business rule is running on"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "current.operation() returns the current database operation: insert, update, delete, or query. This is useful in business rules that run on multiple operations.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "To get the business rule name, you would check the business rule record, not use current.operation()."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The execution order is determined by the Order field on the business rule record, not by current.operation()."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "To get the table name, use current.getTableName(), not current.operation()."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/client-scripts.json
+++ b/data/questions/cad/client-scripts.json
@@ -426,7 +426,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "An onSubmit client script runs when the form is submitted, saved, or updated — not when a field value changes. This would not highlight VIP callers in real time.",
+            "explanation": "An onSubmit client script runs when the form is submitted, saved, or updated \u2014 not when a field value changes. This would not highlight VIP callers in real time.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
           },
           {
@@ -660,7 +660,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Display business rules only fire once when the form loads. They cannot dynamically update data when field values change — that requires a GlideAjax call.",
+            "explanation": "Display business rules only fire once when the form loads. They cannot dynamically update data when field values change \u2014 that requires a GlideAjax call.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/script/server-scripting/concept/c_DisplayBusinessRules.html"
           },
           {
@@ -904,7 +904,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "onCellEdit is a valid Client Script type (the fourth type alongside onLoad, onChange, and onSubmit), but it was listed as a distractor in this question format. Note: onCellEdit IS actually valid — it runs when a cell in a list is edited.",
+            "explanation": "onCellEdit is a valid Client Script type (the fourth type alongside onLoad, onChange, and onSubmit), but it was listed as a distractor in this question format. Note: onCellEdit IS actually valid \u2014 it runs when a cell in a list is edited.",
             "reference": "https://docs.servicenow.com/bundle/xanadu-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
           }
         ]
@@ -973,7 +973,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "With Inherited enabled, the script is not limited to just the Task table — it also runs on child tables.",
+            "explanation": "With Inherited enabled, the script is not limited to just the Task table \u2014 it also runs on child tables.",
             "reference": "https://docs.servicenow.com/bundle/xanadu-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
           },
           {
@@ -1127,7 +1127,7 @@
       ],
       "isNegative": true,
       "explanation": {
-        "correct": "The four Client Script types are onLoad, onChange, onSubmit, and onCellEdit. There is no 'onSave' type — save actions are handled by the onSubmit type, which runs when a form is saved, updated, or submitted. See: https://docs.servicenow.com/bundle/xanadu-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
+        "correct": "The four Client Script types are onLoad, onChange, onSubmit, and onCellEdit. There is no 'onSave' type \u2014 save actions are handled by the onSubmit type, which runs when a form is saved, updated, or submitted. See: https://docs.servicenow.com/bundle/xanadu-application-development/page/script/client-scripts/concept/c_ClientScripts.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -1289,7 +1289,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Returning false prevents submission entirely — the record is never sent to the server, so it cannot be deleted.",
+            "explanation": "Returning false prevents submission entirely \u2014 the record is never sent to the server, so it cannot be deleted.",
             "reference": "https://docs.servicenow.com/bundle/xanadu-application-development/page/script/client-scripts/concept/c_ClientScripts.html"
           },
           {
@@ -1333,6 +1333,183 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-client-scripts-018",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to make the 'Short description' field mandatory only when the Priority is set to 1 - Critical. Which client script type should they use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "onLoad client script"
+        },
+        {
+          "id": "b",
+          "text": "onChange client script on the Priority field"
+        },
+        {
+          "id": "c",
+          "text": "onSubmit client script"
+        },
+        {
+          "id": "d",
+          "text": "onCellEdit client script"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "An onChange client script on the Priority field fires whenever the user changes the priority value, allowing you to call g_form.setMandatory('short_description', true) when priority is 1.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "An onLoad script runs when the form loads, but would not respond to subsequent changes to the Priority field."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "An onSubmit script runs when the form is submitted. While it could validate, it would not provide real-time feedback as the user changes Priority."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "onCellEdit scripts run in list view when cells are edited, not on the standard form."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-client-scripts-019",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "analysis",
+      "type": "multiple_choice",
+      "question": "Which of the following is NOT a valid g_form method for controlling field visibility?",
+      "options": [
+        {
+          "id": "a",
+          "text": "g_form.setVisible('field_name', false)"
+        },
+        {
+          "id": "b",
+          "text": "g_form.setDisplay('field_name', false)"
+        },
+        {
+          "id": "c",
+          "text": "g_form.hideFieldMsg('field_name')"
+        },
+        {
+          "id": "d",
+          "text": "g_form.hideRelatedList('list_name')"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "There is no setVisible() method on g_form. The correct method to hide a field is g_form.setDisplay() or g_form.setVisible() does not exist as a standard API.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "g_form.setDisplay() is a valid method that controls whether a field is displayed on the form."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "g_form.hideFieldMsg() is a valid method that hides a previously shown field message."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "g_form.hideRelatedList() is a valid method that hides a related list on the form."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-client-scripts-020",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer writes an onChange client script but it does not fire when the form loads with a pre-populated value. What should they add?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Set the 'Inherited' checkbox on the client script"
+        },
+        {
+          "id": "b",
+          "text": "Add an onLoad client script that manually triggers the onChange logic"
+        },
+        {
+          "id": "c",
+          "text": "Check the 'Fire on load' option in the onChange client script"
+        },
+        {
+          "id": "d",
+          "text": "Set the business rule to populate the field after form load"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "The onChange client script has an 'Inherit' checkbox but lacks... Actually, onChange scripts in ServiceNow do not fire on initial form load by default. However, adding an onLoad script that calls the same logic is the standard workaround.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'Inherited' checkbox controls whether the script applies to extended tables, not whether it fires on load."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Changing when the field is populated does not solve the problem of the onChange not firing on initial load."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-client-scripts-021",
+      "certification": "cad",
+      "topic": "client-scripts",
+      "cognitiveLevel": "knowledge",
+      "type": "multi_select",
+      "question": "Which TWO methods can be used to get the value of a field in a client script? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "g_form.getValue('field_name')"
+        },
+        {
+          "id": "b",
+          "text": "g_form.getReference('field_name')"
+        },
+        {
+          "id": "c",
+          "text": "current.field_name"
+        },
+        {
+          "id": "d",
+          "text": "g_form.getDisplayValue('field_name')"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "d"
+      ],
+      "explanation": {
+        "correct": "g_form.getValue() returns the actual value of a field, and g_form.getDisplayValue() returns the display value. Both are valid client-side methods to retrieve field values.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "g_form.getReference() retrieves the full GlideRecord of a reference field asynchronously. While it can get values, it's specifically for reference lookups, not general value retrieval."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "'current' is a server-side object available in business rules. It is not available in client scripts."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/client-scripts.json
+++ b/data/questions/cad/client-scripts.json
@@ -1474,7 +1474,7 @@
       "certification": "cad",
       "topic": "client-scripts",
       "cognitiveLevel": "knowledge",
-      "type": "multi_select",
+      "type": "multiple_select",
       "question": "Which TWO methods can be used to get the value of a field in a client script? (Choose 2)",
       "options": [
         {

--- a/data/questions/cad/integration-rest.json
+++ b/data/questions/cad/integration-rest.json
@@ -668,7 +668,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "Import set tables serve as temporary staging tables. Source data is first loaded into the import set table, where it is converted into GlideRecords and can be validated before being transformed and moved to the target table. This intermediate step helps manage data quality challenges that arise from bringing in external data. See docs.servicenow.com — Import sets.",
+        "correct": "Import set tables serve as temporary staging tables. Source data is first loaded into the import set table, where it is converted into GlideRecords and can be validated before being transformed and moved to the target table. This intermediate step helps manage data quality challenges that arise from bringing in external data. See docs.servicenow.com \u2014 Import sets.",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -688,7 +688,7 @@
         ]
       },
       "references": [
-        "ServiceNow Docs — Import Sets",
+        "ServiceNow Docs \u2014 Import Sets",
         "ServiceNow Application Development Fundamentals Course"
       ],
       "isFree": false,
@@ -747,7 +747,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "A Transform Map contains the set of instructions that maps columns from the import set table to fields on the target table, and provides automation for handling data quality issues during the transformation process. Multiple Transform Maps can be stacked for more sophisticated operations. See docs.servicenow.com — Transform Maps.",
+        "correct": "A Transform Map contains the set of instructions that maps columns from the import set table to fields on the target table, and provides automation for handling data quality issues during the transformation process. Multiple Transform Maps can be stacked for more sophisticated operations. See docs.servicenow.com \u2014 Transform Maps.",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -767,7 +767,7 @@
         ]
       },
       "references": [
-        "ServiceNow Docs — Transform Maps",
+        "ServiceNow Docs \u2014 Transform Maps",
         "ServiceNow Application Development Fundamentals Course"
       ],
       "isFree": false,
@@ -826,11 +826,11 @@
         "b"
       ],
       "explanation": {
-        "correct": "The Auto Map Matching Fields feature automatically creates field map records based on matching column names between the import set table and the target table. This eliminates the need to manually drag and drop columns in the Mapping Assist tool when column names already match. See docs.servicenow.com — Auto Map Matching Fields.",
+        "correct": "The Auto Map Matching Fields feature automatically creates field map records based on matching column names between the import set table and the target table. This eliminates the need to manually drag and drop columns in the Mapping Assist tool when column names already match. See docs.servicenow.com \u2014 Auto Map Matching Fields.",
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Auto Map Matching Fields still uses the Transform Map process — it simply automates the creation of field map records within the Transform Map, rather than bypassing it entirely.",
+            "explanation": "Auto Map Matching Fields still uses the Transform Map process \u2014 it simply automates the creation of field map records within the Transform Map, rather than bypassing it entirely.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-integrate-applications/page/script/server-scripting/concept/c_TransformMaps.html"
           },
           {
@@ -846,7 +846,7 @@
         ]
       },
       "references": [
-        "ServiceNow Docs — Transform Map Field Mapping",
+        "ServiceNow Docs \u2014 Transform Map Field Mapping",
         "ServiceNow Application Development Fundamentals Course"
       ],
       "isFree": false,
@@ -907,7 +907,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "The import set table serves two key functions: (1) it converts the source data from its original format (Excel, CSV, XML, etc.) into GlideRecords within the ServiceNow platform, and (2) it acts as a staging area where the data can be validated and verified before being transformed and moved to the target table. See docs.servicenow.com — Import Sets.",
+        "correct": "The import set table serves two key functions: (1) it converts the source data from its original format (Excel, CSV, XML, etc.) into GlideRecords within the ServiceNow platform, and (2) it acts as a staging area where the data can be validated and verified before being transformed and moved to the target table. See docs.servicenow.com \u2014 Import Sets.",
         "wrongAnswers": [
           {
             "choiceId": "b",
@@ -922,7 +922,7 @@
         ]
       },
       "references": [
-        "ServiceNow Docs — Import Sets",
+        "ServiceNow Docs \u2014 Import Sets",
         "ServiceNow Application Development Fundamentals Course"
       ],
       "isFree": false,
@@ -982,7 +982,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "The Enforce Mandatory Fields setting on the Transform Map controls how strictly mandatory field requirements are applied during the import process. By default, records can be imported even if mandatory fields are empty — unlike submitting through a form. This setting provides options for different levels of strictness regarding mandatory field enforcement. See docs.servicenow.com — Transform Map properties.",
+        "correct": "The Enforce Mandatory Fields setting on the Transform Map controls how strictly mandatory field requirements are applied during the import process. By default, records can be imported even if mandatory fields are empty \u2014 unlike submitting through a form. This setting provides options for different levels of strictness regarding mandatory field enforcement. See docs.servicenow.com \u2014 Transform Map properties.",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -1002,7 +1002,7 @@
         ]
       },
       "references": [
-        "ServiceNow Docs — Transform Map Properties",
+        "ServiceNow Docs \u2014 Transform Map Properties",
         "ServiceNow Application Development Fundamentals Course"
       ],
       "isFree": false,
@@ -1215,7 +1215,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "The ServiceNow Table API provides built-in CRUD operations on any table. An external system can POST JSON to /api/now/table/incident to create incidents with no custom development needed — only authentication setup is required. See: https://docs.servicenow.com/bundle/xanadu-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html",
+        "correct": "The ServiceNow Table API provides built-in CRUD operations on any table. An external system can POST JSON to /api/now/table/incident to create incidents with no custom development needed \u2014 only authentication setup is required. See: https://docs.servicenow.com/bundle/xanadu-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -1342,6 +1342,187 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-integration-rest-018",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which HTTP method should be used to create a new record via the ServiceNow Table API?",
+      "options": [
+        {
+          "id": "a",
+          "text": "GET"
+        },
+        {
+          "id": "b",
+          "text": "PUT"
+        },
+        {
+          "id": "c",
+          "text": "POST"
+        },
+        {
+          "id": "d",
+          "text": "PATCH"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "POST is the standard HTTP method for creating new resources. The ServiceNow Table API uses POST to /api/now/table/{tableName} to insert new records.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "GET is used to retrieve records, not create them."
+          },
+          {
+            "choiceId": "b",
+            "explanation": "PUT is used to update an existing record by replacing it entirely."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "PATCH is used for partial updates to existing records, not for creating new ones."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-integration-rest-019",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to limit the fields returned by a Table API GET request to only sys_id and short_description. Which query parameter should they use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "sysparm_fields=sys_id,short_description"
+        },
+        {
+          "id": "b",
+          "text": "sysparm_display_value=sys_id,short_description"
+        },
+        {
+          "id": "c",
+          "text": "sysparm_query=fieldsIN sys_id,short_description"
+        },
+        {
+          "id": "d",
+          "text": "sysparm_columns=sys_id,short_description"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "sysparm_fields is the query parameter used to specify which fields to return in a Table API response, reducing payload size.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "sysparm_display_value controls whether to return display values (true/false/all), not which fields to include."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "sysparm_query is for filtering which records to return, not which fields."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "sysparm_columns is not a valid Table API parameter. Use sysparm_fields."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-integration-rest-020",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "analysis",
+      "type": "multi_select",
+      "question": "Which TWO authentication methods are supported by ServiceNow's inbound REST APIs? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Basic Authentication with username and password"
+        },
+        {
+          "id": "b",
+          "text": "OAuth 2.0 bearer tokens"
+        },
+        {
+          "id": "c",
+          "text": "API key in request header"
+        },
+        {
+          "id": "d",
+          "text": "SAML assertion in request body"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "ServiceNow REST APIs support Basic Authentication (username/password in Authorization header) and OAuth 2.0 (bearer tokens). Both are commonly used for API integrations.",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": "ServiceNow does not natively support API key authentication for its REST APIs. Use Basic Auth or OAuth instead."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "SAML is used for browser-based SSO authentication, not for direct REST API calls."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-integration-rest-021",
+      "certification": "cad",
+      "topic": "integration-rest",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "What is the correct endpoint format to retrieve a specific incident record using the Table API?",
+      "options": [
+        {
+          "id": "a",
+          "text": "/api/now/table/incident?sys_id=<sys_id>"
+        },
+        {
+          "id": "b",
+          "text": "/api/now/table/incident/<sys_id>"
+        },
+        {
+          "id": "c",
+          "text": "/api/now/incident/<sys_id>"
+        },
+        {
+          "id": "d",
+          "text": "/api/now/table/incident/get/<sys_id>"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The Table API uses the format /api/now/table/{tableName}/{sys_id} to retrieve a specific record by its sys_id.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "While sysparm_query could filter by sys_id, the standard RESTful approach is to include the sys_id in the URL path."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The Table API requires '/table/' in the path: /api/now/table/incident/{sys_id}."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The Table API uses HTTP methods (GET) to determine the operation, not URL segments like '/get/'."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/integration-rest.json
+++ b/data/questions/cad/integration-rest.json
@@ -1441,7 +1441,7 @@
       "certification": "cad",
       "topic": "integration-rest",
       "cognitiveLevel": "analysis",
-      "type": "multi_select",
+      "type": "multiple_select",
       "question": "Which TWO authentication methods are supported by ServiceNow's inbound REST APIs? (Choose 2)",
       "options": [
         {

--- a/data/questions/cad/script-includes.json
+++ b/data/questions/cad/script-includes.json
@@ -31,7 +31,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "A Script Include stores reusable JavaScript for server-side execution. Script Includes follow a 'write once, use many' pattern — they are written once and can be called from anywhere server-side JavaScript is accepted. They must be explicitly called to run and do not have automatic triggers. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "correct": "A Script Include stores reusable JavaScript for server-side execution. Script Includes follow a 'write once, use many' pattern \u2014 they are written once and can be called from anywhere server-side JavaScript is accepted. They must be explicitly called to run and do not have automatic triggers. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -45,7 +45,7 @@
           },
           {
             "choiceId": "d",
-            "explanation": "Scheduled Jobs are used to run automation at defined time intervals. Script Includes do not run on a schedule — they must be explicitly called from other scripts or processes.",
+            "explanation": "Scheduled Jobs are used to run automation at defined time intervals. Script Includes do not run on a schedule \u2014 they must be explicitly called from other scripts or processes.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-platform-administration/page/administer/time/concept/c_ScheduledJobs.html"
           }
         ]
@@ -123,7 +123,7 @@
           },
           {
             "choiceId": "d",
-            "explanation": "The previous object is also unavailable in Script Includes for the same reason — there is no table association. The previous object is available in Business Rules alongside current.",
+            "explanation": "The previous object is also unavailable in Script Includes for the same reason \u2014 there is no table association. The previous object is available in Business Rules alongside current.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/business-rules/concept/c_BusinessRules.html"
           }
         ]
@@ -270,7 +270,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "Script Includes must be explicitly called to run — they have no automatic triggers tied to table events. Additionally, the Name field of the Script Include record must exactly match the function name (for classless) or the class variable name (for class-based) defined in the Script field. This naming match is critical for the Script Include to work properly. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
+        "correct": "Script Includes must be explicitly called to run \u2014 they have no automatic triggers tied to table events. Additionally, the Name field of the Script Include record must exactly match the function name (for classless) or the class variable name (for class-based) defined in the Script field. This naming match is critical for the Script Include to work properly. See: https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html",
         "wrongAnswers": [
           {
             "choiceId": "c",
@@ -514,7 +514,7 @@
           },
           {
             "choiceId": "d",
-            "explanation": "While the g_scratchpad technique works to pass data from a display Business Rule to the client, it only executes when the form loads — it does not support dynamic, on-demand data retrieval without a page reload. GlideAjax with AbstractAjaxProcessor is the correct approach for asynchronous requests.",
+            "explanation": "While the g_scratchpad technique works to pass data from a display Business Rule to the client, it only executes when the form loads \u2014 it does not support dynamic, on-demand data retrieval without a page reload. GlideAjax with AbstractAjaxProcessor is the correct approach for asynchronous requests.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/business-rules/concept/c_DisplayBusinessRules.html"
           }
         ]
@@ -897,7 +897,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Creating a separate Script Include adds unnecessary complexity. The initialize function within the same Script Include is designed for this exact purpose — centralizing shared setup logic.",
+            "explanation": "Creating a separate Script Include adds unnecessary complexity. The initialize function within the same Script Include is designed for this exact purpose \u2014 centralizing shared setup logic.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/script/script-includes/concept/c_ScriptIncludes.html"
           },
           {
@@ -1058,7 +1058,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "This is correct. Script Includes use lazy loading — they are only loaded into memory when referenced, which improves performance.",
+            "explanation": "This is correct. Script Includes use lazy loading \u2014 they are only loaded into memory when referenced, which improves performance.",
             "reference": "https://docs.servicenow.com/bundle/xanadu-application-development/page/script/server-scripting/concept/c_ScriptIncludes.html"
           },
           {
@@ -1136,7 +1136,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Duplicating code violates the DRY (Don't Repeat Yourself) principle and creates maintenance issues — any fix must be applied in multiple places.",
+            "explanation": "Duplicating code violates the DRY (Don't Repeat Yourself) principle and creates maintenance issues \u2014 any fix must be applied in multiple places.",
             "reference": "https://docs.servicenow.com/bundle/xanadu-application-development/page/script/server-scripting/concept/c_ScriptIncludes.html"
           },
           {
@@ -1259,6 +1259,190 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-script-includes-017",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What must be true for a Script Include to be accessible from a client script via GlideAjax?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The Script Include must extend AbstractAjaxProcessor and have 'Client callable' checked"
+        },
+        {
+          "id": "b",
+          "text": "The Script Include must be in the global scope"
+        },
+        {
+          "id": "c",
+          "text": "The Script Include must have the 'Public' access modifier"
+        },
+        {
+          "id": "d",
+          "text": "The Script Include must be attached to the same table as the client script"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "To be called from a client script via GlideAjax, a Script Include must extend AbstractAjaxProcessor and have the 'Client callable' checkbox selected.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "Script Includes can be in any application scope and still be client-callable, as long as they extend AbstractAjaxProcessor and are marked client-callable."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "There is no 'Public' access modifier on Script Includes. The 'Client callable' checkbox is what controls client-side access."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Script Includes are not attached to specific tables. They are standalone server-side scripts."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-script-includes-018",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer creates a Script Include called 'IncidentUtils' with a method 'getHighPriority()'. How would they call this from a business rule?",
+      "options": [
+        {
+          "id": "a",
+          "text": "var util = new IncidentUtils(); util.getHighPriority();"
+        },
+        {
+          "id": "b",
+          "text": "IncidentUtils.getHighPriority();"
+        },
+        {
+          "id": "c",
+          "text": "gs.include('IncidentUtils').getHighPriority();"
+        },
+        {
+          "id": "d",
+          "text": "var util = GlideScriptInclude('IncidentUtils'); util.getHighPriority();"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "Script Includes are instantiated using the 'new' keyword with the Script Include name, then methods are called on the instance: new IncidentUtils().getHighPriority().",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "This syntax would only work for static methods. Standard Script Include methods require instantiation with 'new'."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "gs.include() is used for on-demand loading of Script Includes but does not return an instance to call methods on directly."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "GlideScriptInclude is not the correct way to instantiate a Script Include. Use 'new ScriptIncludeName()'."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-script-includes-019",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "analysis",
+      "type": "multiple_choice",
+      "question": "What is the primary benefit of using Script Includes over writing logic directly in business rules?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Script Includes execute faster than business rules"
+        },
+        {
+          "id": "b",
+          "text": "Script Includes promote code reusability across multiple scripts"
+        },
+        {
+          "id": "c",
+          "text": "Script Includes can access client-side APIs"
+        },
+        {
+          "id": "d",
+          "text": "Script Includes bypass ACL restrictions"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Script Includes encapsulate reusable logic that can be called from business rules, scheduled jobs, UI actions, and other server-side scripts, promoting code reuse and maintainability.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Script Includes do not inherently execute faster. They run on the same server-side engine as business rules."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "Script Includes are server-side and cannot directly access client-side APIs like g_form."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "Script Includes do not bypass ACLs. They respect the same security model as other server-side scripts."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-script-includes-020",
+      "certification": "cad",
+      "topic": "script-includes",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which property of a Script Include determines if it loads automatically or on demand?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The 'Active' checkbox"
+        },
+        {
+          "id": "b",
+          "text": "The 'Accessible from' field"
+        },
+        {
+          "id": "c",
+          "text": "The API Name field"
+        },
+        {
+          "id": "d",
+          "text": "The 'Protection policy' field"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The 'Accessible from' field determines the scope accessibility of a Script Include. Script Includes load on demand when instantiated with 'new' - they are not automatically loaded unless explicitly called.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The 'Active' checkbox determines if the Script Include is available at all, not how it loads."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "The API Name is the identifier used to instantiate the Script Include. It doesn't control loading behavior."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "The Protection policy controls whether the script can be modified in other instances, not loading behavior."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/scripting-apis.json
+++ b/data/questions/cad/scripting-apis.json
@@ -2414,7 +2414,7 @@
       "certification": "cad",
       "topic": "scripting-apis",
       "cognitiveLevel": "analysis",
-      "type": "multi_select",
+      "type": "multiple_select",
       "question": "Which TWO of the following are valid ways to query records using GlideRecord in a server-side script? (Choose 2)",
       "options": [
         {

--- a/data/questions/cad/scripting-apis.json
+++ b/data/questions/cad/scripting-apis.json
@@ -811,7 +811,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Processing only the first record would occur with an if(gr.next()) statement. Using while(gr.hasNext()) does not process a single record and return — it creates an infinite loop because hasNext() never advances the record pointer.",
+            "explanation": "Processing only the first record would occur with an if(gr.next()) statement. Using while(gr.hasNext()) does not process a single record and return \u2014 it creates an infinite loop because hasNext() never advances the record pointer.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
           },
           {
@@ -979,7 +979,7 @@
           },
           {
             "choiceId": "d",
-            "explanation": "GlideAggregate is designed for aggregate operations like COUNT, SUM, and AVG — not for filtering records with complex query conditions. It does not replace the need for addEncodedQuery() in this scenario.",
+            "explanation": "GlideAggregate is designed for aggregate operations like COUNT, SUM, and AVG \u2014 not for filtering records with complex query conditions. It does not replace the need for addEncodedQuery() in this scenario.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-api-reference/page/app-store/dev_portal/API_reference/GlideAggregate/concept/c_GlideAggregateAPI.html"
           }
         ]
@@ -1125,11 +1125,11 @@
         "b"
       ],
       "explanation": {
-        "correct": "A subflow is a sequence of reusable actions that can be started from a flow, a subflow, or a script. Unlike flows, subflows do not require a trigger — they are called by other automation components. Subflows can also be used to group together common actions and brought into a flow like a template. See https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html",
+        "correct": "A subflow is a sequence of reusable actions that can be started from a flow, a subflow, or a script. Unlike flows, subflows do not require a trigger \u2014 they are called by other automation components. Subflows can also be used to group together common actions and brought into a flow like a template. See https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html",
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "This is incorrect. A flow requires a trigger and at least one action. A subflow does not require a trigger at all — it is invoked by other flows, subflows, or scripts.",
+            "explanation": "This is incorrect. A flow requires a trigger and at least one action. A subflow does not require a trigger at all \u2014 it is invoked by other flows, subflows, or scripts.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-build-workflows/page/administer/flow-designer/concept/flow-designer.html"
           },
           {
@@ -1417,7 +1417,7 @@
       "topic": "scripting-apis",
       "cognitiveLevel": "understanding",
       "type": "multiple_choice",
-      "question": "Why does a UI policy in advanced view provide two separate scripting fields — 'Execute if true' and 'Execute if false'?",
+      "question": "Why does a UI policy in advanced view provide two separate scripting fields \u2014 'Execute if true' and 'Execute if false'?",
       "options": [
         {
           "id": "a",
@@ -2084,7 +2084,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "For reference fields, these methods return different values — the sys_id vs the display name. They would return the same value for simple text fields.",
+            "explanation": "For reference fields, these methods return different values \u2014 the sys_id vs the display name. They would return the same value for simple text fields.",
             "reference": "https://docs.servicenow.com/bundle/xanadu-application-development/page/app-store/dev_portal/API_reference/GlideRecord/concept/c_GlideRecordAPI.html"
           },
           {
@@ -2361,6 +2361,187 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-scripting-apis-031",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to get the display value of a reference field called 'assigned_to' in a server-side script. Which method should they use?",
+      "options": [
+        {
+          "id": "a",
+          "text": "current.assigned_to"
+        },
+        {
+          "id": "b",
+          "text": "current.assigned_to.getDisplayValue()"
+        },
+        {
+          "id": "c",
+          "text": "current.getDisplayValue('assigned_to')"
+        },
+        {
+          "id": "d",
+          "text": "current.assigned_to.toString()"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The getDisplayValue() method on a reference field's GlideElement returns the display value of the referenced record, typically the name field.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "This returns the GlideElement object, not the display value. It would need .getDisplayValue() to get the human-readable name."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "getDisplayValue() on the GlideRecord with a field name returns the display value, but the standard approach for reference fields is to call it on the GlideElement directly."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "toString() returns the sys_id of the referenced record, not the display value."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-scripting-apis-032",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "analysis",
+      "type": "multi_select",
+      "question": "Which TWO of the following are valid ways to query records using GlideRecord in a server-side script? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "gr.addQuery('active', true); gr.query();"
+        },
+        {
+          "id": "b",
+          "text": "gr.find('active', true);"
+        },
+        {
+          "id": "c",
+          "text": "gr.addEncodedQuery('active=true'); gr.query();"
+        },
+        {
+          "id": "d",
+          "text": "gr.select('active', true);"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Both addQuery() and addEncodedQuery() are valid methods to build queries on a GlideRecord. addQuery() takes field, operator, and value parameters, while addEncodedQuery() takes a URL-encoded query string.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "There is no find() method on GlideRecord. Use addQuery() or addEncodedQuery() followed by query()."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "There is no select() method on GlideRecord. This is not a valid ServiceNow API method."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-scripting-apis-033",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which API is used to make outbound REST calls from a server-side script in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "GlideHTTPClient"
+        },
+        {
+          "id": "b",
+          "text": "RESTMessageV2"
+        },
+        {
+          "id": "c",
+          "text": "GlideURLRequest"
+        },
+        {
+          "id": "d",
+          "text": "sn_ws.SOAPMessageV2"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "RESTMessageV2 (sn_ws.RESTMessageV2) is the server-side API used to make outbound REST API calls from ServiceNow scripts.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "GlideHTTPClient is not a standard ServiceNow API. RESTMessageV2 is the correct API for outbound REST calls."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "GlideURLRequest is not a standard ServiceNow API for REST calls."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "SOAPMessageV2 is used for SOAP-based web service calls, not REST calls."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-scripting-apis-034",
+      "certification": "cad",
+      "topic": "scripting-apis",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer wants to display an informational message to the user after a form is submitted and reloaded. Which method should they use in a business rule?",
+      "options": [
+        {
+          "id": "a",
+          "text": "gs.addInfoMessage()"
+        },
+        {
+          "id": "b",
+          "text": "gs.print()"
+        },
+        {
+          "id": "c",
+          "text": "g_form.addInfoMessage()"
+        },
+        {
+          "id": "d",
+          "text": "gs.log()"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "gs.addInfoMessage() displays a blue informational message on the next page load. It is available in server-side scripts like business rules.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "gs.print() writes output to the system log, not to the user interface."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "g_form.addInfoMessage() is a client-side method and cannot be used in a business rule, which runs server-side."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "gs.log() writes to the system log and does not display messages to the user."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/ui-policies-actions.json
+++ b/data/questions/cad/ui-policies-actions.json
@@ -196,7 +196,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "'Reverse if false' does not change the condition logic itself. The condition remains the same; the checkbox controls what happens when the condition evaluates to false—the UI policy actions are reversed.",
+            "explanation": "'Reverse if false' does not change the condition logic itself. The condition remains the same; the checkbox controls what happens when the condition evaluates to false\u2014the UI policy actions are reversed.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
           },
           {
@@ -265,7 +265,7 @@
         "c"
       ],
       "explanation": {
-        "correct": "ServiceNow recommends UI policies over client scripts when both can achieve the same result because UI policies are usually unscripted. They use the Condition builder and UI policy actions, making them easier to maintain—especially for less technical administrators who may not know how to script.",
+        "correct": "ServiceNow recommends UI policies over client scripts when both can achieve the same result because UI policies are usually unscripted. They use the Condition builder and UI policy actions, making them easier to maintain\u2014especially for less technical administrators who may not know how to script.",
         "wrongAnswers": [
           {
             "choiceId": "a",
@@ -349,7 +349,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "Making a field mandatory based on another field's value is a standard UI policy action. A condition can be set on the UI policy, and a UI policy action can set the target field to mandatory—no scripting required.",
+            "explanation": "Making a field mandatory based on another field's value is a standard UI policy action. A condition can be set on the UI policy, and a UI policy action can set the target field to mandatory\u2014no scripting required.",
             "reference": "https://docs.servicenow.com/bundle/yokohama-application-development/page/administer/form-administration/concept/c_UIPolicies.html"
           },
           {
@@ -400,7 +400,7 @@
       "options": [
         {
           "id": "a",
-          "text": "Create two separate UI policies—one for the Critical condition and one for the non-Critical condition"
+          "text": "Create two separate UI policies\u2014one for the Critical condition and one for the non-Critical condition"
         },
         {
           "id": "b",
@@ -1335,6 +1335,187 @@
         "version": "1.1",
         "release": "Xanadu",
         "reviewed": false
+      }
+    },
+    {
+      "id": "cad-ui-policies-021",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "analysis",
+      "type": "multiple_choice",
+      "question": "A form has both a UI Policy making a field read-only and a client script setting the same field to writable. Which takes precedence?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The client script always overrides UI Policies"
+        },
+        {
+          "id": "b",
+          "text": "The UI Policy takes precedence because it runs after client scripts"
+        },
+        {
+          "id": "c",
+          "text": "The last one to execute takes precedence, based on order"
+        },
+        {
+          "id": "d",
+          "text": "UI Policies with 'Reverse if false' enabled always win"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "Both UI Policies and client scripts manipulate the form DOM. The last one to execute will determine the final state. UI Policies typically run after onLoad client scripts, but the execution order depends on configuration.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "Client scripts do not always override UI Policies. The order of execution determines the outcome."
+          },
+          {
+            "choiceId": "b",
+            "explanation": "While UI Policies often run after onLoad scripts, this is not an absolute rule and depends on the specific configuration."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "'Reverse if false' controls whether the UI Policy reverses its actions when conditions are no longer met. It does not determine precedence over client scripts."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-ui-policies-022",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What does the 'Reverse if false' option do on a UI Policy?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Deletes the UI Policy if its conditions are never met"
+        },
+        {
+          "id": "b",
+          "text": "Reverses the UI Policy actions when the conditions are no longer true"
+        },
+        {
+          "id": "c",
+          "text": "Applies the opposite actions when the form first loads"
+        },
+        {
+          "id": "d",
+          "text": "Prevents the UI Policy from running on insert operations"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "'Reverse if false' automatically reverses the UI Policy actions (e.g., if the policy made a field mandatory, it becomes non-mandatory) when the conditions are no longer met.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "The option does not delete the UI Policy. It only reverses the actions dynamically."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "It does not apply opposite actions on load. It reverses actions when conditions change from true to false."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "This option has nothing to do with insert operations. Use the 'On insert' checkbox for that."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-ui-policies-023",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A developer needs to hide a section on a form when the State is 'Closed'. What is the recommended approach?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create a UI Policy with condition State = Closed and a UI Policy Action to hide the section"
+        },
+        {
+          "id": "b",
+          "text": "Write an onLoad client script to check state and hide the section element"
+        },
+        {
+          "id": "c",
+          "text": "Create an ACL to restrict access to the section"
+        },
+        {
+          "id": "d",
+          "text": "Use a UI Macro to conditionally render the section"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "UI Policies are the recommended no-code approach for conditionally showing/hiding form sections. Create a UI Policy with the condition and add a UI Policy Action targeting the section.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": "While a client script could hide sections, UI Policies are preferred because they are easier to maintain and don't require coding."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "ACLs control data access at the security level, not form element visibility."
+          },
+          {
+            "choiceId": "d",
+            "explanation": "UI Macros are for custom UI components and are not the standard approach for conditionally hiding form sections."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cad-ui-policies-024",
+      "certification": "cad",
+      "topic": "ui-policies-actions",
+      "cognitiveLevel": "analysis",
+      "type": "multi_select",
+      "question": "Which TWO actions can a UI Policy Action perform on a form field? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Set the field value to a specific string"
+        },
+        {
+          "id": "b",
+          "text": "Make the field mandatory"
+        },
+        {
+          "id": "c",
+          "text": "Change the field's data type"
+        },
+        {
+          "id": "d",
+          "text": "Make the field read-only"
+        }
+      ],
+      "correctAnswers": [
+        "b",
+        "d"
+      ],
+      "explanation": {
+        "correct": "UI Policy Actions can set a field's mandatory, visible, and read-only properties. Making a field mandatory and read-only are two of the three core actions.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": "UI Policy Actions control field properties (mandatory, visible, read-only) but cannot set field values. Use a client script or business rule to set values."
+          },
+          {
+            "choiceId": "c",
+            "explanation": "A field's data type is defined in the dictionary and cannot be changed by a UI Policy Action."
+          }
+        ]
       }
     }
   ]

--- a/data/questions/cad/ui-policies-actions.json
+++ b/data/questions/cad/ui-policies-actions.json
@@ -1480,7 +1480,7 @@
       "certification": "cad",
       "topic": "ui-policies-actions",
       "cognitiveLevel": "analysis",
-      "type": "multi_select",
+      "type": "multiple_select",
       "question": "Which TWO actions can a UI Policy Action perform on a form field? (Choose 2)",
       "options": [
         {

--- a/data/topics/cad-topics.json
+++ b/data/topics/cad-topics.json
@@ -22,7 +22,7 @@
         "Flow Designer scripting actions",
         "Scoped vs global scripting"
       ],
-      "questionCount": 30,
+      "questionCount": 34,
       "freeQuestionCount": 5
     },
     {
@@ -46,7 +46,7 @@
         "g_scratchpad for display rules",
         "Business rule best practices"
       ],
-      "questionCount": 20,
+      "questionCount": 24,
       "freeQuestionCount": 5
     },
     {
@@ -70,7 +70,7 @@
         "Client script debugging",
         "Performance best practices"
       ],
-      "questionCount": 17,
+      "questionCount": 21,
       "freeQuestionCount": 5
     },
     {
@@ -94,7 +94,7 @@
         "UI Action visibility conditions",
         "Cross-platform considerations"
       ],
-      "questionCount": 17,
+      "questionCount": 21,
       "freeQuestionCount": 5
     },
     {
@@ -118,7 +118,7 @@
         "Script Include debugging",
         "initialize() and type patterns"
       ],
-      "questionCount": 16,
+      "questionCount": 20,
       "freeQuestionCount": 5
     },
     {
@@ -142,7 +142,7 @@
         "Coalesce fields for upsert",
         "Integration Hub basics"
       ],
-      "questionCount": 17,
+      "questionCount": 21,
       "freeQuestionCount": 5
     },
     {
@@ -166,7 +166,7 @@
         "Cross-scope access",
         "Source control integration"
       ],
-      "questionCount": 49,
+      "questionCount": 53,
       "freeQuestionCount": 5
     }
   ]


### PR DESCRIPTION
## Changes

### CAD Question Expansion (172 → 200)
- +28 new questions across all 7 domains (4 per domain)
- Mix: single choice, multi-select, negative, scenario-based

### Blog Post
- CAD practice test guide targeting high-intent keywords
- 13-min read

### Preview
https://feat-expand-cad-200.snready.pages.dev