### PR TITLE
feat: Expand CIS-SM to 150 questions (+29) with practice test blog post

### DIFF
--- a/data/blog/posts.ts
+++ b/data/blog/posts.ts
@@ -3830,6 +3830,175 @@ If you're deciding between the two, read our [CSA vs CAD comparison](/blog/csa-v
 Every question includes detailed explanations for both correct and incorrect answers. No brain dumps. No shortcut memorization. Real understanding that translates to passing the exam and doing the job.
 `
   },
+  {
+    slug: "servicenow-cis-sm-practice-test-150-questions-2026",
+    title: "CIS-Service Mapping Practice Test: 150 Questions to Pass the ServiceNow Exam (2026)",
+    description: "150 expert-written CIS-SM practice questions covering all 6 exam domains. Pattern design, traffic-based discovery, tag-based mapping, Predictive Intelligence — with full explanations.",
+    publishedAt: "2026-04-04",
+    author: "SNReady Team",
+    tags: ["CIS-SM", "practice test", "exam prep", "service mapping"],
+    featured: true,
+    readingTime: 14,
+    content: `
+## Why Service Mapping Is One of the Hardest CIS Exams
+
+The Certified Implementation Specialist - Service Mapping (CIS-SM) exam is widely considered one of the most technically demanding certifications in the ServiceNow ecosystem. It tests deep knowledge of pattern design, discovery configuration, traffic-based mapping, tag-based services, CMDB integration, and machine learning-powered discovery.
+
+**The exam at a glance:**
+- 60 questions, 90 minutes
+- ~70% passing score (42 correct)
+- Multiple choice and multi-select
+- Heavy on scenario-based questions
+- $210 per attempt
+
+Unlike broader certifications like CSA or CIS-ITSM, the CIS-SM exam requires hands-on experience with Pattern Designer, discovery schedules, entry points, credentials, and the Service Mapping home page. You need to understand how Service Mapping interacts with Discovery, the CMDB, and Predictive Intelligence.
+
+## What Our 150 Questions Cover
+
+We've built 150 practice questions sourced from the official ServiceNow Xanadu documentation, covering every exam domain at the correct weight:
+
+| Domain | Weight | Questions | What's Tested |
+|--------|--------|-----------|--------------|
+| Pattern Design | 30% | 38 | Pattern Designer, pattern types, customization, domain separation, CI types, roles, debugging |
+| SM Configuration | 20% | 26 | Traffic-based discovery, tag-based mapping, entry points, credentials, properties, schedules |
+| Discovery Configuration | 15% | 20 | CMDB-based mapping, readiness checklist, MID Server, ADM, traffic data tables |
+| CMDB Integration | 15% | 19 | Tag-based services, traversal rules, CI relationships, service map tables |
+| Machine Learning | 10% | 13 | Predictive Intelligence, confidence levels, connection suggestions, connection rules |
+| Engagement Readiness | 10% | 12 | Readiness checklist, roles, optional/mandatory checks, prerequisites |
+
+### Question Types Match the Real Exam
+
+Our questions include the same mix you'll face on exam day:
+
+- **Single choice** (~60%): Standard "which one" questions
+- **Multi-select** (~25%): "Choose 2" or "Choose 3" — these are where people lose points
+- **Scenario-based** (~30%): "An administrator configures X, then Y happens. What's the result?"
+- **Negative** (~10%): "Which is NOT..." or "All EXCEPT..."
+
+Every question includes a detailed explanation of why the correct answer is right AND why each wrong answer is wrong.
+
+## Domain Deep Dive: What to Study
+
+### 1. Pattern Design (30% — 18 questions on exam)
+
+This is the largest domain and covers everything about discovery patterns:
+
+**Key topics:**
+- Two pattern types: Infrastructure (Discovery only, device lists) and Application (both SM and Discovery)
+- Pattern customization creates a COPY — original is preserved for updates
+- Domain separation: global patterns vs domain-specific copies
+- Roles: Discovery admin and PD admin can create/edit/publish; PD user is read-only
+- Pattern operations don't support multi-language (non-English values cause failures)
+- Top-down discovery uses only the main CI type; horizontal discovers main + related
+- Patterns stored in Discovery Patterns [sa_pattern] table
+- Update set workflow: develop → test → export → commit in production
+- Visibility Content 6.28.0: activation/deactivation no longer counts as customization
+
+**Sample question:**
+> During Service Mapping top-down discovery, a pattern has F5 BigIP GTM as its main CI type and DNS names as related CI types. Which CI types are discovered?
+>
+> A) Only the main CI type ✅
+> B) Main and all related CI types
+> C) Only related CI types
+> D) No CI types
+
+### 2. SM Configuration (20% — 12 questions on exam)
+
+Configuration covers how you set up and tune Service Mapping:
+
+**Key topics:**
+- Traffic-based discovery is OFF by default (sa.traffic_based_discovery.active)
+- Four enablement levels: product → service instance → CI type → specific CI (more specific overrides general)
+- Must enable at product level before other levels work
+- Pattern-based connections override traffic-based duplicates (traffic-based removed)
+- Tag-based mapping: no credentials or elevated rights needed
+- Tags stored in Key Value [cmdb_key_value] table
+- Tag-based services in Tag-Based Application Service [cmdb_ci_service_by_tags] table
+
+**Sample question:**
+> Traffic-based discovery is enabled for a service instance with Tomcat, MySQL, and a web app. A CI type rule excludes Tomcat. Which CIs use traffic-based discovery?
+>
+> A) Only Tomcat
+> B) MySQL and web application only ✅
+> C) All three
+> D) None
+
+### 3. Discovery Configuration (15% — 9 questions on exam)
+
+This domain tests your understanding of how discovery works under the hood:
+
+**Key topics:**
+- CMDB-based mapping works WITHOUT MID Server access
+- When application can't be identified, ADM creates one in cmdb_ci_appl
+- TCP Connection [cmdb_tcp] stores netstat/lsof data
+- Flow Connector [sa_flow_connection] stores Netflow/VPC log data
+- Readiness Checklist: MID Server config is mandatory; hosts, load balancers, Netflow are optional
+
+### 4. CMDB Integration (15% — 9 questions on exam)
+
+How Service Mapping interacts with the CMDB:
+
+**Key topics:**
+- Traversal Rules [svc_traversal_rules] table defines how tag-based connections are created
+- CIs with multiple tags can belong to multiple services
+- Untagged CIs are included if they're part of relationships with tagged CIs
+- Service Mapping queries CMDB for matching tag values to create services
+
+### 5. Machine Learning (10% — 6 questions on exam)
+
+Predictive Intelligence powers smarter discovery:
+
+**Key topics:**
+- Property: sa_ml.connection_suggestions.active
+- Confidence levels: High (internal/specific), Medium (middleware/shared), Low (monitoring/widespread), Very Low (organization-wide like AD)
+- Connection rules enhance suggestions; evaluated in order (local first, then global)
+- During rediscovery, invalid rules → decision set to Undecided → connections removed
+
+### 6. Engagement Readiness (10% — 6 questions on exam)
+
+Pre-implementation readiness and prerequisites:
+
+**Key topics:**
+- service_mapping_admin role required for readiness checklist
+- Mandatory: MID Servers with IP ranges and capabilities configured
+- Optional: 100+ hosts, 3+ load balancers, Netflow/VPC, Cloud Discovery
+- Can still map without optional items but results may be incomplete
+
+## Study Plan: 2 Weeks to CIS-SM
+
+| Day | Focus | Action |
+|-----|-------|--------|
+| 1-3 | Pattern Design | Study pattern types, customization, domain separation. Do 15 practice questions. |
+| 4-5 | SM Configuration | Traffic-based discovery levels, tag-based mapping. Do 10 practice questions. |
+| 6-7 | Discovery Config | CMDB-based mapping, readiness checklist, tables. Do 10 practice questions. |
+| 8-9 | CMDB Integration | Tag-based services, traversal rules, relationships. Do 10 practice questions. |
+| 10 | ML + Engagement | Confidence levels, connection rules, readiness. Do 10 practice questions. |
+| 11-12 | Full Mock Exams | Take timed 60-question exams. Target 80%+. |
+| 13-14 | Review Weak Areas | Focus on domains below 70%. Retake questions you got wrong. |
+
+## Why Brain Dumps Won't Work for CIS-SM
+
+Service Mapping questions are heavily scenario-based. Brain dump memorization fails because:
+
+1. **The scenarios are specific** — you need to understand HOW traffic-based discovery precedence works, not just THAT it exists
+2. **Multi-select questions require complete knowledge** — choosing 2 out of 4 means you need to know all 4 options
+3. **ServiceNow updates the question bank** — Xanadu introduced new features that change correct answers from previous versions
+
+Our 150 questions teach you the WHY behind each answer, which is what you need for scenario questions.
+
+## Start Practicing Now
+
+Every question in our bank includes:
+- ✅ Detailed explanation of the correct answer
+- ❌ Why each wrong answer is wrong
+- 📚 Source reference to official ServiceNow docs
+- 🏷️ Domain and subtopic tags for targeted study
+
+[Start your CIS-SM practice test →](/cis-sm)
+
+The CIS-SM exam rewards depth of understanding. 150 questions with explanations will build that depth faster than any other study method.
+`
+  },
 ];
 
 export function getAllPosts(): BlogPost[] {

--- a/data/questions/cis-sm/cmdb-integration.json
+++ b/data/questions/cis-sm/cmdb-integration.json
@@ -1025,6 +1025,270 @@
         "release": "Xanadu",
         "reviewed": false
       }
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1010",
+      "certification": "cis-sm",
+      "topic": "cmdb-integration",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which table stores tag-based application services created by Service Mapping?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Application Service [cmdb_ci_service_auto]"
+        },
+        {
+          "id": "b",
+          "text": "Tag-Based Application Service [cmdb_ci_service_by_tags]"
+        },
+        {
+          "id": "c",
+          "text": "Service Map [sa_service_map]"
+        },
+        {
+          "id": "d",
+          "text": "Discovered Service [cmdb_ci_service_discovered]"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Service Mapping adds tag-based application services to the Tag-Based Application Service [cmdb_ci_service_by_tags] table.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "cmdb_ci_service_auto is for auto-discovered services."
+          },
+          {
+            "id": "c",
+            "explanation": "No standard sa_service_map table."
+          },
+          {
+            "id": "d",
+            "explanation": "Not the table for tag-based services."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Service Mapping adds new application services to the Tag-Based Application Service [cmdb_ci_service_by_tags] table.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/tag-based-mapping.html"
+      },
+      "labels": {
+        "domain": "CMDB Integration",
+        "subtopics": [
+          "Tag-based mapping",
+          "Tables"
+        ],
+        "tags": [
+          "cmdb_ci_service_by_tags",
+          "tables"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1011",
+      "certification": "cis-sm",
+      "topic": "cmdb-integration",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "How does Service Mapping create connections between tagged CIs in tag-based services?",
+      "options": [
+        {
+          "id": "a",
+          "text": "By running horizontal discovery on each CI"
+        },
+        {
+          "id": "b",
+          "text": "By using CI relationships from the Traversal Rules table"
+        },
+        {
+          "id": "c",
+          "text": "By analyzing network traffic between tagged CIs"
+        },
+        {
+          "id": "d",
+          "text": "By matching tag keys across CI classes"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Service Mapping creates connections based on CI relationships using the Traversal Rules for Application Services [svc_traversal_rules] table.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Tag-based mapping uses CMDB relationships, not horizontal discovery."
+          },
+          {
+            "id": "c",
+            "explanation": "Traffic analysis is a different method."
+          },
+          {
+            "id": "d",
+            "explanation": "Connections are based on traversal rules, not tag key matching."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "The Traversal Rules for Application Services [svc_traversal_rules] table contains information used for creating tag-based application services.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/tag-based-mapping.html"
+      },
+      "labels": {
+        "domain": "CMDB Integration",
+        "subtopics": [
+          "Tag-based mapping",
+          "Traversal rules"
+        ],
+        "tags": [
+          "traversal-rules",
+          "ci-relationships"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1012",
+      "certification": "cis-sm",
+      "topic": "cmdb-integration",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "CIs with two tags assigned are included in tag-based mapping. What happens to these CIs?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Assigned only to the first matching service"
+        },
+        {
+          "id": "b",
+          "text": "Can be part of multiple services based on their tags"
+        },
+        {
+          "id": "c",
+          "text": "Excluded from mapping due to ambiguity"
+        },
+        {
+          "id": "d",
+          "text": "Flagged for manual review"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "CIs with more than one tag can be part of multiple services.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "CIs are not limited to one service."
+          },
+          {
+            "id": "c",
+            "explanation": "Multiple tags do not cause exclusion."
+          },
+          {
+            "id": "d",
+            "explanation": "No manual review is needed."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "CIs that have more than one tags assigned to them, can be part of multiple services.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/tag-based-mapping.html"
+      },
+      "labels": {
+        "domain": "CMDB Integration",
+        "subtopics": [
+          "Tag-based mapping",
+          "Multi-service"
+        ],
+        "tags": [
+          "tags",
+          "multiple-services"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1013",
+      "certification": "cis-sm",
+      "topic": "cmdb-integration",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "During tag-based mapping, why does Service Mapping include untagged CIs that are part of CI relationships?",
+      "options": [
+        {
+          "id": "a",
+          "text": "To ensure complete service maps by following relationship connections"
+        },
+        {
+          "id": "b",
+          "text": "Because all CMDB CIs are automatically included"
+        },
+        {
+          "id": "c",
+          "text": "To populate the tag database with missing entries"
+        },
+        {
+          "id": "d",
+          "text": "Because untagged CIs always belong to the global domain"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "Service Mapping includes CIs in relationships even without tags to ensure complete service map topology.",
+        "wrongAnswers": [
+          {
+            "id": "b",
+            "explanation": "Not all CMDB CIs are included."
+          },
+          {
+            "id": "c",
+            "explanation": "Not about populating the tag database."
+          },
+          {
+            "id": "d",
+            "explanation": "Domain assignment is unrelated."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Service Mapping includes CIs that are part of these relationships even if these CIs do not have tags assigned.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/tag-based-mapping.html"
+      },
+      "labels": {
+        "domain": "CMDB Integration",
+        "subtopics": [
+          "Tag-based mapping",
+          "Relationships"
+        ],
+        "tags": [
+          "untagged-cis",
+          "relationships"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     }
   ]
 }

--- a/data/questions/cis-sm/discovery-configuration.json
+++ b/data/questions/cis-sm/discovery-configuration.json
@@ -920,7 +920,7 @@
         "wrongAnswers": [
           {
             "id": "a",
-            "explanation": "HTTP/HTTPS ports (80, 443, 8080, 8443) are not ignored by default — they are often important for application service mapping."
+            "explanation": "HTTP/HTTPS ports (80, 443, 8080, 8443) are not ignored by default \u2014 they are often important for application service mapping."
           },
           {
             "id": "c",
@@ -1012,6 +1012,332 @@
           "scheduled-jobs",
           "cleanup",
           "deferred-discovery"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-discovery-configuration-710",
+      "certification": "cis-sm",
+      "topic": "discovery-configuration",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What is CMDB-based mapping in Service Mapping?",
+      "options": [
+        {
+          "id": "a",
+          "text": "A method requiring multiple MID Servers"
+        },
+        {
+          "id": "b",
+          "text": "A method using CMDB data to map services without MID Server access"
+        },
+        {
+          "id": "c",
+          "text": "A manual service map creation process"
+        },
+        {
+          "id": "d",
+          "text": "A backup method when all MID Servers are online"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "CMDB-based mapping uses data stored in the CMDB to run top-down discovery without requiring MID Server access.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "CMDB-based mapping does NOT require MID Servers."
+          },
+          {
+            "id": "c",
+            "explanation": "It is automated, not manual."
+          },
+          {
+            "id": "d",
+            "explanation": "It activates when a MID Server is NOT available."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Using data stored in the CMDB, you can map application services without having to access a MID Server.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/cmdb-based-mapping.html"
+      },
+      "labels": {
+        "domain": "Discovery Configuration",
+        "subtopics": [
+          "CMDB-based mapping"
+        ],
+        "tags": [
+          "cmdb-based-mapping",
+          "mid-server"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-discovery-configuration-711",
+      "certification": "cis-sm",
+      "topic": "discovery-configuration",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "During CMDB-based mapping, what happens if an application cannot be identified for a target process?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Discovery fails and logs an error"
+        },
+        {
+          "id": "b",
+          "text": "ADM logic classifies and creates an application in the CMDB"
+        },
+        {
+          "id": "c",
+          "text": "The CI is skipped"
+        },
+        {
+          "id": "d",
+          "text": "A manual task is created for review"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "If an application isn't identified, CMDB-based mapping uses ADM logic to classify and create an application. If ADM cannot classify it, a simple application is created in cmdb_ci_appl.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Discovery does not fail; it falls back to ADM."
+          },
+          {
+            "id": "c",
+            "explanation": "The CI is not skipped."
+          },
+          {
+            "id": "d",
+            "explanation": "No manual task is created."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "If an application isn't identified, CMDB-based mapping uses ADM logic to classify and create an application.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/cmdb-based-mapping.html"
+      },
+      "labels": {
+        "domain": "Discovery Configuration",
+        "subtopics": [
+          "CMDB-based mapping",
+          "ADM"
+        ],
+        "tags": [
+          "adm",
+          "application-classification"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-discovery-configuration-712",
+      "certification": "cis-sm",
+      "topic": "discovery-configuration",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which table stores traffic data collected from netstat and lsof commands for traffic-based discovery?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Flow Connector [sa_flow_connection]"
+        },
+        {
+          "id": "b",
+          "text": "TCP Connection [cmdb_tcp]"
+        },
+        {
+          "id": "c",
+          "text": "Flow Services [sa_flow_service]"
+        },
+        {
+          "id": "d",
+          "text": "Network Traffic [sa_network_traffic]"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The TCP Connection [cmdb_tcp] table stores data from netstat and lsof commands, used during top-down discovery.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Flow Connector stores Netflow/VPC log data."
+          },
+          {
+            "id": "c",
+            "explanation": "Flow Services stores Netflow/VPC data about listening ports."
+          },
+          {
+            "id": "d",
+            "explanation": "No standard sa_network_traffic table exists."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "TCP Connection [cmdb_tcp]: Source: netstat and lsof commands.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/traffic-based-discovery.html"
+      },
+      "labels": {
+        "domain": "Discovery Configuration",
+        "subtopics": [
+          "Traffic-based discovery",
+          "Tables"
+        ],
+        "tags": [
+          "cmdb_tcp",
+          "netstat"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-discovery-configuration-713",
+      "certification": "cis-sm",
+      "topic": "discovery-configuration",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "What is the default state of traffic-based discovery in Service Mapping?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Enabled for all service instances"
+        },
+        {
+          "id": "b",
+          "text": "Enabled at product level only"
+        },
+        {
+          "id": "c",
+          "text": "Turned off by default"
+        },
+        {
+          "id": "d",
+          "text": "Enabled for CIs with credentials"
+        }
+      ],
+      "correctAnswers": [
+        "c"
+      ],
+      "explanation": {
+        "correct": "By default, traffic-based discovery is turned off. It must be explicitly enabled at the product level first.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Not enabled by default."
+          },
+          {
+            "id": "b",
+            "explanation": "Off at all levels by default."
+          },
+          {
+            "id": "d",
+            "explanation": "Not tied to credential configuration."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "By default, traffic-based discovery in Service Mapping is turned off.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/traffic-based-discovery.html"
+      },
+      "labels": {
+        "domain": "Discovery Configuration",
+        "subtopics": [
+          "Traffic-based discovery",
+          "Default settings"
+        ],
+        "tags": [
+          "default-settings",
+          "traffic-based"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-discovery-configuration-714",
+      "certification": "cis-sm",
+      "topic": "discovery-configuration",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "Which TWO are mandatory checks in the Service Mapping Readiness Checklist? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "MID Servers with correctly configured IP ranges"
+        },
+        {
+          "id": "b",
+          "text": "At least 100 hosts discovered in the last 14 days"
+        },
+        {
+          "id": "c",
+          "text": "MID Server applications and capabilities settings"
+        },
+        {
+          "id": "d",
+          "text": "Cloud Discovery is activated"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "The mandatory check requires MID Servers with correctly configured IP ranges and applications/capabilities settings. All other checks (hosts, load balancers, Netflow, Cloud) are optional.",
+        "wrongAnswers": [
+          {
+            "id": "b",
+            "explanation": "100 hosts is an optional check."
+          },
+          {
+            "id": "d",
+            "explanation": "Cloud Discovery is an optional check."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "(Mandatory) There are MID Servers with correctly configured IP ranges and the applications and capabilities settings.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/check-service-mapping-readiness-for-mapping.html"
+      },
+      "labels": {
+        "domain": "Discovery Configuration",
+        "subtopics": [
+          "Readiness checklist",
+          "MID Server"
+        ],
+        "tags": [
+          "readiness",
+          "mandatory-checks"
         ]
       },
       "meta": {

--- a/data/questions/cis-sm/engagement-readiness.json
+++ b/data/questions/cis-sm/engagement-readiness.json
@@ -676,6 +676,134 @@
         "release": "Xanadu",
         "reviewed": false
       }
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1111",
+      "certification": "cis-sm",
+      "topic": "engagement-readiness",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "Which TWO are optional checks in the Service Mapping Readiness Checklist? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "At least 100 hosts discovered in the last 14 days"
+        },
+        {
+          "id": "b",
+          "text": "At least three load balancers recently discovered"
+        },
+        {
+          "id": "c",
+          "text": "All CI types have assigned patterns"
+        },
+        {
+          "id": "d",
+          "text": "ITSM modules are installed"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "The optional checks include at least 100 hosts discovered in 14 days and at least three load balancers from horizontal discovery.",
+        "wrongAnswers": [
+          {
+            "id": "c",
+            "explanation": "CI type pattern assignment is not a checklist item."
+          },
+          {
+            "id": "d",
+            "explanation": "ITSM module configuration is not part of the checklist."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "(Optional) There are at least three load balancers recently discovered. (Optional) At least 100 hosts discovered in the last 14 days.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/check-service-mapping-readiness-for-mapping.html"
+      },
+      "labels": {
+        "domain": "Engagement Readiness",
+        "subtopics": [
+          "Readiness checklist"
+        ],
+        "tags": [
+          "readiness",
+          "optional-checks"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1112",
+      "certification": "cis-sm",
+      "topic": "engagement-readiness",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which role is required to run the Service Mapping Readiness Checklist?",
+      "options": [
+        {
+          "id": "a",
+          "text": "discovery_admin"
+        },
+        {
+          "id": "b",
+          "text": "service_mapping_admin"
+        },
+        {
+          "id": "c",
+          "text": "itil"
+        },
+        {
+          "id": "d",
+          "text": "pd_admin"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The service_mapping_admin role is required to access Service Mapping Home and run the Readiness Checklist.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "discovery_admin manages Discovery, not the SM Readiness Checklist."
+          },
+          {
+            "id": "c",
+            "explanation": "itil provides ITSM access, not SM admin."
+          },
+          {
+            "id": "d",
+            "explanation": "pd_admin manages Pattern Designer, not the Readiness Checklist."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Role required: service_mapping_admin",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/check-service-mapping-readiness-for-mapping.html"
+      },
+      "labels": {
+        "domain": "Engagement Readiness",
+        "subtopics": [
+          "Roles",
+          "Readiness checklist"
+        ],
+        "tags": [
+          "service_mapping_admin",
+          "roles"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     }
   ]
 }

--- a/data/questions/cis-sm/machine-learning.json
+++ b/data/questions/cis-sm/machine-learning.json
@@ -681,6 +681,203 @@
         "release": "Xanadu",
         "reviewed": false
       }
+    },
+    {
+      "id": "cis-sm-machine-learning-811",
+      "certification": "cis-sm",
+      "topic": "machine-learning",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "Which property controls Predictive Intelligence connection suggestions in Service Mapping?",
+      "options": [
+        {
+          "id": "a",
+          "text": "sa.traffic_based_discovery.active"
+        },
+        {
+          "id": "b",
+          "text": "sa_ml.connection_suggestions.active"
+        },
+        {
+          "id": "c",
+          "text": "sa.predictive.intelligence.enabled"
+        },
+        {
+          "id": "d",
+          "text": "ml.service_mapping.suggestions.on"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The sa_ml.connection_suggestions.active property controls the connection suggestions feature.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "This controls traffic-based discovery, not Predictive Intelligence."
+          },
+          {
+            "id": "c",
+            "explanation": "Not a valid property."
+          },
+          {
+            "id": "d",
+            "explanation": "Not a valid property."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "The sa_ml.connection_suggestions.active property controls this feature.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/predictive-intelligence-discovery.html"
+      },
+      "labels": {
+        "domain": "Machine Learning",
+        "subtopics": [
+          "Predictive Intelligence",
+          "Properties"
+        ],
+        "tags": [
+          "properties",
+          "connection-suggestions"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-machine-learning-812",
+      "certification": "cis-sm",
+      "topic": "machine-learning",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "What does a 'Medium' confidence level mean for a Predictive Intelligence connection suggestion?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Likely to an internal component for this specific application"
+        },
+        {
+          "id": "b",
+          "text": "Likely to a middleware component used by multiple services"
+        },
+        {
+          "id": "c",
+          "text": "Likely to a monitoring app deployed on many servers"
+        },
+        {
+          "id": "d",
+          "text": "Likely to a central organization-wide application"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Medium confidence means the connection is likely to a middleware component used by multiple services, such as IBM MQ or Oracle WebLogic.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "This describes High confidence."
+          },
+          {
+            "id": "c",
+            "explanation": "This describes Low confidence."
+          },
+          {
+            "id": "d",
+            "explanation": "This describes Very Low confidence."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Medium - This connection is likely to a middleware component used by multiple services.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/predictive-intelligence-discovery.html"
+      },
+      "labels": {
+        "domain": "Machine Learning",
+        "subtopics": [
+          "Confidence levels"
+        ],
+        "tags": [
+          "confidence-levels",
+          "medium"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-machine-learning-813",
+      "certification": "cis-sm",
+      "topic": "machine-learning",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "During rediscovery, what happens when a previously applied connection rule is no longer valid?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The connection is kept but marked deprecated"
+        },
+        {
+          "id": "b",
+          "text": "The suggestion decision changes to Undecided and the connection is removed if no other rule applies"
+        },
+        {
+          "id": "c",
+          "text": "An alert is sent for manual review"
+        },
+        {
+          "id": "d",
+          "text": "The connection rule is automatically deleted"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Service Mapping changes the decision to Undecided and removes the association. If no other rule applies, the connections are removed from application services.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Connections are not kept with a deprecated status."
+          },
+          {
+            "id": "c",
+            "explanation": "No manual alert is sent."
+          },
+          {
+            "id": "d",
+            "explanation": "The rule itself is not deleted, only the association."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "If a rule is no longer valid, Service Mapping changes the decision attribute to Undecided.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/predictive-intelligence-discovery.html"
+      },
+      "labels": {
+        "domain": "Machine Learning",
+        "subtopics": [
+          "Connection rules",
+          "Rediscovery"
+        ],
+        "tags": [
+          "rule-validation",
+          "rediscovery"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     }
   ]
 }

--- a/data/questions/cis-sm/pattern-design.json
+++ b/data/questions/cis-sm/pattern-design.json
@@ -218,7 +218,7 @@
         },
         {
           "id": "b",
-          "text": "Disables the SNMP – Routing pattern for routers running BGP protocol"
+          "text": "Disables the SNMP \u2013 Routing pattern for routers running BGP protocol"
         },
         {
           "id": "c",
@@ -233,7 +233,7 @@
         "b"
       ],
       "explanation": {
-        "correct": "When glide.discovery.bgp_router_disable is set to true (the default), it disables running the SNMP – Routing pattern when discovering a router running the BGP protocol. This is done because enabling it can cause performance issues including out-of-memory issues on the MID Server.",
+        "correct": "When glide.discovery.bgp_router_disable is set to true (the default), it disables running the SNMP \u2013 Routing pattern when discovering a router running the BGP protocol. This is done because enabling it can cause performance issues including out-of-memory issues on the MID Server.",
         "wrongAnswers": [
           {
             "id": "a",
@@ -245,12 +245,12 @@
           },
           {
             "id": "d",
-            "explanation": "Serial number population is not affected by this property. It specifically controls whether the SNMP – Routing pattern runs for BGP routers."
+            "explanation": "Serial number population is not affected by this property. It specifically controls whether the SNMP \u2013 Routing pattern runs for BGP routers."
           }
         ]
       },
       "source": {
-        "excerpt": "glide.discovery.bgp_router_disable: Disables running the SNMP – Routing pattern when discovering a router running the BGP protocol... Notice that enabling this property can cause performance issues including out-of-memory issues on the MID Server.",
+        "excerpt": "glide.discovery.bgp_router_disable: Disables running the SNMP \u2013 Routing pattern when discovering a router running the BGP protocol... Notice that enabling this property can cause performance issues including out-of-memory issues on the MID Server.",
         "url": "https://www.servicenow.com/docs/bundle/xanadu-it-operations-management/page/product/discovery-and-service-mapping-patterns/network-router-patterns.html"
       },
       "labels": {
@@ -1865,7 +1865,7 @@
         "wrongAnswers": [
           {
             "id": "a",
-            "explanation": "Patterns are released more frequently than quarterly — they are released monthly."
+            "explanation": "Patterns are released more frequently than quarterly \u2014 they are released monthly."
           },
           {
             "id": "c",
@@ -1957,6 +1957,596 @@
           "slow-steps",
           "troubleshooting",
           "sys_step_pattern"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-318",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "What happens when you customize a preconfigured discovery pattern in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The original pattern is permanently modified"
+        },
+        {
+          "id": "b",
+          "text": "A copy of the original pattern is created, and the original is preserved"
+        },
+        {
+          "id": "c",
+          "text": "The pattern is locked and cannot receive future updates"
+        },
+        {
+          "id": "d",
+          "text": "All instances using the pattern are immediately affected"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "When you customize a pattern, you create a copy of the original preconfigured pattern. The original version is preserved and updated separately when downloading updates from the ServiceNow Store.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "The original pattern is not modified. A separate customized copy is created."
+          },
+          {
+            "id": "c",
+            "explanation": "The original continues to receive updates independently."
+          },
+          {
+            "id": "d",
+            "explanation": "Only the local instance uses the customized version."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "When you customize a pattern, you actually create a copy of the original preconfigured pattern.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Pattern customization",
+          "Pattern versioning"
+        ],
+        "tags": [
+          "customization",
+          "pattern-versions"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-319",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In a domain-separated instance, what happens when you customize a global pattern and assign it to a specific domain?",
+      "options": [
+        {
+          "id": "a",
+          "text": "The global pattern is replaced for all domains"
+        },
+        {
+          "id": "b",
+          "text": "A domain-specific copy is created; the original global pattern is used for all other domains"
+        },
+        {
+          "id": "c",
+          "text": "The pattern becomes unavailable in all other domains"
+        },
+        {
+          "id": "d",
+          "text": "Domain separation is disabled for that pattern type"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Customizing a global pattern for a specific domain creates a copy. The original global pattern is still used for all other domains.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "The global pattern is not replaced."
+          },
+          {
+            "id": "c",
+            "explanation": "The pattern remains available in other domains via the global version."
+          },
+          {
+            "id": "d",
+            "explanation": "Domain separation continues to function normally."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "If you customize an existing pattern in the global domain and assign it to a specific domain, you create a copy.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Domain separation",
+          "Pattern customization"
+        ],
+        "tags": [
+          "domain-separation",
+          "global-patterns"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-320",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "application",
+      "type": "multiple_select",
+      "question": "Which TWO user roles can create, edit, and publish discovery patterns? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Discovery admin"
+        },
+        {
+          "id": "b",
+          "text": "PD user"
+        },
+        {
+          "id": "c",
+          "text": "PD admin"
+        },
+        {
+          "id": "d",
+          "text": "PDE viewer"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "explanation": {
+        "correct": "Both Discovery admin and PD admin can view, create, edit, and publish patterns.",
+        "wrongAnswers": [
+          {
+            "id": "b",
+            "explanation": "PD user has read-only access to Discovery Pattern Log."
+          },
+          {
+            "id": "d",
+            "explanation": "PDE viewer can only view Command Validation related tables."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Discovery admin: Can view, create, edit, and publish patterns. PD admin: Can view, create, edit, and publish patterns.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Roles and permissions"
+        ],
+        "tags": [
+          "roles",
+          "discovery-admin",
+          "pd-admin"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-321",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What are the two main types of discovery patterns in ITOM Visibility?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Infrastructure patterns and Application patterns"
+        },
+        {
+          "id": "b",
+          "text": "Discovery patterns and Mapping patterns"
+        },
+        {
+          "id": "c",
+          "text": "Network patterns and Server patterns"
+        },
+        {
+          "id": "d",
+          "text": "Horizontal patterns and Vertical patterns"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "Patterns can be infrastructure or application type. Infrastructure patterns are used only by Discovery for device lists. Application patterns serve both Service Mapping and Discovery.",
+        "wrongAnswers": [
+          {
+            "id": "b",
+            "explanation": "There is no 'Mapping patterns' category."
+          },
+          {
+            "id": "c",
+            "explanation": "Patterns are not categorized as Network and Server."
+          },
+          {
+            "id": "d",
+            "explanation": "Horizontal and top-down are discovery process types, not pattern types."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Patterns can be of the infrastructure or application type.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Pattern types"
+        ],
+        "tags": [
+          "infrastructure-patterns",
+          "application-patterns"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-322",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "Why might pattern operations fail when discovering devices in a non-English environment?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Pattern Designer only supports UTF-8 encoding"
+        },
+        {
+          "id": "b",
+          "text": "Pattern operations do not support multi-languages and non-English values cannot be parsed"
+        },
+        {
+          "id": "c",
+          "text": "The MID Server requires English locale"
+        },
+        {
+          "id": "d",
+          "text": "ServiceNow instances must be configured in English"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Pattern operations do not support multi-languages. Non-English values returned from operations cannot be parsed properly, causing discovery failure.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "The issue is about language parsing, not encoding."
+          },
+          {
+            "id": "c",
+            "explanation": "The MID Server can run in various locales."
+          },
+          {
+            "id": "d",
+            "explanation": "The instance language is not the issue."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Currently, pattern operations do not support multi-languages.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Pattern limitations",
+          "Multi-language"
+        ],
+        "tags": [
+          "multi-language",
+          "pattern-operations"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-323",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "A pattern for BIG-IP GTM F5 has F5 BigIP GTM as its main CI type and DNS names/network adapters as related CI types. During Service Mapping top-down discovery, which CI types are discovered?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Only the main CI type (F5 BigIP GTM)"
+        },
+        {
+          "id": "b",
+          "text": "The main CI type and all related CI types"
+        },
+        {
+          "id": "c",
+          "text": "Only the related CI types"
+        },
+        {
+          "id": "d",
+          "text": "No CI types \u2014 F5 requires a separate infrastructure pattern"
+        }
+      ],
+      "correctAnswers": [
+        "a"
+      ],
+      "explanation": {
+        "correct": "For top-down discovery by Service Mapping, each application pattern discovers only the main CI type. Related CI types are discovered during horizontal discovery.",
+        "wrongAnswers": [
+          {
+            "id": "b",
+            "explanation": "Both main and related CI types are discovered during horizontal discovery, not top-down."
+          },
+          {
+            "id": "c",
+            "explanation": "Related CI types alone are not discovered in top-down."
+          },
+          {
+            "id": "d",
+            "explanation": "F5 BigIP GTM uses an application pattern for top-down discovery."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "For the top-down discovery performed by Service Mapping, each application pattern serves to discover only the main CI type.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Top-down discovery",
+          "CI types"
+        ],
+        "tags": [
+          "main-ci-type",
+          "top-down"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-324",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In which table are all discovery patterns stored in ServiceNow?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Discovery Definition [sa_discovery_definition]"
+        },
+        {
+          "id": "b",
+          "text": "Discovery Patterns [sa_pattern]"
+        },
+        {
+          "id": "c",
+          "text": "Pattern Steps [sa_pattern_step]"
+        },
+        {
+          "id": "d",
+          "text": "Discovery Schedule [discovery_schedule]"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Patterns of all types are stored in the Discovery Patterns [sa_pattern] table.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Discovery Definition is for schedules, not patterns."
+          },
+          {
+            "id": "c",
+            "explanation": "Pattern Steps stores individual steps, not patterns themselves."
+          },
+          {
+            "id": "d",
+            "explanation": "Discovery Schedule stores schedule configs, not patterns."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Patterns of all types are stored in the Discovery Patterns [sa_pattern] table.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Tables",
+          "Pattern storage"
+        ],
+        "tags": [
+          "sa_pattern",
+          "tables"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-325",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "What is the recommended workflow for deploying customized patterns to production?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Create patterns directly in production"
+        },
+        {
+          "id": "b",
+          "text": "Create and test in development, then export as an update set to production"
+        },
+        {
+          "id": "c",
+          "text": "Use the ServiceNow Store to push patterns"
+        },
+        {
+          "id": "d",
+          "text": "Clone the production instance and modify in place"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Create or modify patterns in development, test and verify, then export as an update set and commit in production.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Creating directly in production bypasses testing."
+          },
+          {
+            "id": "c",
+            "explanation": "The Store is for preconfigured patterns, not custom ones."
+          },
+          {
+            "id": "d",
+            "explanation": "Cloning is unnecessary; update sets are the proper method."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Create or modify patterns, test them, and verify results in the development instance.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/c_MappingPatternsCustomization.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Pattern deployment",
+          "Best practices"
+        ],
+        "tags": [
+          "update-sets",
+          "development-workflow"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-pattern-design-326",
+      "certification": "cis-sm",
+      "topic": "pattern-design",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "Starting with Visibility Content version 6.28.0, what changed about pattern activation behavior?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Activating patterns now requires Discovery admin exclusively"
+        },
+        {
+          "id": "b",
+          "text": "Activating or deactivating a pattern is no longer considered a customization"
+        },
+        {
+          "id": "c",
+          "text": "Patterns can only be activated through the ServiceNow Store"
+        },
+        {
+          "id": "d",
+          "text": "Pattern activation triggers automatic rediscovery"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Starting with Visibility Content version 6.28.0, activating or deactivating a pattern is no longer considered a customization and continues to receive updates.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "The change is about customization status, not role requirements."
+          },
+          {
+            "id": "c",
+            "explanation": "Patterns can still be activated from the Discovery Patterns list."
+          },
+          {
+            "id": "d",
+            "explanation": "Activation does not trigger automatic rediscovery."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Starting with Visibility Content version 6.28.0, activating or deactivating a pattern won't be considered a customization.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/discovery-and-service-mapping-patterns/activate-disabled-pattern.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Pattern Design",
+        "subtopics": [
+          "Pattern activation",
+          "Visibility Content"
+        ],
+        "tags": [
+          "pattern-activation",
+          "visibility-content"
         ]
       },
       "meta": {

--- a/data/questions/cis-sm/sm-configuration.json
+++ b/data/questions/cis-sm/sm-configuration.json
@@ -787,7 +787,7 @@
         "wrongAnswers": [
           {
             "id": "b",
-            "explanation": "While IP is related, the three criteria are specifically Application, Capability, and IP range — not Domain or Protocol."
+            "explanation": "While IP is related, the three criteria are specifically Application, Capability, and IP range \u2014 not Domain or Protocol."
           },
           {
             "id": "c",
@@ -857,7 +857,7 @@
           },
           {
             "id": "c",
-            "explanation": "The request does not fail immediately — Service Mapping first tries to use the default MID Server before giving up."
+            "explanation": "The request does not fail immediately \u2014 Service Mapping first tries to use the default MID Server before giving up."
           },
           {
             "id": "d",
@@ -1058,7 +1058,7 @@
           },
           {
             "id": "b",
-            "explanation": "MID Servers are not required at every level — they must specifically be in the lowest (leaf) domain level."
+            "explanation": "MID Servers are not required at every level \u2014 they must specifically be in the lowest (leaf) domain level."
           },
           {
             "id": "d",
@@ -1259,7 +1259,7 @@
           },
           {
             "id": "c",
-            "explanation": "The values are reversed — 0 is MID-only, not ACC-only."
+            "explanation": "The values are reversed \u2014 0 is MID-only, not ACC-only."
           },
           {
             "id": "d",
@@ -1349,6 +1349,399 @@
           "netstat",
           "traffic-based",
           "tcp"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-sm-configuration-515",
+      "certification": "cis-sm",
+      "topic": "sm-configuration",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What property controls traffic-based discovery at the product level in Service Mapping?",
+      "options": [
+        {
+          "id": "a",
+          "text": "sa.discovery.traffic.enabled"
+        },
+        {
+          "id": "b",
+          "text": "sa.traffic_based_discovery.active"
+        },
+        {
+          "id": "c",
+          "text": "sm.traffic.discovery.mode"
+        },
+        {
+          "id": "d",
+          "text": "sa.service_mapping.traffic.on"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The sa.traffic_based_discovery.active property controls traffic-based discovery at the product level.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Not a valid ServiceNow property."
+          },
+          {
+            "id": "c",
+            "explanation": "Not a valid property."
+          },
+          {
+            "id": "d",
+            "explanation": "Not a valid property."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "The Traffic based discovery (sa.traffic_based_discovery.active) property controls traffic-based discovery.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/traffic-based-discovery.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Configuration",
+        "subtopics": [
+          "Traffic-based discovery",
+          "Properties"
+        ],
+        "tags": [
+          "properties",
+          "traffic-based"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-sm-configuration-516",
+      "certification": "cis-sm",
+      "topic": "sm-configuration",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_select",
+      "question": "At which levels can traffic-based discovery be enabled? (Choose 2)",
+      "options": [
+        {
+          "id": "a",
+          "text": "Product level and Service instance level"
+        },
+        {
+          "id": "b",
+          "text": "CI type level and Specific CI level"
+        },
+        {
+          "id": "c",
+          "text": "MID Server level and Domain level"
+        },
+        {
+          "id": "d",
+          "text": "Schedule level and Credential level"
+        }
+      ],
+      "correctAnswers": [
+        "a",
+        "b"
+      ],
+      "explanation": {
+        "correct": "Traffic-based discovery can be enabled at four levels: product, service instance, CI type, and specific CI.",
+        "wrongAnswers": [
+          {
+            "id": "c",
+            "explanation": "Not configurable at MID Server or Domain level."
+          },
+          {
+            "id": "d",
+            "explanation": "No schedule or credential level for this."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "You can enable it at different levels: product, service instance, CI type, specific CI.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/traffic-based-discovery.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Configuration",
+        "subtopics": [
+          "Traffic-based discovery",
+          "Configuration levels"
+        ],
+        "tags": [
+          "traffic-based",
+          "levels"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-sm-configuration-517",
+      "certification": "cis-sm",
+      "topic": "sm-configuration",
+      "cognitiveLevel": "application",
+      "type": "multiple_choice",
+      "question": "Traffic-based discovery is enabled for a service instance with Tomcat, MySQL, and a web app. A CI type rule excludes Tomcat. Which CIs use traffic-based discovery?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Only Tomcat"
+        },
+        {
+          "id": "b",
+          "text": "MySQL and web application only"
+        },
+        {
+          "id": "c",
+          "text": "All three CIs"
+        },
+        {
+          "id": "d",
+          "text": "None \u2014 the rule disables all traffic-based discovery"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "CI type rules override service instance settings. The Tomcat exclusion means only MySQL and the web app use traffic-based discovery.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Tomcat is excluded by the CI type rule."
+          },
+          {
+            "id": "c",
+            "explanation": "The CI type rule overrides the service instance setting for Tomcat."
+          },
+          {
+            "id": "d",
+            "explanation": "The rule only excludes Tomcat, not all CIs."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "You create a CI type rule that excludes all Tomcat servers. Service Mapping discovers MySQL and the web application.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/traffic-based-discovery.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Configuration",
+        "subtopics": [
+          "Traffic-based discovery",
+          "CI type rules"
+        ],
+        "tags": [
+          "ci-type-rules",
+          "precedence"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-sm-configuration-518",
+      "certification": "cis-sm",
+      "topic": "sm-configuration",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "What happens to duplicate connections when pattern-based discovery runs after traffic-based discovery?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Both connections are kept"
+        },
+        {
+          "id": "b",
+          "text": "Traffic-based connections are removed if they duplicate pattern-based ones"
+        },
+        {
+          "id": "c",
+          "text": "Pattern-based connections are removed"
+        },
+        {
+          "id": "d",
+          "text": "An error is logged requiring manual fix"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "The system removes traffic-based connections that are also created by pattern-based discovery to avoid duplicates.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Duplicates are not kept."
+          },
+          {
+            "id": "c",
+            "explanation": "Pattern-based connections take precedence; traffic-based duplicates are removed."
+          },
+          {
+            "id": "d",
+            "explanation": "Deduplication is automatic."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "The system removes any connections created by traffic-based discovery if they're also created by pattern-based discovery.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/traffic-based-discovery.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Configuration",
+        "subtopics": [
+          "Traffic-based discovery",
+          "Deduplication"
+        ],
+        "tags": [
+          "duplicates",
+          "deduplication"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-sm-configuration-519",
+      "certification": "cis-sm",
+      "topic": "sm-configuration",
+      "cognitiveLevel": "comprehension",
+      "type": "multiple_choice",
+      "question": "What advantage does tag-based mapping offer over other Service Mapping methods regarding credentials?",
+      "options": [
+        {
+          "id": "a",
+          "text": "It uses OAuth 2.0 for credential rotation"
+        },
+        {
+          "id": "b",
+          "text": "It does not require configuring credentials or elevated rights"
+        },
+        {
+          "id": "c",
+          "text": "It stores credentials encrypted in CMDB"
+        },
+        {
+          "id": "d",
+          "text": "It shares credentials across MID Servers"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Tag-based mapping does not require configuring credentials or providing users with elevated rights.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "Tag-based mapping requires no credentials at all."
+          },
+          {
+            "id": "c",
+            "explanation": "The advantage is no credentials needed, not better encryption."
+          },
+          {
+            "id": "d",
+            "explanation": "It avoids credentials entirely."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Unlike other mapping methods, tag-based mapping does not require configuring credentials or providing users with elevated rights.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/tag-based-mapping.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Configuration",
+        "subtopics": [
+          "Tag-based mapping",
+          "Credentials"
+        ],
+        "tags": [
+          "tag-based",
+          "credentials"
+        ]
+      },
+      "meta": {
+        "version": "1.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
+    },
+    {
+      "id": "cis-sm-sm-configuration-520",
+      "certification": "cis-sm",
+      "topic": "sm-configuration",
+      "cognitiveLevel": "knowledge",
+      "type": "multiple_choice",
+      "question": "In which table are discovered tags stored for tag-based Service Mapping?",
+      "options": [
+        {
+          "id": "a",
+          "text": "Tag Definition [cmdb_tag_definition]"
+        },
+        {
+          "id": "b",
+          "text": "Key Value [cmdb_key_value]"
+        },
+        {
+          "id": "c",
+          "text": "CI Tag [cmdb_ci_tag]"
+        },
+        {
+          "id": "d",
+          "text": "Service Tags [sa_service_tags]"
+        }
+      ],
+      "correctAnswers": [
+        "b"
+      ],
+      "explanation": {
+        "correct": "Discovered tags are populated into the Key Value [cmdb_key_value] table.",
+        "wrongAnswers": [
+          {
+            "id": "a",
+            "explanation": "No standard cmdb_tag_definition table exists."
+          },
+          {
+            "id": "c",
+            "explanation": "Not the standard location for discovered tags."
+          },
+          {
+            "id": "d",
+            "explanation": "No sa_service_tags table exists."
+          }
+        ]
+      },
+      "source": {
+        "excerpt": "Discovery and Cloud Provisioning discover tags and populate data into the Key Value [cmdb_key_value] table.",
+        "url": "https://www.servicenow.com/docs/r/xanadu/it-operations-management/service-mapping/tag-based-mapping.html"
+      },
+      "labels": {
+        "domain": "Service Mapping Configuration",
+        "subtopics": [
+          "Tag-based mapping",
+          "Tables"
+        ],
+        "tags": [
+          "cmdb_key_value",
+          "tags"
         ]
       },
       "meta": {

--- a/data/topics/cis-sm-topics.json
+++ b/data/topics/cis-sm-topics.json
@@ -6,7 +6,7 @@
       "name": "Service Mapping Pattern Design",
       "description": "Pattern Designer operations, steps, temp variables, command line console, parsing strategies, WMI/SSH/SNMP scripting, regex, and application identification sections",
       "weight": 30,
-      "questionCount": 29,
+      "questionCount": 38,
       "freeQuestionCount": 3,
       "introduction": {
         "overview": "Service Mapping Pattern Design covers the core technical skills needed to create, modify, and troubleshoot discovery patterns. This domain represents 30% of the CIS-SM exam and focuses on understanding how patterns identify and map application services.",
@@ -18,7 +18,7 @@
       "name": "Service Mapping Configuration",
       "description": "Setup and configuration files, tuning, entry points, CI types, credentials, service maps, schedules, service groups, and technical services",
       "weight": 20,
-      "questionCount": 20,
+      "questionCount": 26,
       "freeQuestionCount": 3,
       "introduction": {
         "overview": "Service Mapping Configuration covers the administrative setup and configuration of Service Mapping including entry points, credentials, service groups, and access control. This domain represents 20% of the CIS-SM exam.",
@@ -30,7 +30,7 @@
       "name": "Discovery Configuration",
       "description": "Discovery behaviors, clusters, IP services, schedules, MID servers, PCIE phases, ECC queue, and troubleshooting authentication errors",
       "weight": 15,
-      "questionCount": 15,
+      "questionCount": 20,
       "freeQuestionCount": 3,
       "introduction": {
         "overview": "Discovery Configuration covers the setup and troubleshooting of Discovery components that support Service Mapping. This domain represents 15% of the CIS-SM exam and focuses on MID Server configuration, discovery schedules, and error handling.",
@@ -42,7 +42,7 @@
       "name": "Machine Learning",
       "description": "Service Mapping methods guidance, ML-powered mapping, Service Mapping Workspace, and mapping service candidates",
       "weight": 10,
-      "questionCount": 10,
+      "questionCount": 13,
       "freeQuestionCount": 3,
       "introduction": {
         "overview": "Machine Learning covers intelligent service mapping capabilities including tag-based mapping, Predictive Intelligence, and the Service Mapping Workspace. This domain represents 10% of the CIS-SM exam.",
@@ -54,7 +54,7 @@
       "name": "Configuration Management Database",
       "description": "CI Class Manager, CMDB Health Dashboard, tables, reclassification, identification rules, reconciliation rules, and de-duplication tasks",
       "weight": 15,
-      "questionCount": 15,
+      "questionCount": 19,
       "freeQuestionCount": 3,
       "introduction": {
         "overview": "CMDB Integration covers how Service Mapping interacts with the CMDB including CI relationships, discovery patterns, and data storage. This domain represents 15% of the CIS-SM exam.",
@@ -66,7 +66,7 @@
       "name": "Service Mapping Engagement Readiness",
       "description": "Service definition, shared services, licensing, MID server requirements, implementation planning, security requirements, and measurable KPIs",
       "weight": 10,
-      "questionCount": 10,
+      "questionCount": 12,
       "freeQuestionCount": 3,
       "introduction": {
         "overview": "Engagement Readiness covers planning and preparation for Service Mapping implementations including prerequisites, credentials, and service organization. This domain represents 10% of the CIS-SM exam.",


### PR DESCRIPTION
## What

Expands CIS-Service Mapping question bank from 121 to 150 questions (+29 new questions) and adds a practice test blog post targeting high-intent search keywords.

### Question Expansion

| Domain | Before | After | Added |
|--------|--------|-------|-------|
| Pattern Design | 29 | 38 | +9 |
| SM Configuration | 20 | 26 | +6 |
| Discovery Configuration | 15 | 20 | +5 |
| CMDB Integration | 15 | 19 | +4 |
| Machine Learning | 10 | 13 | +3 |
| Engagement Readiness | 10 | 12 | +2 |
| **Total** | **99** | **128** | **+29** |

(+ 4 delta + 18 free = 150 total)

### New Topics Covered
- Pattern customization and versioning
- Domain separation for patterns
- Pattern Designer roles (Discovery admin, PD admin, PD user, PDE viewer)
- Infrastructure vs Application pattern types
- Multi-language limitations in pattern operations
- Top-down vs horizontal CI type discovery
- Traffic-based discovery levels and precedence
- Tag-based mapping (no credentials, cmdb_key_value table)
- CMDB-based mapping without MID Server
- Predictive Intelligence confidence levels
- Connection rules and rediscovery behavior
- Service Mapping Readiness Checklist

### Blog Post
- "CIS-Service Mapping Practice Test: 150 Questions" 
- Targets: cis-sm practice test, servicenow service mapping exam
- 14-min read with domain deep dive and 2-week study plan

### Preview
https://feat-expand-cis-sm-150.snready.pages.dev