### PR TITLE
fix: CSA ui-navigation schema + unblock deploy

### DIFF
--- a/data/questions/csa/ui-navigation.json
+++ b/data/questions/csa/ui-navigation.json
@@ -1679,7 +1679,7 @@
           },
           {
             "choiceId": "c",
-            "explanation": "Security constraints still apply \u2014 if a row can't be edited, a message indicates the field cannot be edited."
+            "explanation": "Security constraints still apply — if a row can't be edited, a message indicates the field cannot be edited."
           },
           {
             "choiceId": "d",
@@ -2253,7 +2253,7 @@
         "wrongAnswers": [
           {
             "choiceId": "a",
-            "explanation": "OR would return records matching either condition, not both \u2014 showing incidents from other groups or in other states."
+            "explanation": "OR would return records matching either condition, not both — showing incidents from other groups or in other states."
           },
           {
             "choiceId": "c",
@@ -2326,7 +2326,7 @@
         "wrongAnswers": [
           {
             "choiceId": "b",
-            "explanation": "Views and form layouts are related but distinct \u2014 views are named configurations, layouts define field arrangement."
+            "explanation": "Views and form layouts are related but distinct — views are named configurations, layouts define field arrangement."
           },
           {
             "choiceId": "c",
@@ -2393,8 +2393,23 @@
           "text": "Reference linking"
         }
       ],
-      "correctAnswer": "b",
-      "explanation": "Dot-walking is ServiceNow's method for accessing data from related tables through reference fields. When you have a reference field pointing to another table, you can 'walk' through the reference using dot notation to access fields in the referenced table. For example, if an incident has a 'caller_id' reference field pointing to the user table, you can access the caller's department using 'caller_id.department'. This is fundamental to ServiceNow's data access patterns and is used extensively in both the UI and scripting.",
+      "explanation": {
+        "correct": "Dot-walking is ServiceNow's method for accessing data from related tables through reference fields. When you have a reference field pointing to another table, you can 'walk' through the reference using dot notation to access fields in the referenced table. For example, if an incident has a 'caller_id' reference field pointing to the user table, you can access the caller's department using 'caller_id.department'. This is fundamental to ServiceNow's data access patterns and is used extensively in both the UI and scripting.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": ""
+          },
+          {
+            "choiceId": "c",
+            "explanation": ""
+          },
+          {
+            "choiceId": "d",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Lists and Filters",
@@ -2402,13 +2417,31 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "dot-walking",
-        "reference-fields",
-        "data-access"
-      ],
       "isFree": true,
-      "difficulty": "medium"
+      "correctAnswers": [
+        "b"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "dot-walking",
+          "reference-fields",
+          "data-access"
+        ],
+        "tags": [
+          "dot-walking",
+          "reference-fields",
+          "data-access"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-032",
@@ -2435,8 +2468,23 @@
           "text": "Modify form layouts"
         }
       ],
-      "correctAnswer": "b",
-      "explanation": "List header controls provide essential data manipulation capabilities including grouping records by field values, sorting columns in ascending/descending order, showing or hiding columns to customize the view, and applying filters to narrow down displayed records. These controls help users organize and find information efficiently without modifying the underlying data structure or form layouts. Understanding these controls is fundamental for effective ServiceNow navigation.",
+      "explanation": {
+        "correct": "List header controls provide essential data manipulation capabilities including grouping records by field values, sorting columns in ascending/descending order, showing or hiding columns to customize the view, and applying filters to narrow down displayed records. These controls help users organize and find information efficiently without modifying the underlying data structure or form layouts. Understanding these controls is fundamental for effective ServiceNow navigation.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": ""
+          },
+          {
+            "choiceId": "c",
+            "explanation": ""
+          },
+          {
+            "choiceId": "d",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Lists and Filters",
@@ -2444,13 +2492,31 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "list-controls",
-        "data-organization",
-        "user-interface"
-      ],
       "isFree": false,
-      "difficulty": "easy"
+      "correctAnswers": [
+        "b"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "list-controls",
+          "data-organization",
+          "user-interface"
+        ],
+        "tags": [
+          "list-controls",
+          "data-organization",
+          "user-interface"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-033",
@@ -2477,8 +2543,23 @@
           "text": "The view has active filters applied"
         }
       ],
-      "correctAnswer": "c",
-      "explanation": "Brackets around a list view name indicate that you are not viewing the default list view. ServiceNow shows brackets to make it clear when you've switched from the default view to a different saved view, such as 'Assigned to me', 'Recent', or custom views. The default view typically shows without brackets. This visual indicator helps users understand which view they're currently using and is important for navigation awareness.",
+      "explanation": {
+        "correct": "Brackets around a list view name indicate that you are not viewing the default list view. ServiceNow shows brackets to make it clear when you've switched from the default view to a different saved view, such as 'Assigned to me', 'Recent', or custom views. The default view typically shows without brackets. This visual indicator helps users understand which view they're currently using and is important for navigation awareness.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": ""
+          },
+          {
+            "choiceId": "b",
+            "explanation": ""
+          },
+          {
+            "choiceId": "d",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Lists and Filters",
@@ -2486,13 +2567,31 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "list-views",
-        "default-view",
-        "navigation-indicators"
-      ],
       "isFree": false,
-      "difficulty": "medium"
+      "correctAnswers": [
+        "c"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "list-views",
+          "default-view",
+          "navigation-indicators"
+        ],
+        "tags": [
+          "list-views",
+          "default-view",
+          "navigation-indicators"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-034",
@@ -2519,11 +2618,19 @@
           "text": "UI Policy Designer"
         }
       ],
