### PR TITLE
feat: send post-purchase follow-up emails

### DIFF
--- a/docs/purchase-followups.md
+++ b/docs/purchase-followups.md
@@ -1,0 +1,45 @@
+# Purchase Follow-up Emails
+
+SNReady sends an automated check-in email after each completed Stripe checkout asking whether the buyer had a good experience and passed their certification exam.
+
+## How it works
+
+1. `checkout.session.completed` in `functions/api/webhook.ts` grants access and enqueues a follow-up record in the existing `SNREADY_ACCESS` KV namespace.
+2. `/api/session` also enqueues the same follow-up after checkout success, so buyers are still scheduled if the Stripe webhook is delayed. The Stripe session ID is the idempotency key, so duplicate scheduling is safe.
+3. A Cloudflare Pages scheduled function or a protected `POST /api/followups/run` call processes due follow-ups daily.
+4. The processor finds due records from KV, sends emails through Resend, marks successful records as `sent`, and deletes their due index key.
+
+## KV keys
+
+- `purchase_followup:{stripeSessionId}` — durable purchase follow-up record.
+- `purchase_followup_due:{YYYY-MM-DD}:{stripeSessionId}` — due-date index scanned by the daily runner.
+
+## Configuration
+
+Cloudflare Pages environment variables/secrets:
+
+- `RESEND_API_KEY` — existing Resend API key used to send email.
+- `SITE_URL` — existing site URL, used for the practice/login link.
+- `FOLLOWUP_RUN_SECRET` — required shared secret for `POST /api/followups/run`.
+- `FOLLOWUP_DELAY_DAYS` — optional number of days after purchase before sending; defaults to `21`.
+- `FOLLOWUP_FROM_EMAIL` — optional sender; defaults to `SNReady <jesse@snready.com>`.
+- `FOLLOWUP_REPLY_TO` — optional reply-to; defaults to `jesse@snready.com`.
+
+Schedule a daily Cloudflare Pages Functions cron trigger for the deployment. The `onScheduled` handler in `functions/api/followups/run.ts` processes up to 100 due emails per run with a 14-day lookback. The protected HTTP endpoint is also available for manual runs or for schedulers that call URLs.
+
+## Manual run
+
+```bash
+curl -X POST \
+  "https://www.snready.com/api/followups/run?dryRun=true&limit=100&lookbackDays=14" \
+  -H "Authorization: Bearer $FOLLOWUP_RUN_SECRET"
+```
+
+Change `dryRun=true` to `dryRun=false` or omit it to send due emails.
+
+## Safety
+
+- Emails are idempotent per Stripe checkout session.
+- Sent records stay in KV for auditability.
+- Due index keys are deleted after successful send.
+- Failed records are marked `failed` with the error message and can be retried by rewriting their status to `pending` or by adding a new due index key.

