### PR TITLE
feat(cis-df): add Reddit-informed study guide advice

### DIFF
--- a/app/cis-df/study-guide/page.tsx
+++ b/app/cis-df/study-guide/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   title:
     "How to Pass CIS-DF (Data Foundations) — Complete Study Guide [2026]",
   description:
-    "Everything you need to pass the ServiceNow CIS-DF (Certified Implementation Specialist - Data Foundations) exam. Domain breakdown, study plan, common mistakes, and free practice questions. Govern (35%) is the highest-weight domain — here's how to master it.",
+    "Reddit-informed CIS-DF study guide for the ServiceNow Certified Implementation Specialist - Data Foundations exam. Domain breakdown, community study advice, common mistakes, and free practice questions. Govern (35%) is the highest-weight domain — here's how to master it.",
   keywords: [
     "CIS-DF study guide",
     "CIS-DF exam prep",
@@ -168,6 +168,11 @@ const faqData = [
       "Most candidates with CSA-level ServiceNow experience spend 3-5 weeks preparing for CIS-DF, studying 1-2 hours per day. If you're new to CMDB and CSDM concepts, budget extra time for the Govern domain. We recommend starting with a practice test to identify your weakest domains, then focusing study time there.",
   },
   {
+    question: "What does Reddit say is the best way to prepare for CIS-DF?",
+    answer:
+      "Across ServiceNow Reddit discussions, experienced practitioners repeatedly recommend three things: follow the official NowLearning learning path and exam blueprint, study the CSDM material instead of memorizing isolated table names, and use a personal developer instance for CMDB Health, relationships, Discovery/MID Server, and dashboard practice. Community advice also warns against relying on dumps because implementation-specialist exams test scenario judgment, not just definitions.",
+  },
+  {
     question: "Is there a delta exam for CIS-DF?",
     answer:
       "Yes. ServiceNow releases delta exams after each major release (e.g., Zurich). The delta exam covers only what changed in the new release and is a prerequisite for maintaining your certification. Delta exams typically have 10 questions, are 20 minutes long, and must be completed within the designated exam window.",
@@ -210,6 +215,44 @@ const howToSteps = [
     name: "Take full-length mock exams",
     text: "After studying all domains, take at least 2-3 full-length CIS-DF practice exams under timed conditions. Review every wrong answer and trace it back to the specific domain and concept. Aim for scores consistently above 80% before scheduling the real exam.",
     position: 6,
+  },
+];
+
+const communityTakeaways = [
+  {
+    title: "Use the official blueprint as the spine",
+    source:
+      "r/servicenow certification threads frequently point candidates back to the module-specific NowLearning course and blueprint before using any third-party resource.",
+    action:
+      "Map every study session to one of the five CIS-DF domains, then spend the most review time on Govern, Insight, and Ingest because they make up 74% of the exam.",
+  },
+  {
+    title: "Do not study CSDM as table-name trivia",
+    source:
+      "CSDM and CMDB comments emphasize reading the CSDM guidance, understanding service relationships, and knowing when manual relationships stop scaling.",
+    action:
+      "Draw the relationship chain from Business Service to Service Offering, Service Instance, Application Service, and the supporting CIs until you can explain the business reason for each link.",
+  },
+  {
+    title: "Practice in a PDI, not only flashcards",
+    source:
+      "Community answers routinely recommend running the NowLearning training beside a personal developer instance so the UI and dashboards become familiar.",
+    action:
+      "Open CMDB Health, create a small CI relationship set, review class hierarchy, and trace how Identification and Reconciliation rules handle incoming data.",
+  },
+  {
+    title: "Learn automated vs. manual data ownership",
+    source:
+      "CMDB implementation discussions warn that manual CI and relationship maintenance breaks down quickly unless scope is tiny and stable.",
+    action:
+      "Know when to use Discovery, Service Graph Connectors, MID Server, import sets, and governance controls — and when a manual process is only a temporary bridge.",
+  },
+  {
+    title: "Avoid dumps; review explanations",
+    source:
+      "ServiceNow exam-prep comments favor official courses, blueprints, and concept review over answer dumps because CIS exams ask scenario-based questions.",
+    action:
+      "When you miss a practice question, write the underlying rule in your own words: what data is trusted, who owns it, how it is reconciled, and how the platform reports on it.",
   },
 ];
 
@@ -668,6 +711,60 @@ export default async function CISDFStudyGuidePage() {
                         </h3>
                         <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
                           {step.text}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Community / Reddit Takeaways */}
+        <section className="border-t border-zinc-200 py-16 dark:border-zinc-800">
+          <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+            <div className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-6 dark:border-emerald-900/60 dark:bg-emerald-950/20">
+              <div className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-sm font-medium text-emerald-700 shadow-sm dark:bg-zinc-900 dark:text-emerald-300">
+                Reddit-informed study notes
+              </div>
+              <h2 className="mt-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+                What ServiceNow Reddit Comments Reveal About Passing CIS-DF
+              </h2>
+              <p className="mt-3 text-zinc-600 dark:text-zinc-400">
+                Reddit does not have many CIS-DF-specific exam reports yet, but
+                the recurring advice across r/servicenow CMDB, CSDM, Discovery,
+                and implementation-specialist certification threads is consistent:
+                use the official blueprint, practice hands-on, and learn why
+                data governance decisions are made — not just what fields are
+                named.
+              </p>
+
+              <div className="mt-8 space-y-4">
+                {communityTakeaways.map((item, index) => (
+                  <div
+                    key={item.title}
+                    className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+                  >
+                    <div className="flex items-start gap-4">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-sm font-bold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                          {item.title}
+                        </h3>
+                        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                          <span className="font-medium text-zinc-900 dark:text-zinc-200">
+                            Reddit pattern:
+                          </span>{" "}
+                          {item.source}
+                        </p>
+                        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                          <span className="font-medium text-zinc-900 dark:text-zinc-200">
+                            Study action:
+                          </span>{" "}
+                          {item.action}
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Adds a Reddit-informed community advice section to the CIS-DF study guide
- Updates SEO metadata and FAQ structured data to answer Reddit-style prep questions
- Converts recurring r/servicenow CMDB/CSDM/certification themes into actionable study steps

## Research basis
- Pullpush Reddit search over r/servicenow comments/submissions for CIS-DF, Data Foundations, CSDM, CMDB, and CIS exam prep themes
- Key recurring themes: use official NowLearning/blueprint, practice in PDI, understand CSDM relationships, learn automated vs manual CI ownership, avoid dumps

## Test Plan
- npx eslint app/cis-df/study-guide/page.tsx
- npx tsc --noEmit
- npm run build