-      "correctAnswer": [
-        "a",
-        "c"
-      ],
-      "explanation": "ServiceNow provides two primary methods for modifying form layouts: Form Designer (a drag-and-drop interface for arranging form elements) and Form Layout Tool (for more advanced layout modifications). List Editor is used for customizing list views, not forms. UI Policy Designer creates dynamic form behaviors but doesn't directly modify layouts. Understanding the distinction between these tools is important for form customization tasks.",
+      "explanation": {
+        "correct": "ServiceNow provides two primary methods for modifying form layouts: Form Designer (a drag-and-drop interface for arranging form elements) and Form Layout Tool (for more advanced layout modifications). List Editor is used for customizing list views, not forms. UI Policy Designer creates dynamic form behaviors but doesn't directly modify layouts. Understanding the distinction between these tools is important for form customization tasks.",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": ""
+          },
+          {
+            "choiceId": "d",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Forms and Configuration",
@@ -2531,13 +2638,32 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "form-layout",
-        "form-designer",
-        "customization-tools"
-      ],
       "isFree": false,
-      "difficulty": "medium"
+      "correctAnswers": [
+        "a",
+        "c"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "form-layout",
+          "form-designer",
+          "customization-tools"
+        ],
+        "tags": [
+          "form-layout",
+          "form-designer",
+          "customization-tools"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-035",
@@ -2564,8 +2690,23 @@
           "text": "The filter becomes a new list view"
         }
       ],
-      "correctAnswer": "b",
-      "explanation": "When users apply filter conditions to a list, ServiceNow maintains these conditions and displays them in the breadcrumb trail at the top of the list. This breadcrumb shows the current filter state and allows users to modify or remove filters. The breadcrumb trail provides navigation context and filter transparency. Filters are not automatically saved as permanent views unless explicitly saved, but they persist during the session and are visible in the breadcrumbs.",
+      "explanation": {
+        "correct": "When users apply filter conditions to a list, ServiceNow maintains these conditions and displays them in the breadcrumb trail at the top of the list. This breadcrumb shows the current filter state and allows users to modify or remove filters. The breadcrumb trail provides navigation context and filter transparency. Filters are not automatically saved as permanent views unless explicitly saved, but they persist during the session and are visible in the breadcrumbs.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": ""
+          },
+          {
+            "choiceId": "c",
+            "explanation": ""
+          },
+          {
+            "choiceId": "d",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Lists and Filters",
@@ -2573,14 +2714,33 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "filters",
-        "breadcrumbs",
-        "navigation",
-        "session-persistence"
-      ],
       "isFree": true,
-      "difficulty": "medium"
+      "correctAnswers": [
+        "b"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "filters",
+          "breadcrumbs",
+          "navigation",
+          "session-persistence"
+        ],
+        "tags": [
+          "filters",
+          "breadcrumbs",
+          "navigation",
+          "session-persistence"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-036",
@@ -2611,12 +2771,19 @@
           "text": "Modify table schemas"
         }
       ],