--- a/functions/api/followups/run.ts
+++ b/functions/api/followups/run.ts
@@ -1,0 +1,74 @@
+import { processDueFollowups } from "../../lib/followup";
+
+interface Env {
+  SNREADY_ACCESS: KVNamespace;
+  RESEND_API_KEY: string;
+  SITE_URL: string;
+  FOLLOWUP_DELAY_DAYS?: string;
+  FOLLOWUP_FROM_EMAIL?: string;
+  FOLLOWUP_REPLY_TO?: string;
+  FOLLOWUP_RUN_SECRET: string;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function isAuthorized(request: Request, env: Env): boolean {
+  if (!env.FOLLOWUP_RUN_SECRET) {
+    console.error("FOLLOWUP_RUN_SECRET is not configured");
+    return false;
+  }
+
+  const authorization = request.headers.get("authorization") || "";
+  const bearerToken = authorization.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : "";
+  const headerToken = request.headers.get("x-followup-secret") || "";
+
+  return bearerToken === env.FOLLOWUP_RUN_SECRET || headerToken === env.FOLLOWUP_RUN_SECRET;
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  if (!isAuthorized(request, env)) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  const url = new URL(request.url);
+  const limit = Number(url.searchParams.get("limit") || "50");
+  const lookbackDays = Number(url.searchParams.get("lookbackDays") || "7");
+  const dryRun = url.searchParams.get("dryRun") === "true";
+
+  try {
+    const result = await processDueFollowups(env, {
+      limit: Number.isFinite(limit) ? Math.min(Math.max(Math.floor(limit), 1), 200) : 50,
+      lookbackDays: Number.isFinite(lookbackDays) ? Math.min(Math.max(Math.floor(lookbackDays), 0), 60) : 7,
+      dryRun,
+    });
+
+    return jsonResponse({ success: true, dryRun, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown follow-up processing error";
+    console.error("Follow-up run failed:", message, error);
+    return jsonResponse({ error: "Follow-up run failed", details: message }, 500);
+  }
+};
+
+export const onRequestGet: PagesFunction<Env> = async () => {
+  return jsonResponse({ error: "Use POST" }, 405);
+};
+
+export const onScheduled: PagesFunction<Env> = async ({ env }) => {
+  try {
+    const result = await processDueFollowups(env, {
+      limit: 100,
+      lookbackDays: 14,
+    });
+    console.log("Purchase follow-up scheduled run complete", JSON.stringify(result));
+    return jsonResponse({ success: true, ...result });
+  } catch (error) {
+    console.error("Purchase follow-up scheduled run failed", error);
+    throw error;
+  }
+};

--- a/functions/api/session.ts
+++ b/functions/api/session.ts
@@ -1,9 +1,15 @@
 import Stripe from "stripe";
+import { enqueuePurchaseFollowup } from "../lib/followup";
 import { makeSessionCookie } from "../lib/session";
 
 interface Env {
   STRIPE_SECRET_KEY: string;
   SNREADY_ACCESS: KVNamespace;
+  RESEND_API_KEY: string;
+  SITE_URL: string;
+  FOLLOWUP_DELAY_DAYS?: string;
+  FOLLOWUP_FROM_EMAIL?: string;
+  FOLLOWUP_REPLY_TO?: string;
 }
 
 // Verify a checkout session and grant access
@@ -107,6 +113,15 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       }),
       kvOptions
     );
+
+    await enqueuePurchaseFollowup(env, {
+      sessionId: session.id,
+      email: normalizedEmail,
+      plan: effectivePlan,
+      certification,
+      certifications,
+      purchasedAt: (session.created || Math.floor(Date.now() / 1000)) * 1000,
+    });
 
     return new Response(
       JSON.stringify({

--- a/functions/api/webhook.ts
+++ b/functions/api/webhook.ts
@@ -1,9 +1,15 @@
 import Stripe from "stripe";
+import { enqueuePurchaseFollowup } from "../lib/followup";
 
 interface Env {
   STRIPE_SECRET_KEY: string;
   STRIPE_WEBHOOK_SECRET: string;
   SNREADY_ACCESS: KVNamespace;
+  RESEND_API_KEY: string;
+  SITE_URL: string;
+  FOLLOWUP_DELAY_DAYS?: string;
+  FOLLOWUP_FROM_EMAIL?: string;
+  FOLLOWUP_REPLY_TO?: string;
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -59,6 +65,16 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
           }),
           kvOptions
         );
+
+        await enqueuePurchaseFollowup(env, {
+          sessionId: session.id,
+          email,
+          plan,
+          certification,
+          certifications: plan === "single" && certification ? [certification] : [],
+          purchasedAt: (session.created || Math.floor(Date.now() / 1000)) * 1000,
+        });
+
         console.log(`Access granted to ${email} (${plan}) until ${new Date(expiresAt).toISOString()}`);
       }
     }

--- a/functions/lib/followup.ts
+++ b/functions/lib/followup.ts
@@ -1,0 +1,286 @@
+export interface FollowupEnv {
+  SNREADY_ACCESS: KVNamespace;
+  RESEND_API_KEY: string;
+  SITE_URL: string;
+  FOLLOWUP_DELAY_DAYS?: string;
+  FOLLOWUP_FROM_EMAIL?: string;
+  FOLLOWUP_REPLY_TO?: string;
+}
+
+export interface PurchaseFollowupRecord {
+  sessionId: string;
+  email: string;
+  plan: string;
+  certification: string;
+  certifications?: string[];
+  purchasedAt: number;
+  dueAt: number;
+  status: "pending" | "sent" | "failed";
+  createdAt: number;
+  sentAt?: number;
+  resendId?: string;
+  error?: string;
+}
+
+export interface ProcessFollowupsResult {
+  checkedDateKeys: string[];
+  due: number;
+  sent: number;
+  failed: number;
+  skipped: number;
+  errors: Array<{ key: string; error: string }>;
+}
+
+const DEFAULT_FOLLOWUP_DELAY_DAYS = 21;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function getFollowupDelayDays(env: Pick<FollowupEnv, "FOLLOWUP_DELAY_DAYS">): number {
+  const configured = Number(env.FOLLOWUP_DELAY_DAYS);
+  if (Number.isFinite(configured) && configured >= 1 && configured <= 180) {
+    return Math.floor(configured);
+  }
+  return DEFAULT_FOLLOWUP_DELAY_DAYS;
+}
+
+function dateKey(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function normalizeEmail(email: string): string {
+  return email.toLowerCase().trim();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function describePurchase(plan: string, certification: string, certifications?: string[]): string {
+  if (plan === "all") {
+    return "all ServiceNow certifications";
+  }
+
+  const certs = certifications?.length ? certifications : certification ? [certification] : [];
+  if (certs.length === 0 || certs.includes("all")) {
+    return "your ServiceNow certification";
+  }
+
+  return certs.map((cert) => cert.toUpperCase()).join(", ");
+}
+
+function buildFollowupEmail(record: PurchaseFollowupRecord, siteUrl: string): { subject: string; html: string; text: string } {
+  const certDescription = describePurchase(record.plan, record.certification, record.certifications);
+  const escapedCertDescription = escapeHtml(certDescription);
+  const subject = "Quick check-in: how did SNReady work for you?";
+  const loginUrl = `${siteUrl.replace(/\/$/, "")}/login`;
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 620px; margin: 0 auto; padding: 24px; color: #1f2937;">
+      <h1 style="color: #059669; margin: 0 0 20px;">SNReady</h1>
+      <p style="font-size: 16px; line-height: 1.6; margin: 0 0 16px;">Hey — just checking in after your SNReady purchase for <strong>${escapedCertDescription}</strong>.</p>
+      <p style="font-size: 16px; line-height: 1.6; margin: 0 0 16px;">Did you have a good experience? And more importantly, did you pass your certification exam?</p>
+      <p style="font-size: 16px; line-height: 1.6; margin: 0 0 20px;">Hit reply and let me know:</p>
+      <ul style="font-size: 16px; line-height: 1.7; padding-left: 24px; margin: 0 0 24px;">
+        <li>Whether you passed</li>
+        <li>Which exam you took</li>
+        <li>What SNReady helped with</li>
+        <li>What would have made it better</li>
+      </ul>
+      <p style="font-size: 16px; line-height: 1.6; margin: 0 0 24px;">If you are still studying, you can keep practicing here:</p>
+      <div style="margin: 28px 0;">
+        <a href="${loginUrl}" style="background-color: #059669; color: #ffffff; padding: 14px 24px; text-decoration: none; border-radius: 8px; font-weight: 700; display: inline-block;">Keep practicing</a>
+      </div>
+      <p style="font-size: 14px; color: #6b7280; line-height: 1.6; margin-top: 28px;">Thanks for using SNReady — your feedback directly improves the question bank for future ServiceNow candidates.</p>
+    </div>
+  `;
+
+  const text = `SNReady\n\nHey — just checking in after your SNReady purchase for ${certDescription}.\n\nDid you have a good experience? And more importantly, did you pass your certification exam?\n\nHit reply and let me know:\n- Whether you passed\n- Which exam you took\n- What SNReady helped with\n- What would have made it better\n\nIf you are still studying, you can keep practicing here: ${loginUrl}\n\nThanks for using SNReady — your feedback directly improves the question bank for future ServiceNow candidates.`;
+
+  return { subject, html, text };
+}
+
+async function sendFollowupEmail(env: FollowupEnv, record: PurchaseFollowupRecord): Promise<string | undefined> {
+  const { subject, html, text } = buildFollowupEmail(record, env.SITE_URL);
+  const from = env.FOLLOWUP_FROM_EMAIL || "SNReady <jesse@snready.com>";
+  const replyTo = env.FOLLOWUP_REPLY_TO || "jesse@snready.com";
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: record.email,
+      reply_to: replyTo,
+      subject,
+      html,
+      text,
+    }),
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(`Resend ${response.status}: ${responseText}`);
+  }
+
+  try {
+    const data = JSON.parse(responseText) as { id?: string };
+    return data.id;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function enqueuePurchaseFollowup(
+  env: FollowupEnv,
+  purchase: {
+    sessionId: string;
+    email: string;
+    plan: string;
+    certification: string;
+    certifications?: string[];
+    purchasedAt?: number;
+  }
+): Promise<PurchaseFollowupRecord> {
+  const normalizedEmail = normalizeEmail(purchase.email);
+  const purchasedAt = purchase.purchasedAt || Date.now();
+  const dueAt = purchasedAt + getFollowupDelayDays(env) * DAY_MS;
+  const record: PurchaseFollowupRecord = {
+    sessionId: purchase.sessionId,
+    email: normalizedEmail,
+    plan: purchase.plan,
+    certification: purchase.certification,
+    certifications: purchase.certifications,
+    purchasedAt,
+    dueAt,
+    status: "pending",
+    createdAt: Date.now(),
+  };
+
+  const recordKey = `purchase_followup:${purchase.sessionId}`;
+  const dueKey = `purchase_followup_due:${dateKey(dueAt)}:${purchase.sessionId}`;
+
+  await Promise.all([
+    env.SNREADY_ACCESS.put(recordKey, JSON.stringify(record)),
+    env.SNREADY_ACCESS.put(dueKey, purchase.sessionId),
+  ]);
+
+  return record;
+}
+
+async function listAllDueKeys(env: FollowupEnv, date: string): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await env.SNREADY_ACCESS.list({ prefix: `purchase_followup_due:${date}:`, cursor });
+    keys.push(...page.keys.map((key) => key.name));
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return keys;
+}
+
+function datesBetween(startTimestamp: number, endTimestamp: number): string[] {
+  const start = new Date(dateKey(startTimestamp)).getTime();
+  const end = new Date(dateKey(endTimestamp)).getTime();
+  const dates: string[] = [];
+
+  for (let day = start; day <= end; day += DAY_MS) {
+    dates.push(dateKey(day));
+  }
+
+  return dates;
+}
+
+export async function processDueFollowups(
+  env: FollowupEnv,
+  options: { now?: number; lookbackDays?: number; limit?: number; dryRun?: boolean } = {}
+): Promise<ProcessFollowupsResult> {
+  const now = options.now || Date.now();
+  const lookbackDays = options.lookbackDays ?? 7;
+  const limit = options.limit ?? 50;
+  const checkedDateKeys = datesBetween(now - lookbackDays * DAY_MS, now);
+  const result: ProcessFollowupsResult = {
+    checkedDateKeys,
+    due: 0,
+    sent: 0,
+    failed: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  const dueKeys = (await Promise.all(checkedDateKeys.map((date) => listAllDueKeys(env, date)))).flat();
+
+  for (const dueKey of dueKeys.slice(0, limit)) {
+    const dueKeyParts = dueKey.split(":");
+    const sessionId = dueKeyParts[dueKeyParts.length - 1];
+    if (!sessionId) {
+      result.skipped += 1;
+      continue;
+    }
+
+    const recordKey = `purchase_followup:${sessionId}`;
+    try {
+      const rawRecord = await env.SNREADY_ACCESS.get(recordKey);
+      if (!rawRecord) {
+        await env.SNREADY_ACCESS.delete(dueKey);
+        result.skipped += 1;
+        continue;
+      }
+
+      const record = JSON.parse(rawRecord) as PurchaseFollowupRecord;
+      if (record.status === "sent") {
+        await env.SNREADY_ACCESS.delete(dueKey);
+        result.skipped += 1;
+        continue;
+      }
+
+      if (record.dueAt > now) {
+        result.skipped += 1;
+        continue;
+      }
+
+      result.due += 1;
+      if (options.dryRun) {
+        continue;
+      }
+
+      try {
+        const resendId = await sendFollowupEmail(env, record);
+        const sentRecord: PurchaseFollowupRecord = {
+          ...record,
+          status: "sent",
+          sentAt: Date.now(),
+          resendId,
+          error: undefined,
+        };
+        await Promise.all([
+          env.SNREADY_ACCESS.put(recordKey, JSON.stringify(sentRecord)),
+          env.SNREADY_ACCESS.delete(dueKey),
+        ]);
+        result.sent += 1;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown send error";
+        const failedRecord: PurchaseFollowupRecord = {
+          ...record,
+          status: "failed",
+          error: message,
+        };
+        await env.SNREADY_ACCESS.put(recordKey, JSON.stringify(failedRecord));
+        result.failed += 1;
+        result.errors.push({ key: recordKey, error: message });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown processing error";
+      result.failed += 1;
+      result.errors.push({ key: dueKey, error: message });
+    }
+  }
+
+  return result;
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,3 +14,8 @@ database_name = "snready-salaries"
 database_id = "9a5b9e4d-59ea-401b-ba2d-05b755dabd90"
 
 # SITE_URL is set as a secret in Cloudflare Pages settings
+# Purchase follow-up emails also use:
+# - RESEND_API_KEY (existing)
+# - FOLLOWUP_RUN_SECRET (for protected manual HTTP runs)
+# - FOLLOWUP_DELAY_DAYS (optional; defaults to 21)
+# - FOLLOWUP_FROM_EMAIL / FOLLOWUP_REPLY_TO (optional)


### PR DESCRIPTION
## Summary
- Enqueue a follow-up email for every paid Stripe checkout using the existing SNREADY_ACCESS KV namespace
- Add a protected /api/followups/run processor plus a scheduled handler for due emails
- Send Resend emails asking buyers whether they had a good experience and passed their certification
- Document KV keys, configuration, and manual dry-run usage

## Test Plan
- npm run build ✅
- npx tsc --noEmit --strict --skipLibCheck --module esnext --moduleResolution bundler --target ES2021 --lib ES2021,WebWorker --types @cloudflare/workers-types functions/lib/followup.ts functions/api/followups/run.ts functions/api/session.ts functions/api/webhook.ts ✅
- npm run lint ⚠️ fails on pre-existing unrelated lint errors in app/salaries, dumps pages, scripts, etc.; no new follow-up files reported

## Deploy notes
- Set Cloudflare Pages secret FOLLOWUP_RUN_SECRET for protected manual runs
- Optional: FOLLOWUP_DELAY_DAYS (defaults to 21), FOLLOWUP_FROM_EMAIL, FOLLOWUP_REPLY_TO
- Configure a daily Cloudflare Pages Functions cron trigger for the onScheduled handler, or call POST /api/followups/run from an existing scheduler