-      "correctAnswer": [
-        "a",
-        "b",
-        "d"
-      ],
-      "explanation": "Users can personalize lists by rearranging column order (dragging columns to preferred positions), setting column widths (adjusting the display width of columns), and saving custom list views (preserving filter and display preferences). Users cannot create new table fields or modify table schemas - these are administrative functions requiring proper roles and permissions. List personalization focuses on display and organization, not data structure modifications.",
+      "explanation": {
+        "correct": "Users can personalize lists by rearranging column order (dragging columns to preferred positions), setting column widths (adjusting the display width of columns), and saving custom list views (preserving filter and display preferences). Users cannot create new table fields or modify table schemas - these are administrative functions requiring proper roles and permissions. List personalization focuses on display and organization, not data structure modifications.",
+        "wrongAnswers": [
+          {
+            "choiceId": "c",
+            "explanation": ""
+          },
+          {
+            "choiceId": "e",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Lists and Filters",
@@ -2624,13 +2791,33 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "list-personalization",
-        "user-customization",
-        "list-views"
-      ],
       "isFree": false,
-      "difficulty": "medium"
+      "correctAnswers": [
+        "a",
+        "b",
+        "d"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "list-personalization",
+          "user-customization",
+          "list-views"
+        ],
+        "tags": [
+          "list-personalization",
+          "user-customization",
+          "list-views"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-037",
@@ -2657,8 +2844,23 @@
           "text": "All statements are true"
         }
       ],
-      "correctAnswer": "a",
-      "explanation": "Statement A is TRUE: Personal list configurations (column order, widths, personal views) only affect the individual user's experience. Statement B is TRUE: System-level form modifications (adding fields, changing layouts, UI policies) affect all users unless overridden by role-based configurations. Statement C is FALSE: Related lists typically show records from different tables that are related to the current record via reference fields (e.g., incidents related to a CI, tasks related to a change).",
+      "explanation": {
+        "correct": "Statement A is TRUE: Personal list configurations (column order, widths, personal views) only affect the individual user's experience. Statement B is TRUE: System-level form modifications (adding fields, changing layouts, UI policies) affect all users unless overridden by role-based configurations. Statement C is FALSE: Related lists typically show records from different tables that are related to the current record via reference fields (e.g., incidents related to a CI, tasks related to a change).",
+        "wrongAnswers": [
+          {
+            "choiceId": "b",
+            "explanation": ""
+          },
+          {
+            "choiceId": "c",
+            "explanation": ""
+          },
+          {
+            "choiceId": "d",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - Forms and Lists Configuration",
@@ -2666,13 +2868,31 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "configuration-scope",
-        "personal-vs-system",
-        "related-lists"
-      ],
       "isFree": true,
-      "difficulty": "hard"
+      "correctAnswers": [
+        "a"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "configuration-scope",
+          "personal-vs-system",
+          "related-lists"
+        ],
+        "tags": [
+          "configuration-scope",
+          "personal-vs-system",
+          "related-lists"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     },
     {
       "id": "csa-ui-navigation-038",
@@ -2699,8 +2919,23 @@
           "text": "Drag-and-drop form builder"
         }
       ],
-      "correctAnswer": "d",
-      "explanation": "The list collector interface is used for selecting multiple items from a list and includes: an 'Available' items list showing selectable options, a 'Selected' items list showing chosen items, and move arrows (or add/remove buttons) to transfer items between the lists. A drag-and-drop form builder is NOT part of the list collector - that's a separate interface component used in Form Designer for building form layouts. Understanding UI component distinctions is important for proper system navigation.",
+      "explanation": {
+        "correct": "The list collector interface is used for selecting multiple items from a list and includes: an 'Available' items list showing selectable options, a 'Selected' items list showing chosen items, and move arrows (or add/remove buttons) to transfer items between the lists. A drag-and-drop form builder is NOT part of the list collector - that's a separate interface component used in Form Designer for building form layouts. Understanding UI component distinctions is important for proper system navigation.",
+        "wrongAnswers": [
+          {
+            "choiceId": "a",
+            "explanation": ""
+          },
+          {
+            "choiceId": "b",
+            "explanation": ""
+          },
+          {
+            "choiceId": "c",
+            "explanation": ""
+          }
+        ]
+      },
       "references": [
         {
           "title": "ServiceNow Administration Fundamentals - User Interface Components",
@@ -2708,13 +2943,31 @@
           "url": "https://nowlearning.servicenow.com"
         }
       ],
-      "tags": [
-        "list-collector",
-        "ui-components",
-        "interface-elements"
-      ],
       "isFree": false,
-      "difficulty": "easy"
+      "correctAnswers": [
+        "d"
+      ],
+      "labels": {
+        "certification": "csa",
+        "domain": "ui-navigation",
+        "domainSlug": "ui-navigation",
+        "subtopics": [
+          "list-collector",
+          "ui-components",
+          "interface-elements"
+        ],
+        "tags": [
+          "list-collector",
+          "ui-components",
+          "interface-elements"
+        ]
+      },
+      "meta": {
+        "generatedAt": "2026-03-31T02:09:00Z",
+        "version": "2.0",
+        "release": "Xanadu",
+        "reviewed": false
+      }
     }
   ]
 }


### PR DESCRIPTION
Converts CSA ui-navigation questions 31-37 from old schema (correctAnswer + string explanation) to new schema (correctAnswers array + object explanation). Unblocks the Cloudflare Pages deploy which was failing validation.