### PR TITLE
feat: add exam intelligence profile generator

### DIFF
--- a/data/exam-intel/README.md
+++ b/data/exam-intel/README.md
@@ -1,0 +1,24 @@
+# Exam Intelligence Data
+
+This directory contains publishable symbolic exam-intelligence artifacts. It must not contain raw exam dumps, verbatim observed exam questions, or private source material.
+
+## Layout
+
+- `artifacts/servicenow-core-artifacts.json` — reusable question-shape registry used to classify and plan ServiceNow exam-style items.
+- `profiles/*-exam-profile.json` — quantified profiles generated from SNReady's existing public question bank. These summarize artifact/fact distributions and generation targets without raw dump text.
+
+## Generate profiles
+
+```bash
+npm run exam-intel:profile
+# optional single cert
+npx tsx scripts/exam-intel/profile-existing-questions.ts --cert=csa
+```
+
+The generator is deterministic except for `generatedAt`. For reproducible CI/local diffs, set `SNREADY_EXAM_INTEL_GENERATED_AT`.
+
+## Guardrails
+
+- Do not store raw dump stems/options here.
+- Dump-derived material must be quarantined outside public app data until distilled into artifacts/facts/mappings.
+- Facts should be source-verified before they are used to render public SNReady questions.

--- a/data/exam-intel/artifacts/servicenow-core-artifacts.json
+++ b/data/exam-intel/artifacts/servicenow-core-artifacts.json
@@ -1,0 +1,98 @@
+{
+  "version": "1.0.0",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "description": "Reusable symbolic artifact registry for classifying ServiceNow exam-style question shapes without publishing or storing raw dump content.",
+  "artifacts": [
+    {
+      "id": "entity_table_name_lookup",
+      "name": "Entity/table name lookup",
+      "description": "Given a ServiceNow entity, class, record type, or concept, ask for its backing table or class name.",
+      "factType": "entity_table_name",
+      "generationUse": "Rotate table/class stems and typed same-family table distractors."
+    },
+    {
+      "id": "role_permission_lookup",
+      "name": "Role/permission lookup",
+      "description": "Given an action, module, feature, or capability, ask which role grants access or permission.",
+      "factType": "role_permission",
+      "generationUse": "Bind verified role facts to scenario stems and adjacent-role distractors."
+    },
+    {
+      "id": "choose_valid_components",
+      "name": "Choose valid components",
+      "description": "Ask which options are valid members, components, features, states, or values of a set.",
+      "factType": "component_membership",
+      "generationUse": "Use sibling concepts from the same product area as distractors."
+    },
+    {
+      "id": "configuration_order_sequence",
+      "name": "Configuration order/sequence",
+      "description": "Ask first/next/final step or dependency order in a configuration or process flow.",
+      "factType": "ordered_process",
+      "generationUse": "Rotate process steps while preserving the verified dependency ordering."
+    },
+    {
+      "id": "navigation_path_lookup",
+      "name": "Navigation path lookup",
+      "description": "Ask where to navigate in ServiceNow to reach a module, list, menu, workspace, or UI action.",
+      "factType": "navigation_path",
+      "generationUse": "Use adjacent application/module paths as distractors."
+    },
+    {
+      "id": "scenario_best_tool",
+      "name": "Scenario best tool/method",
+      "description": "Given a short scenario, ask for the best ServiceNow tool, method, configuration, or feature.",
+      "factType": "scenario_tool_fit",
+      "generationUse": "Create applied stems that discriminate between similar ServiceNow features."
+    },
+    {
+      "id": "identify_invalid_option",
+      "name": "Identify invalid option",
+      "description": "NOT/EXCEPT/cannot/invalid-style item asking which option does not belong.",
+      "factType": "negative_membership",
+      "generationUse": "Generate controlled negative variants from positive set membership facts."
+    },
+    {
+      "id": "concept_difference_lookup",
+      "name": "Concept difference lookup",
+      "description": "Ask for the key difference between two related ServiceNow concepts, records, or features.",
+      "factType": "concept_difference",
+      "generationUse": "Pair related concepts and rotate difference-focused distractors."
+    },
+    {
+      "id": "relationship_lookup",
+      "name": "Relationship lookup",
+      "description": "Ask how two ServiceNow concepts, records, CIs, or process objects relate to each other.",
+      "factType": "relationship",
+      "generationUse": "Bind entity pairs to verified relationship facts."
+    },
+    {
+      "id": "default_value_lookup",
+      "name": "Default value lookup",
+      "description": "Ask for a default property, value, state, duration, threshold, or preconfigured behavior.",
+      "factType": "default_value",
+      "generationUse": "Use nearby valid values and adjacent properties as distractors."
+    },
+    {
+      "id": "release_feature_lookup",
+      "name": "Release feature lookup",
+      "description": "Ask which feature, capability, API, or behavior was added or changed in a named release.",
+      "factType": "release_feature",
+      "generationUse": "Drive delta exam coverage from release-note facts."
+    },
+    {
+      "id": "business_outcome_lookup",
+      "name": "Business outcome lookup",
+      "description": "Ask what business outcome, benefit, KPI, or process result a ServiceNow feature supports.",
+      "factType": "business_outcome",
+      "generationUse": "Create outcome-oriented applied questions tied to source-backed benefits."
+    },
+    {
+      "id": "property_behavior_lookup",
+      "name": "Property behavior lookup",
+      "description": "Ask how a system property, setting, or configuration changes platform behavior.",
+      "factType": "property_behavior",
+      "generationUse": "Generate property-behavior variants with adjacent-property distractors."
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cad-exam-profile.json
+++ b/data/exam-intel/profiles/cad-exam-profile.json
@@ -1,0 +1,2478 @@
+{
+  "certification": "cad",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 200,
+  "classifiedItemCount": 199,
+  "classifiedPercentage": 99.5,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 47,
+      "percentage": 23.6,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 45,
+      "percentage": 22.6,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 44,
+      "percentage": 22.1,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 38,
+      "percentage": 19.1,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 12,
+      "percentage": 6,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 3,
+      "percentage": 1.5,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 3,
+      "percentage": 1.5,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 3,
+      "percentage": 1.5,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 2,
+      "percentage": 1,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 2,
+      "percentage": 1,
+      "artifactId": "navigation_path_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 47,
+      "percentage": 23.6,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "release_feature",
+      "count": 45,
+      "percentage": 22.6,
+      "factType": "release_feature"
+    },
+    {
+      "id": "component_membership",
+      "count": 44,
+      "percentage": 22.1,
+      "factType": "component_membership"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 38,
+      "percentage": 19.1,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 12,
+      "percentage": 6,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "default_value",
+      "count": 3,
+      "percentage": 1.5,
+      "factType": "default_value"
+    },
+    {
+      "id": "ordered_process",
+      "count": 3,
+      "percentage": 1.5,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "role_permission",
+      "count": 3,
+      "percentage": 1.5,
+      "factType": "role_permission"
+    },
+    {
+      "id": "business_outcome",
+      "count": 2,
+      "percentage": 1,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "navigation_path",
+      "count": 2,
+      "percentage": 1,
+      "factType": "navigation_path"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "application-development",
+      "count": 52,
+      "percentage": 26.1,
+      "topic": "application-development"
+    },
+    {
+      "id": "scripting-apis",
+      "count": 34,
+      "percentage": 17.1,
+      "topic": "scripting-apis"
+    },
+    {
+      "id": "business-rules",
+      "count": 24,
+      "percentage": 12.1,
+      "topic": "business-rules"
+    },
+    {
+      "id": "client-scripts",
+      "count": 21,
+      "percentage": 10.6,
+      "topic": "client-scripts"
+    },
+    {
+      "id": "integration-rest",
+      "count": 21,
+      "percentage": 10.6,
+      "topic": "integration-rest"
+    },
+    {
+      "id": "ui-policies-actions",
+      "count": 21,
+      "percentage": 10.6,
+      "topic": "ui-policies-actions"
+    },
+    {
+      "id": "script-includes",
+      "count": 20,
+      "percentage": 10.1,
+      "topic": "script-includes"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 6,
+      "percentage": 3,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 24,
+    "release_feature_lookup": 23,
+    "choose_valid_components": 22,
+    "scenario_best_tool": 19,
+    "entity_table_name_lookup": 6,
+    "default_value_lookup": 5,
+    "configuration_order_sequence": 5,
+    "role_permission_lookup": 5,
+    "navigation_path_lookup": 5,
+    "business_outcome_lookup": 5
+  },
+  "lowConfidenceExamples": [],
+  "unmatchedExamples": [
+    {
+      "id": "cad-application-development-009",
+      "topic": "application-development"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cad-application-development-001",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cad-application-development-002",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-003",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-004",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cad-application-development-005",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-application-development-006",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-007",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-008",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-010",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-011",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-012",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-013",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-application-development-014",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cad-application-development-015",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-016",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-application-development-017",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-018",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-019",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-020",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-021",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-application-development-022",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-023",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-024",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-025",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-026",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-027",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-028",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-application-development-029",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-030",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-031",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-032",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-033",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-034",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-035",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-application-development-036",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-037",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-application-development-038",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-039",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-040",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-041",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-042",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-043",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-044",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-045",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-application-development-046",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-application-development-047",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-048",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-application-development-049",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cad-app-dev-050",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cad-app-dev-051",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-app-dev-052",
+      "topic": "application-development",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-app-dev-053",
+      "topic": "application-development",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-001",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-002",
+      "topic": "business-rules",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-business-rules-003",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-004",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-business-rules-005",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-business-rules-006",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-007",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-business-rules-008",
+      "topic": "business-rules",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-business-rules-009",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-010",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-011",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-012",
+      "topic": "business-rules",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-business-rules-013",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-business-rules-014",
+      "topic": "business-rules",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-business-rules-015",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-business-rules-016",
+      "topic": "business-rules",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-business-rules-017",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-018",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-019",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-business-rules-020",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-business-rules-021",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-business-rules-022",
+      "topic": "business-rules",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-business-rules-023",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-business-rules-024",
+      "topic": "business-rules",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-001",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-002",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-003",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-004",
+      "topic": "client-scripts",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-005",
+      "topic": "client-scripts",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-006",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-007",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-008",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-009",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-010",
+      "topic": "client-scripts",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-011",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-012",
+      "topic": "client-scripts",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-013",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-014",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-015",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-016",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-017",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-018",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-019",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-020",
+      "topic": "client-scripts",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-client-scripts-021",
+      "topic": "client-scripts",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-delta-zurich-006",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-001",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-002",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-003",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-004",
+      "topic": "integration-rest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-005",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-006",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-007",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-008",
+      "topic": "integration-rest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-009",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-010",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-011",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-012",
+      "topic": "integration-rest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-013",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-014",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-015",
+      "topic": "integration-rest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-016",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-017",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-018",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-019",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-020",
+      "topic": "integration-rest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-integration-rest-021",
+      "topic": "integration-rest",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-script-includes-001",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-script-includes-002",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-003",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-004",
+      "topic": "script-includes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-script-includes-005",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-006",
+      "topic": "script-includes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-script-includes-007",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-008",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-script-includes-009",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-script-includes-010",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-011",
+      "topic": "script-includes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-script-includes-012",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-013",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-script-includes-014",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-script-includes-015",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-script-includes-016",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-script-includes-017",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-script-includes-018",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cad-script-includes-019",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cad-script-includes-020",
+      "topic": "script-includes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-001",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-002",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-003",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-004",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-005",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-006",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-007",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-008",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-009",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-010",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-011",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-012",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-013",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-014",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-015",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-016",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-017",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-018",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-019",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-020",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-021",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-022",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-023",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-024",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-025",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-026",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-027",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-028",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-029",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-030",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-031",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-032",
+      "topic": "scripting-apis",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-033",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cad-scripting-apis-034",
+      "topic": "scripting-apis",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-001",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-002",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-003",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-004",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-005",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-006",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-007",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-008",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-009",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-010",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-011",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-012",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-013",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-014",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-015",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-016",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-actions-017",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-021",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-022",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-023",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cad-ui-policies-024",
+      "topic": "ui-policies-actions",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-csm-exam-profile.json
+++ b/data/exam-intel/profiles/cis-csm-exam-profile.json
@@ -1,0 +1,1329 @@
+{
+  "certification": "cis-csm",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 103,
+  "classifiedItemCount": 94,
+  "classifiedPercentage": 91.3,
+  "artifactDistribution": [
+    {
+      "id": "navigation_path_lookup",
+      "count": 13,
+      "percentage": 13.8,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 13,
+      "percentage": 13.8,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 12,
+      "percentage": 12.8,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 11,
+      "percentage": 11.7,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 10,
+      "percentage": 10.6,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 8,
+      "percentage": 8.5,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 7,
+      "percentage": 7.4,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 6,
+      "percentage": 6.4,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 5,
+      "percentage": 5.3,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 4,
+      "percentage": 4.3,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 3,
+      "percentage": 3.2,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 2,
+      "percentage": 2.1,
+      "artifactId": "property_behavior_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "navigation_path",
+      "count": 13,
+      "percentage": 13.8,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "role_permission",
+      "count": 13,
+      "percentage": 13.8,
+      "factType": "role_permission"
+    },
+    {
+      "id": "negative_membership",
+      "count": 12,
+      "percentage": 12.8,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "ordered_process",
+      "count": 11,
+      "percentage": 11.7,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 10,
+      "percentage": 10.6,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "component_membership",
+      "count": 8,
+      "percentage": 8.5,
+      "factType": "component_membership"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 7,
+      "percentage": 7.4,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "concept_difference",
+      "count": 6,
+      "percentage": 6.4,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "release_feature",
+      "count": 5,
+      "percentage": 5.3,
+      "factType": "release_feature"
+    },
+    {
+      "id": "relationship",
+      "count": 4,
+      "percentage": 4.3,
+      "factType": "relationship"
+    },
+    {
+      "id": "default_value",
+      "count": 3,
+      "percentage": 3.2,
+      "factType": "default_value"
+    },
+    {
+      "id": "property_behavior",
+      "count": 2,
+      "percentage": 2.1,
+      "factType": "property_behavior"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "csm-configuration",
+      "count": 27,
+      "percentage": 28.7,
+      "topic": "csm-configuration"
+    },
+    {
+      "id": "foundational-data-model",
+      "count": 19,
+      "percentage": 20.2,
+      "topic": "foundational-data-model"
+    },
+    {
+      "id": "case-management",
+      "count": 16,
+      "percentage": 17,
+      "topic": "case-management"
+    },
+    {
+      "id": "workspace-portals-analytics",
+      "count": 14,
+      "percentage": 14.9,
+      "topic": "workspace-portals-analytics"
+    },
+    {
+      "id": "best-practices-knowledge",
+      "count": 13,
+      "percentage": 13.8,
+      "topic": "best-practices-knowledge"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 5,
+      "percentage": 5.3,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "role_permission_lookup": 14,
+    "navigation_path_lookup": 14,
+    "identify_invalid_option": 13,
+    "configuration_order_sequence": 12,
+    "scenario_best_tool": 11,
+    "choose_valid_components": 9,
+    "entity_table_name_lookup": 7,
+    "concept_difference_lookup": 6,
+    "release_feature_lookup": 5,
+    "relationship_lookup": 5,
+    "default_value_lookup": 5,
+    "property_behavior_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-csm-cm-005",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-005",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-csm-bpk-008",
+      "topic": "best-practices-knowledge"
+    },
+    {
+      "id": "cis-csm-cm-001",
+      "topic": "case-management"
+    },
+    {
+      "id": "cis-csm-cm-004",
+      "topic": "case-management"
+    },
+    {
+      "id": "cis-csm-cfg-011",
+      "topic": "csm-configuration"
+    },
+    {
+      "id": "cis-csm-cfg-013",
+      "topic": "csm-configuration"
+    },
+    {
+      "id": "cis-csm-cfg-019",
+      "topic": "csm-configuration"
+    },
+    {
+      "id": "cis-csm-fdm-001",
+      "topic": "foundational-data-model"
+    },
+    {
+      "id": "cis-csm-fdm-008",
+      "topic": "foundational-data-model"
+    },
+    {
+      "id": "cis-csm-fdm-020",
+      "topic": "foundational-data-model"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-csm-bpk-001",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-002",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-003",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-004",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-005",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-006",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-007",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-009",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-010",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-011",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-012",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-013",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-bpk-014",
+      "topic": "best-practices-knowledge",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-002",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-003",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-005",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-006",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-007",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-008",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-009",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-010",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-011",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-012",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-013",
+      "topic": "case-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-014",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-015",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-016",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-017",
+      "topic": "case-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-csm-cm-018",
+      "topic": "case-management",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-001",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-002",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-003",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-004",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-005",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-006",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-007",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-008",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-009",
+      "topic": "csm-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-010",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-012",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-014",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-015",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-016",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-017",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-018",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-020",
+      "topic": "csm-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-021",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-022",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-023",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-024",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-025",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-026",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-027",
+      "topic": "csm-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-028",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-029",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-csm-cfg-030",
+      "topic": "csm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-csm-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-csm-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-csm-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-csm-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-002",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-003",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-004",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-005",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-006",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-007",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-009",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-010",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-011",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-012",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-013",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-014",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-015",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-016",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-017",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-018",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-019",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-021",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-csm-fdm-022",
+      "topic": "foundational-data-model",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-001",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-002",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-003",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-004",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-005",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-006",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-007",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-008",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-009",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-010",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-011",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-012",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-013",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-csm-wpa-014",
+      "topic": "workspace-portals-analytics",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-df-exam-profile.json
+++ b/data/exam-intel/profiles/cis-df-exam-profile.json
@@ -1,0 +1,2722 @@
+{
+  "certification": "cis-df",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 222,
+  "classifiedItemCount": 220,
+  "classifiedPercentage": 99.1,
+  "artifactDistribution": [
+    {
+      "id": "choose_valid_components",
+      "count": 44,
+      "percentage": 20,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 44,
+      "percentage": 20,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 41,
+      "percentage": 18.6,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 19,
+      "percentage": 8.6,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 18,
+      "percentage": 8.2,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 15,
+      "percentage": 6.8,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 9,
+      "percentage": 4.1,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 8,
+      "percentage": 3.6,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 7,
+      "percentage": 3.2,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 6,
+      "percentage": 2.7,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 5,
+      "percentage": 2.3,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 4,
+      "percentage": 1.8,
+      "artifactId": "relationship_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "component_membership",
+      "count": 44,
+      "percentage": 20,
+      "factType": "component_membership"
+    },
+    {
+      "id": "release_feature",
+      "count": 44,
+      "percentage": 20,
+      "factType": "release_feature"
+    },
+    {
+      "id": "negative_membership",
+      "count": 41,
+      "percentage": 18.6,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 19,
+      "percentage": 8.6,
+      "factType": "role_permission"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 18,
+      "percentage": 8.2,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "default_value",
+      "count": 15,
+      "percentage": 6.8,
+      "factType": "default_value"
+    },
+    {
+      "id": "navigation_path",
+      "count": 9,
+      "percentage": 4.1,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "business_outcome",
+      "count": 8,
+      "percentage": 3.6,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "ordered_process",
+      "count": 7,
+      "percentage": 3.2,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 6,
+      "percentage": 2.7,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "concept_difference",
+      "count": 5,
+      "percentage": 2.3,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "relationship",
+      "count": 4,
+      "percentage": 1.8,
+      "factType": "relationship"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "govern",
+      "count": 94,
+      "percentage": 42.7,
+      "topic": "govern"
+    },
+    {
+      "id": "insight",
+      "count": 36,
+      "percentage": 16.4,
+      "topic": "insight"
+    },
+    {
+      "id": "ingest",
+      "count": 33,
+      "percentage": 15,
+      "topic": "ingest"
+    },
+    {
+      "id": "configuration",
+      "count": 29,
+      "percentage": 13.2,
+      "topic": "configuration"
+    },
+    {
+      "id": "csdm-fundamentals",
+      "count": 22,
+      "percentage": 10,
+      "topic": "csdm-fundamentals"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 6,
+      "percentage": 2.7,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "release_feature_lookup": 20,
+    "choose_valid_components": 20,
+    "identify_invalid_option": 19,
+    "role_permission_lookup": 9,
+    "entity_table_name_lookup": 8,
+    "default_value_lookup": 7,
+    "navigation_path_lookup": 5,
+    "business_outcome_lookup": 5,
+    "configuration_order_sequence": 5,
+    "scenario_best_tool": 5,
+    "concept_difference_lookup": 5,
+    "relationship_lookup": 5
+  },
+  "lowConfidenceExamples": [],
+  "unmatchedExamples": [
+    {
+      "id": "cis-df-csdm-fundamentals-020",
+      "topic": "csdm-fundamentals"
+    },
+    {
+      "id": "cis-df-govern-094",
+      "topic": "govern"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-df-configuration-001",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-002",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-003",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-004",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-005",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-006",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-007",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-008",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-009",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-010",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-011",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-012",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-013",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-014",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-015",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-016",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-017",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-018",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-019",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-020",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-021",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-022",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-023",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-024",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-025",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-026",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-027",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-028",
+      "topic": "configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-configuration-029",
+      "topic": "configuration",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-001",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-002",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-003",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-004",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-005",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-006",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-007",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-008",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-009",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-010",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-011",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-012",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-013",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-014",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-015",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-016",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-017",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-018",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-019",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-021",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-022",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-df-csdm-fundamentals-023",
+      "topic": "csdm-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-df-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-delta-zurich-006",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-001",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-002",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-003",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-004",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-005",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-govern-006",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-govern-007",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-df-govern-008",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-df-govern-009",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-govern-010",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-govern-011",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-012",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-013",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-014",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-015",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-govern-016",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-govern-017",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-govern-018",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-019",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-020",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-021",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-govern-022",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-govern-023",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-024",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-025",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-df-govern-026",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-govern-027",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-028",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-df-govern-029",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-030",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-031",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-032",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-033",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-034",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-govern-035",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-036",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-037",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-govern-038",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-df-govern-039",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-df-govern-040",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-041",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-042",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-df-govern-043",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-044",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-df-govern-045",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-govern-046",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-df-govern-047",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-df-govern-048",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-049",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-df-govern-050",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-051",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-052",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-df-govern-053",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-govern-054",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-govern-055",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-df-govern-056",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-057",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-058",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-059",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-060",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-061",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-062",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-govern-063",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-govern-064",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-065",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-066",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-govern-067",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-068",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-069",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-govern-070",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-071",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-df-govern-072",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-073",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-govern-074",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-govern-075",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-df-govern-076",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-df-govern-077",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-078",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-govern-079",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-govern-080",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-df-govern-081",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-govern-082",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-govern-083",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-084",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-govern-085",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-df-govern-086",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-govern-087",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-govern-088",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-govern-089",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-df-govern-090",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-govern-091",
+      "topic": "govern",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-govern-092",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-govern-093",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-govern-095",
+      "topic": "govern",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-001",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-002",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-003",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-004",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-005",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-006",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-007",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-008",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-009",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-010",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-011",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-012",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-013",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-014",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-015",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-016",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-017",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-018",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-019",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-020",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-021",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-022",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-023",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-024",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-025",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-026",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-027",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-028",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-029",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-030",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-031",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-032",
+      "topic": "ingest",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-ingest-033",
+      "topic": "ingest",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-001",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-002",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-insight-003",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-insight-004",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-df-insight-005",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-insight-006",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-df-insight-007",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-insight-008",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-009",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-010",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-df-insight-011",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-012",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-insight-013",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-insight-014",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-015",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-df-insight-016",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-df-insight-017",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-insight-018",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-019",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-020",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-021",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-insight-022",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-insight-023",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-df-insight-024",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-df-insight-025",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-df-insight-026",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-027",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-028",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-029",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-df-insight-030",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-031",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-df-insight-032",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-df-insight-033",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-034",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-df-insight-035",
+      "topic": "insight",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-df-insight-036",
+      "topic": "insight",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-discovery-exam-profile.json
+++ b/data/exam-intel/profiles/cis-discovery-exam-profile.json
@@ -1,0 +1,1185 @@
+{
+  "certification": "cis-discovery",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 85,
+  "classifiedPercentage": 85,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 30,
+      "percentage": 35.3,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 15,
+      "percentage": 17.6,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 11,
+      "percentage": 12.9,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 9,
+      "percentage": 10.6,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 5,
+      "percentage": 5.9,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 5,
+      "percentage": 5.9,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 4,
+      "percentage": 4.7,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 2,
+      "percentage": 2.4,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 2,
+      "percentage": 2.4,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 2,
+      "percentage": 2.4,
+      "artifactId": "scenario_best_tool"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 30,
+      "percentage": 35.3,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 15,
+      "percentage": 17.6,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "default_value",
+      "count": 11,
+      "percentage": 12.9,
+      "factType": "default_value"
+    },
+    {
+      "id": "role_permission",
+      "count": 9,
+      "percentage": 10.6,
+      "factType": "role_permission"
+    },
+    {
+      "id": "ordered_process",
+      "count": 5,
+      "percentage": 5.9,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "release_feature",
+      "count": 5,
+      "percentage": 5.9,
+      "factType": "release_feature"
+    },
+    {
+      "id": "navigation_path",
+      "count": 4,
+      "percentage": 4.7,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "component_membership",
+      "count": 2,
+      "percentage": 2.4,
+      "factType": "component_membership"
+    },
+    {
+      "id": "concept_difference",
+      "count": 2,
+      "percentage": 2.4,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 2,
+      "percentage": 2.4,
+      "factType": "scenario_tool_fit"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "pattern-design",
+      "count": 27,
+      "percentage": 31.8,
+      "topic": "pattern-design"
+    },
+    {
+      "id": "discovery-configuration",
+      "count": 24,
+      "percentage": 28.2,
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cmdb-integration",
+      "count": 17,
+      "percentage": 20,
+      "topic": "cmdb-integration"
+    },
+    {
+      "id": "engagement-readiness",
+      "count": 13,
+      "percentage": 15.3,
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 4,
+      "percentage": 4.7,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 35,
+    "entity_table_name_lookup": 18,
+    "default_value_lookup": 13,
+    "role_permission_lookup": 11,
+    "release_feature_lookup": 6,
+    "configuration_order_sequence": 6,
+    "navigation_path_lookup": 5,
+    "choose_valid_components": 5,
+    "concept_difference_lookup": 5,
+    "scenario_best_tool": 5
+  },
+  "lowConfidenceExamples": [],
+  "unmatchedExamples": [
+    {
+      "id": "cis-discovery-cmdb-017",
+      "topic": "cmdb-integration"
+    },
+    {
+      "id": "cis-discovery-configuration-001",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-discovery-configuration-002",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-discovery-configuration-010",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-discovery-configuration-019",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-discovery-configuration-020",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-discovery-configuration-024",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-discovery-engagement-001",
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "cis-discovery-engagement-005",
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "cis-discovery-engagement-009",
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "cis-discovery-engagement-010",
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "cis-discovery-engagement-011",
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "cis-discovery-pattern-design-004",
+      "topic": "pattern-design"
+    },
+    {
+      "id": "cis-discovery-pattern-design-006",
+      "topic": "pattern-design"
+    },
+    {
+      "id": "cis-discovery-pattern-design-025",
+      "topic": "pattern-design"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-discovery-cmdb-001",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-002",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-003",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-004",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-005",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-006",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-007",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-008",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-009",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-010",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-011",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-012",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-013",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-014",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-015",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-016",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-discovery-cmdb-018",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-discovery-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-discovery-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-discovery-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-003",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-004",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-005",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-006",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-007",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-008",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-009",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-011",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-012",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-013",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-014",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-015",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-016",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-017",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-018",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-021",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-022",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-023",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-025",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-026",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-027",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-028",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-029",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-configuration-030",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-002",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-003",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-004",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-006",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-007",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-008",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-012",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-013",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-014",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-015",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-016",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-017",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-discovery-engagement-018",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-001",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-002",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-003",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-005",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-007",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-008",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-009",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-010",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-011",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-012",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-013",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-014",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-015",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-016",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-017",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-018",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-019",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-020",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-021",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-022",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-023",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-024",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-026",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-027",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-028",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-029",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-discovery-pattern-design-030",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-em-exam-profile.json
+++ b/data/exam-intel/profiles/cis-em-exam-profile.json
@@ -1,0 +1,1337 @@
+{
+  "certification": "cis-em",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 105,
+  "classifiedItemCount": 105,
+  "classifiedPercentage": 100,
+  "artifactDistribution": [
+    {
+      "id": "release_feature_lookup",
+      "count": 66,
+      "percentage": 62.9,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 17,
+      "percentage": 16.2,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 9,
+      "percentage": 8.6,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 7,
+      "percentage": 6.7,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 2,
+      "percentage": 1.9,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 2,
+      "percentage": 1.9,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "navigation_path_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "release_feature",
+      "count": 66,
+      "percentage": 62.9,
+      "factType": "release_feature"
+    },
+    {
+      "id": "negative_membership",
+      "count": 17,
+      "percentage": 16.2,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "component_membership",
+      "count": 9,
+      "percentage": 8.6,
+      "factType": "component_membership"
+    },
+    {
+      "id": "default_value",
+      "count": 7,
+      "percentage": 6.7,
+      "factType": "default_value"
+    },
+    {
+      "id": "role_permission",
+      "count": 2,
+      "percentage": 1.9,
+      "factType": "role_permission"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 2,
+      "percentage": 1.9,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 1,
+      "percentage": 1,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "navigation_path",
+      "count": 1,
+      "percentage": 1,
+      "factType": "navigation_path"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "alerts-tasks",
+      "count": 30,
+      "percentage": 28.6,
+      "topic": "alerts-tasks"
+    },
+    {
+      "id": "event-configuration",
+      "count": 27,
+      "percentage": 25.7,
+      "topic": "event-configuration"
+    },
+    {
+      "id": "event-sources",
+      "count": 16,
+      "percentage": 15.2,
+      "topic": "event-sources"
+    },
+    {
+      "id": "architecture-discovery",
+      "count": 10,
+      "percentage": 9.5,
+      "topic": "architecture-discovery"
+    },
+    {
+      "id": "metric-intelligence",
+      "count": 10,
+      "percentage": 9.5,
+      "topic": "metric-intelligence"
+    },
+    {
+      "id": "em-overview",
+      "count": 7,
+      "percentage": 6.7,
+      "topic": "em-overview"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 5,
+      "percentage": 4.8,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "release_feature_lookup": 63,
+    "identify_invalid_option": 16,
+    "choose_valid_components": 9,
+    "default_value_lookup": 7,
+    "role_permission_lookup": 5,
+    "scenario_best_tool": 5,
+    "entity_table_name_lookup": 5,
+    "navigation_path_lookup": 5
+  },
+  "lowConfidenceExamples": [],
+  "unmatchedExamples": [],
+  "classifiedQuestions": [
+    {
+      "id": "cis-em-alerts-tasks-001",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-002",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-003",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-004",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-005",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-006",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-007",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-008",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-009",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-010",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-011",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-012",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-013",
+      "topic": "alerts-tasks",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-014",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-015",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-016",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-017",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-018",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-019",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-020",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-021",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-022",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-023",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-024",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-025",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-026",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-027",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-028",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-029",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-alerts-tasks-030",
+      "topic": "alerts-tasks",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-001",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-002",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-003",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-004",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-005",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-006",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-007",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-008",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-009",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-architecture-discovery-010",
+      "topic": "architecture-discovery",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-001",
+      "topic": "em-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-002",
+      "topic": "em-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-003",
+      "topic": "em-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-004",
+      "topic": "em-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-005",
+      "topic": "em-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-006",
+      "topic": "em-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-em-overview-007",
+      "topic": "em-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-001",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-002",
+      "topic": "event-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-003",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-004",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-005",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-006",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-007",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-008",
+      "topic": "event-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-009",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-010",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-011",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-012",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-013",
+      "topic": "event-configuration",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-014",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-015",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-016",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-017",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-018",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-019",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-020",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-021",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-022",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-023",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-024",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-025",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-026",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-configuration-027",
+      "topic": "event-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-001",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-002",
+      "topic": "event-sources",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-003",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-004",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-005",
+      "topic": "event-sources",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-006",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-007",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-008",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-009",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-010",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-011",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-012",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-013",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-014",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-015",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-em-event-sources-016",
+      "topic": "event-sources",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-001",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-002",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-003",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-004",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-005",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-006",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-007",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-008",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-009",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-em-metric-intelligence-010",
+      "topic": "metric-intelligence",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-fsm-exam-profile.json
+++ b/data/exam-intel/profiles/cis-fsm-exam-profile.json
@@ -1,0 +1,1335 @@
+{
+  "certification": "cis-fsm",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 98,
+  "classifiedPercentage": 98,
+  "artifactDistribution": [
+    {
+      "id": "configuration_order_sequence",
+      "count": 18,
+      "percentage": 18.4,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 16,
+      "percentage": 16.3,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 15,
+      "percentage": 15.3,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 13,
+      "percentage": 13.3,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 9,
+      "percentage": 9.2,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 8,
+      "percentage": 8.2,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 5,
+      "percentage": 5.1,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 5,
+      "percentage": 5.1,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 4,
+      "percentage": 4.1,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 3,
+      "percentage": 3.1,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 2,
+      "percentage": 2,
+      "artifactId": "business_outcome_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "ordered_process",
+      "count": 18,
+      "percentage": 18.4,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "component_membership",
+      "count": 16,
+      "percentage": 16.3,
+      "factType": "component_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 15,
+      "percentage": 15.3,
+      "factType": "role_permission"
+    },
+    {
+      "id": "negative_membership",
+      "count": 13,
+      "percentage": 13.3,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 9,
+      "percentage": 9.2,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "release_feature",
+      "count": 8,
+      "percentage": 8.2,
+      "factType": "release_feature"
+    },
+    {
+      "id": "concept_difference",
+      "count": 5,
+      "percentage": 5.1,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 5,
+      "percentage": 5.1,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "navigation_path",
+      "count": 4,
+      "percentage": 4.1,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "default_value",
+      "count": 3,
+      "percentage": 3.1,
+      "factType": "default_value"
+    },
+    {
+      "id": "business_outcome",
+      "count": 2,
+      "percentage": 2,
+      "factType": "business_outcome"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "fundamentals",
+      "count": 42,
+      "percentage": 42.9,
+      "topic": "fundamentals"
+    },
+    {
+      "id": "processes",
+      "count": 42,
+      "percentage": 42.9,
+      "topic": "processes"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 5,
+      "percentage": 5.1,
+      "topic": "delta-zurich"
+    },
+    {
+      "id": "planning",
+      "count": 5,
+      "percentage": 5.1,
+      "topic": "planning"
+    },
+    {
+      "id": "related",
+      "count": 4,
+      "percentage": 4.1,
+      "topic": "related"
+    }
+  ],
+  "generationTargets": {
+    "configuration_order_sequence": 18,
+    "choose_valid_components": 16,
+    "role_permission_lookup": 15,
+    "identify_invalid_option": 13,
+    "scenario_best_tool": 9,
+    "release_feature_lookup": 8,
+    "concept_difference_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "navigation_path_lookup": 5,
+    "default_value_lookup": 5,
+    "business_outcome_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-fsm-processes-701",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-955",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-fsm-processes-801",
+      "topic": "processes"
+    },
+    {
+      "id": "cis-fsm-processes-957",
+      "topic": "processes"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-fsm-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-101",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-102",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-103",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-104",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-105",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-106",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-201",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-202",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-203",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-204",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-205",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-206",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-301",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-302",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-303",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-304",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-305",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-306",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-401",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-402",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-403",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-404",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-901",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-902",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-903",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-904",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-905",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-906",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-907",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-908",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-909",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-910",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-911",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-912",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-913",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-914",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-915",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-916",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-917",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-918",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-919",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-fsm-fundamentals-920",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-fsm-planning-501",
+      "topic": "planning",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-planning-502",
+      "topic": "planning",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-planning-503",
+      "topic": "planning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-planning-504",
+      "topic": "planning",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-fsm-planning-505",
+      "topic": "planning",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-601",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-602",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-603",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-604",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-605",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-606",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-701",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-702",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-703",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-704",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-705",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-706",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-802",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-803",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-804",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-805",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-806",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-901",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-902",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-903",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-904",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-905",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-906",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-907",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-951",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-952",
+      "topic": "processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-953",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-954",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-955",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-956",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-958",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-959",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-960",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-961",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-962",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-963",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-964",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-965",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-966",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-967",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-968",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-processes-969",
+      "topic": "processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-fsm-related-1001",
+      "topic": "related",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-fsm-related-1002",
+      "topic": "related",
+      "questionType": "multiple_select",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-fsm-related-1003",
+      "topic": "related",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-fsm-related-1004",
+      "topic": "related",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-ham-exam-profile.json
+++ b/data/exam-intel/profiles/cis-ham-exam-profile.json
@@ -1,0 +1,1280 @@
+{
+  "certification": "cis-ham",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 89,
+  "classifiedPercentage": 89,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 26,
+      "percentage": 29.2,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 13,
+      "percentage": 14.6,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 11,
+      "percentage": 12.4,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 11,
+      "percentage": 12.4,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 8,
+      "percentage": 9,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 7,
+      "percentage": 7.9,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 6,
+      "percentage": 6.7,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 3,
+      "percentage": 3.4,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "scenario_best_tool"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 26,
+      "percentage": 29.2,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "component_membership",
+      "count": 13,
+      "percentage": 14.6,
+      "factType": "component_membership"
+    },
+    {
+      "id": "ordered_process",
+      "count": 11,
+      "percentage": 12.4,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "role_permission",
+      "count": 11,
+      "percentage": 12.4,
+      "factType": "role_permission"
+    },
+    {
+      "id": "concept_difference",
+      "count": 8,
+      "percentage": 9,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 7,
+      "percentage": 7.9,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "default_value",
+      "count": 6,
+      "percentage": 6.7,
+      "factType": "default_value"
+    },
+    {
+      "id": "navigation_path",
+      "count": 3,
+      "percentage": 3.4,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "business_outcome",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "property_behavior",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "release_feature",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "release_feature"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "scenario_tool_fit"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "itam-fundamentals",
+      "count": 22,
+      "percentage": 24.7,
+      "topic": "itam-fundamentals"
+    },
+    {
+      "id": "practical-management",
+      "count": 20,
+      "percentage": 22.5,
+      "topic": "practical-management"
+    },
+    {
+      "id": "data-integrity",
+      "count": 17,
+      "percentage": 19.1,
+      "topic": "data-integrity"
+    },
+    {
+      "id": "operational-integration",
+      "count": 17,
+      "percentage": 19.1,
+      "topic": "operational-integration"
+    },
+    {
+      "id": "financial-management",
+      "count": 13,
+      "percentage": 14.6,
+      "topic": "financial-management"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 29,
+    "choose_valid_components": 15,
+    "role_permission_lookup": 12,
+    "configuration_order_sequence": 12,
+    "concept_difference_lookup": 9,
+    "entity_table_name_lookup": 8,
+    "default_value_lookup": 7,
+    "navigation_path_lookup": 5,
+    "property_behavior_lookup": 5,
+    "scenario_best_tool": 5,
+    "release_feature_lookup": 5,
+    "business_outcome_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-ham-financial-management-005",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-015",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-011",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-ham-data-integrity-001",
+      "topic": "data-integrity"
+    },
+    {
+      "id": "cis-ham-data-integrity-015",
+      "topic": "data-integrity"
+    },
+    {
+      "id": "cis-ham-data-integrity-016",
+      "topic": "data-integrity"
+    },
+    {
+      "id": "cis-ham-financial-management-007",
+      "topic": "financial-management"
+    },
+    {
+      "id": "cis-ham-financial-management-010",
+      "topic": "financial-management"
+    },
+    {
+      "id": "cis-ham-financial-management-012",
+      "topic": "financial-management"
+    },
+    {
+      "id": "cis-ham-operational-integration-003",
+      "topic": "operational-integration"
+    },
+    {
+      "id": "cis-ham-operational-integration-012",
+      "topic": "operational-integration"
+    },
+    {
+      "id": "cis-ham-practical-management-014",
+      "topic": "practical-management"
+    },
+    {
+      "id": "cis-ham-practical-management-017",
+      "topic": "practical-management"
+    },
+    {
+      "id": "cis-ham-practical-management-022",
+      "topic": "practical-management"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-ham-data-integrity-002",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-003",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-004",
+      "topic": "data-integrity",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-005",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-006",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-007",
+      "topic": "data-integrity",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-008",
+      "topic": "data-integrity",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-009",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-010",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-011",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-012",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-013",
+      "topic": "data-integrity",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-014",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-017",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-018",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-019",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-ham-data-integrity-020",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-001",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-002",
+      "topic": "financial-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-003",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-004",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-005",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-006",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-008",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-009",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-011",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-013",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-014",
+      "topic": "financial-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-015",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-ham-financial-management-016",
+      "topic": "financial-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-001",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-002",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-003",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-004",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-005",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-006",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-007",
+      "topic": "itam-fundamentals",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-008",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-009",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-010",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-011",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-012",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-013",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-014",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-015",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-016",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-017",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-018",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-019",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-020",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-021",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-itam-fundamentals-022",
+      "topic": "itam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-001",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-002",
+      "topic": "operational-integration",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-004",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-005",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-006",
+      "topic": "operational-integration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-007",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-008",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-009",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-010",
+      "topic": "operational-integration",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-011",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-013",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-014",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-015",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-016",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-017",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-018",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-operational-integration-019",
+      "topic": "operational-integration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-001",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-002",
+      "topic": "practical-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-003",
+      "topic": "practical-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-004",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-005",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-006",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-007",
+      "topic": "practical-management",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-008",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-009",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-010",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-011",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-012",
+      "topic": "practical-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-013",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-015",
+      "topic": "practical-management",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-016",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-018",
+      "topic": "practical-management",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-019",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-020",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-021",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-ham-practical-management-023",
+      "topic": "practical-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-hr-exam-profile.json
+++ b/data/exam-intel/profiles/cis-hr-exam-profile.json
@@ -1,0 +1,1316 @@
+{
+  "certification": "cis-hr",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 102,
+  "classifiedItemCount": 100,
+  "classifiedPercentage": 98,
+  "artifactDistribution": [
+    {
+      "id": "release_feature_lookup",
+      "count": 45,
+      "percentage": 45,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 20,
+      "percentage": 20,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 16,
+      "percentage": 16,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 5,
+      "percentage": 5,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 5,
+      "percentage": 5,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 3,
+      "percentage": 3,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 3,
+      "percentage": 3,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "scenario_best_tool"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "release_feature",
+      "count": 45,
+      "percentage": 45,
+      "factType": "release_feature"
+    },
+    {
+      "id": "role_permission",
+      "count": 20,
+      "percentage": 20,
+      "factType": "role_permission"
+    },
+    {
+      "id": "negative_membership",
+      "count": 16,
+      "percentage": 16,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "component_membership",
+      "count": 5,
+      "percentage": 5,
+      "factType": "component_membership"
+    },
+    {
+      "id": "default_value",
+      "count": 5,
+      "percentage": 5,
+      "factType": "default_value"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 3,
+      "percentage": 3,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "navigation_path",
+      "count": 3,
+      "percentage": 3,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "concept_difference",
+      "count": 1,
+      "percentage": 1,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "relationship",
+      "count": 1,
+      "percentage": 1,
+      "factType": "relationship"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 1,
+      "percentage": 1,
+      "factType": "scenario_tool_fit"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "hr-system-architecture",
+      "count": 30,
+      "percentage": 30,
+      "topic": "hr-system-architecture"
+    },
+    {
+      "id": "core-hr-applications",
+      "count": 29,
+      "percentage": 29,
+      "topic": "core-hr-applications"
+    },
+    {
+      "id": "hr-journeys",
+      "count": 20,
+      "percentage": 20,
+      "topic": "hr-journeys"
+    },
+    {
+      "id": "hr-security",
+      "count": 16,
+      "percentage": 16,
+      "topic": "hr-security"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 5,
+      "percentage": 5,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "release_feature_lookup": 45,
+    "role_permission_lookup": 20,
+    "identify_invalid_option": 16,
+    "choose_valid_components": 5,
+    "default_value_lookup": 5,
+    "navigation_path_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "scenario_best_tool": 5,
+    "concept_difference_lookup": 5,
+    "relationship_lookup": 5
+  },
+  "lowConfidenceExamples": [],
+  "unmatchedExamples": [
+    {
+      "id": "cis-hr-core-hr-applications-021",
+      "topic": "core-hr-applications"
+    },
+    {
+      "id": "cis-hr-core-hr-applications-025",
+      "topic": "core-hr-applications"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-hr-core-hr-applications-001",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-002",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-003",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-004",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-005",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-006",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-007",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-008",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-009",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-010",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-011",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-012",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-013",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-014",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-015",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-016",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-017",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-018",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-019",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-020",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-022",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-023",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-024",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-026",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-027",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-028",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-029",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-030",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-core-hr-applications-031",
+      "topic": "core-hr-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-hr-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-001",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-002",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-003",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-004",
+      "topic": "hr-journeys",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-005",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-006",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-007",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-008",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-009",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-010",
+      "topic": "hr-journeys",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-011",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-012",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-013",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-014",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-015",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-016",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-017",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-018",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-019",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-journeys-020",
+      "topic": "hr-journeys",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-001",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-002",
+      "topic": "hr-security",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-003",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-004",
+      "topic": "hr-security",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-005",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-006",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-007",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-008",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-009",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-010",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-011",
+      "topic": "hr-security",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-012",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-013",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-014",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-015",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-security-016",
+      "topic": "hr-security",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-001",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-002",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-003",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-004",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-005",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-006",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-007",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-008",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-009",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-010",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-011",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-012",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-013",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-014",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-015",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-016",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-017",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-018",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-019",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-020",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-021",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-022",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-023",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-024",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-025",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-026",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-027",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-028",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-029",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-hr-hr-system-architecture-030",
+      "topic": "hr-system-architecture",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-itsm-exam-profile.json
+++ b/data/exam-intel/profiles/cis-itsm-exam-profile.json
@@ -1,0 +1,1811 @@
+{
+  "certification": "cis-itsm",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 140,
+  "classifiedItemCount": 124,
+  "classifiedPercentage": 88.6,
+  "artifactDistribution": [
+    {
+      "id": "choose_valid_components",
+      "count": 31,
+      "percentage": 25,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 18,
+      "percentage": 14.5,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 16,
+      "percentage": 12.9,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 14,
+      "percentage": 11.3,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 12,
+      "percentage": 9.7,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 7,
+      "percentage": 5.6,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 5,
+      "percentage": 4,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 5,
+      "percentage": 4,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 4,
+      "percentage": 3.2,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 4,
+      "percentage": 3.2,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 4,
+      "percentage": 3.2,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 3,
+      "percentage": 2.4,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 1,
+      "percentage": 0.8,
+      "artifactId": "entity_table_name_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "component_membership",
+      "count": 31,
+      "percentage": 25,
+      "factType": "component_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 18,
+      "percentage": 14.5,
+      "factType": "role_permission"
+    },
+    {
+      "id": "negative_membership",
+      "count": 16,
+      "percentage": 12.9,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "ordered_process",
+      "count": 14,
+      "percentage": 11.3,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "concept_difference",
+      "count": 12,
+      "percentage": 9.7,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "release_feature",
+      "count": 7,
+      "percentage": 5.6,
+      "factType": "release_feature"
+    },
+    {
+      "id": "business_outcome",
+      "count": 5,
+      "percentage": 4,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "default_value",
+      "count": 5,
+      "percentage": 4,
+      "factType": "default_value"
+    },
+    {
+      "id": "navigation_path",
+      "count": 4,
+      "percentage": 3.2,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "relationship",
+      "count": 4,
+      "percentage": 3.2,
+      "factType": "relationship"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 4,
+      "percentage": 3.2,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "property_behavior",
+      "count": 3,
+      "percentage": 2.4,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 1,
+      "percentage": 0.8,
+      "factType": "entity_table_name"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "incident-management",
+      "count": 26,
+      "percentage": 21,
+      "topic": "incident-management"
+    },
+    {
+      "id": "change-management",
+      "count": 25,
+      "percentage": 20.2,
+      "topic": "change-management"
+    },
+    {
+      "id": "problem-management",
+      "count": 20,
+      "percentage": 16.1,
+      "topic": "problem-management"
+    },
+    {
+      "id": "request-management",
+      "count": 19,
+      "percentage": 15.3,
+      "topic": "request-management"
+    },
+    {
+      "id": "itsm-overview",
+      "count": 11,
+      "percentage": 8.9,
+      "topic": "itsm-overview"
+    },
+    {
+      "id": "reporting-metrics",
+      "count": 10,
+      "percentage": 8.1,
+      "topic": "reporting-metrics"
+    },
+    {
+      "id": "sla-management",
+      "count": 7,
+      "percentage": 5.6,
+      "topic": "sla-management"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 6,
+      "percentage": 4.8,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "choose_valid_components": 25,
+    "role_permission_lookup": 15,
+    "identify_invalid_option": 13,
+    "configuration_order_sequence": 11,
+    "concept_difference_lookup": 10,
+    "release_feature_lookup": 6,
+    "business_outcome_lookup": 5,
+    "default_value_lookup": 5,
+    "relationship_lookup": 5,
+    "scenario_best_tool": 5,
+    "navigation_path_lookup": 5,
+    "property_behavior_lookup": 5,
+    "entity_table_name_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-itsm-change-management-004",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-009",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-010",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-003",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-007",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-022",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-003",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-004",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-008",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-001",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-itsm-change-management-013",
+      "topic": "change-management"
+    },
+    {
+      "id": "cis-itsm-change-management-021",
+      "topic": "change-management"
+    },
+    {
+      "id": "cis-itsm-change-management-022",
+      "topic": "change-management"
+    },
+    {
+      "id": "cis-itsm-incident-management-008",
+      "topic": "incident-management"
+    },
+    {
+      "id": "cis-itsm-incident-management-014",
+      "topic": "incident-management"
+    },
+    {
+      "id": "cis-itsm-itsm-overview-005",
+      "topic": "itsm-overview"
+    },
+    {
+      "id": "cis-itsm-problem-management-006",
+      "topic": "problem-management"
+    },
+    {
+      "id": "cis-itsm-problem-management-013",
+      "topic": "problem-management"
+    },
+    {
+      "id": "cis-itsm-problem-management-014",
+      "topic": "problem-management"
+    },
+    {
+      "id": "cis-itsm-problem-management-016",
+      "topic": "problem-management"
+    },
+    {
+      "id": "cis-itsm-request-management-005",
+      "topic": "request-management"
+    },
+    {
+      "id": "cis-itsm-request-management-008",
+      "topic": "request-management"
+    },
+    {
+      "id": "cis-itsm-request-management-010",
+      "topic": "request-management"
+    },
+    {
+      "id": "cis-itsm-sla-management-001",
+      "topic": "sla-management"
+    },
+    {
+      "id": "cis-itsm-sla-management-002",
+      "topic": "sla-management"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-itsm-change-management-001",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-002",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-003",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-004",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-005",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-006",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-007",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-008",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-009",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-010",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-011",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-012",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-014",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-015",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-016",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-017",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-018",
+      "topic": "change-management",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-019",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-020",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-023",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-024",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-025",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-026",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-027",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-change-management-028",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-delta-zurich-006",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-001",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-002",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-003",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-004",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-005",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-006",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-007",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-009",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-010",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-011",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-012",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-013",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-015",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-016",
+      "topic": "incident-management",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-017",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-018",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-019",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-020",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-021",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-022",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-023",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-024",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-025",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-026",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-027",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-itsm-incident-management-028",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-001",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-002",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-003",
+      "topic": "itsm-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-004",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-006",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-007",
+      "topic": "itsm-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-008",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-009",
+      "topic": "itsm-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-010",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-011",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-itsm-overview-012",
+      "topic": "itsm-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-001",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-002",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-003",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-004",
+      "topic": "problem-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-005",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-007",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-008",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-009",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-010",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-011",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-012",
+      "topic": "problem-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-015",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-017",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-018",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-019",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-020",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-021",
+      "topic": "problem-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-022",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-023",
+      "topic": "problem-management",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-problem-management-024",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-001",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-002",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-003",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-004",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-005",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-006",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-007",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-008",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-009",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-reporting-metrics-010",
+      "topic": "reporting-metrics",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-001",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-002",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-003",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-004",
+      "topic": "request-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-006",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-007",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-009",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-011",
+      "topic": "request-management",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-012",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-013",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-014",
+      "topic": "request-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-015",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-016",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-017",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-018",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-019",
+      "topic": "request-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-020",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-021",
+      "topic": "request-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-itsm-request-management-022",
+      "topic": "request-management",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-003",
+      "topic": "sla-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-004",
+      "topic": "sla-management",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-005",
+      "topic": "sla-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-006",
+      "topic": "sla-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-008",
+      "topic": "sla-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-009",
+      "topic": "sla-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-itsm-sla-management-010",
+      "topic": "sla-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-pa-exam-profile.json
+++ b/data/exam-intel/profiles/cis-pa-exam-profile.json
@@ -1,0 +1,1359 @@
+{
+  "certification": "cis-pa",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 102,
+  "classifiedItemCount": 96,
+  "classifiedPercentage": 94.1,
+  "artifactDistribution": [
+    {
+      "id": "choose_valid_components",
+      "count": 22,
+      "percentage": 22.9,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 21,
+      "percentage": 21.9,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 16,
+      "percentage": 16.7,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 9,
+      "percentage": 9.4,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 6,
+      "percentage": 6.3,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 6,
+      "percentage": 6.3,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 4,
+      "percentage": 4.2,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 3,
+      "percentage": 3.1,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 3,
+      "percentage": 3.1,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 2,
+      "percentage": 2.1,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 2,
+      "percentage": 2.1,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 1,
+      "percentage": 1,
+      "artifactId": "relationship_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "component_membership",
+      "count": 22,
+      "percentage": 22.9,
+      "factType": "component_membership"
+    },
+    {
+      "id": "negative_membership",
+      "count": 21,
+      "percentage": 21.9,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 16,
+      "percentage": 16.7,
+      "factType": "role_permission"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 9,
+      "percentage": 9.4,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "navigation_path",
+      "count": 6,
+      "percentage": 6.3,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "ordered_process",
+      "count": 6,
+      "percentage": 6.3,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "concept_difference",
+      "count": 4,
+      "percentage": 4.2,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "default_value",
+      "count": 3,
+      "percentage": 3.1,
+      "factType": "default_value"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 3,
+      "percentage": 3.1,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "property_behavior",
+      "count": 2,
+      "percentage": 2.1,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "release_feature",
+      "count": 2,
+      "percentage": 2.1,
+      "factType": "release_feature"
+    },
+    {
+      "id": "business_outcome",
+      "count": 1,
+      "percentage": 1,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "relationship",
+      "count": 1,
+      "percentage": 1,
+      "factType": "relationship"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "indicators",
+      "count": 20,
+      "percentage": 20.8,
+      "topic": "indicators"
+    },
+    {
+      "id": "visualization-dashboards",
+      "count": 19,
+      "percentage": 19.8,
+      "topic": "visualization-dashboards"
+    },
+    {
+      "id": "breakdowns",
+      "count": 18,
+      "percentage": 18.8,
+      "topic": "breakdowns"
+    },
+    {
+      "id": "architecture-deployment",
+      "count": 14,
+      "percentage": 14.6,
+      "topic": "architecture-deployment"
+    },
+    {
+      "id": "data-collection",
+      "count": 14,
+      "percentage": 14.6,
+      "topic": "data-collection"
+    },
+    {
+      "id": "admin-advanced",
+      "count": 11,
+      "percentage": 11.5,
+      "topic": "admin-advanced"
+    }
+  ],
+  "generationTargets": {
+    "choose_valid_components": 23,
+    "identify_invalid_option": 22,
+    "role_permission_lookup": 17,
+    "entity_table_name_lookup": 9,
+    "configuration_order_sequence": 6,
+    "navigation_path_lookup": 6,
+    "concept_difference_lookup": 5,
+    "default_value_lookup": 5,
+    "scenario_best_tool": 5,
+    "property_behavior_lookup": 5,
+    "release_feature_lookup": 5,
+    "relationship_lookup": 5,
+    "business_outcome_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-pa-architecture-deployment-004",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-014",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-pa-admin-advanced-002",
+      "topic": "admin-advanced"
+    },
+    {
+      "id": "cis-pa-architecture-deployment-011",
+      "topic": "architecture-deployment"
+    },
+    {
+      "id": "cis-pa-breakdowns-004",
+      "topic": "breakdowns"
+    },
+    {
+      "id": "cis-pa-breakdowns-006",
+      "topic": "breakdowns"
+    },
+    {
+      "id": "cis-pa-data-collection-003",
+      "topic": "data-collection"
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-008",
+      "topic": "visualization-dashboards"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-pa-admin-advanced-001",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-003",
+      "topic": "admin-advanced",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-004",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-005",
+      "topic": "admin-advanced",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-006",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-007",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-008",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-009",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-010",
+      "topic": "admin-advanced",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-011",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-admin-advanced-012",
+      "topic": "admin-advanced",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-001",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-002",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-003",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-004",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-005",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-006",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-007",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-008",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-009",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-010",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-012",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-013",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-014",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-pa-architecture-deployment-015",
+      "topic": "architecture-deployment",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-001",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-002",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-003",
+      "topic": "breakdowns",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-005",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-007",
+      "topic": "breakdowns",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-008",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-009",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-010",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-011",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-012",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-013",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-014",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-015",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-016",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-017",
+      "topic": "breakdowns",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-018",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-019",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-breakdowns-020",
+      "topic": "breakdowns",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-001",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-002",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-004",
+      "topic": "data-collection",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-005",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-006",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-007",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-008",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-009",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-010",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-011",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-012",
+      "topic": "data-collection",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-013",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-014",
+      "topic": "data-collection",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-data-collection-015",
+      "topic": "data-collection",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-001",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-002",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-003",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-004",
+      "topic": "indicators",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-005",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-006",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-007",
+      "topic": "indicators",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-008",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-009",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-010",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-011",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-012",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-013",
+      "topic": "indicators",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-014",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-015",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-016",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-017",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-018",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-019",
+      "topic": "indicators",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-indicators-020",
+      "topic": "indicators",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-001",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-002",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-003",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-004",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-005",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-006",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-007",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-009",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-010",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-011",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-012",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-013",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-014",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-015",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-016",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-017",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-018",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-019",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-pa-visualization-dashboards-020",
+      "topic": "visualization-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-rc-exam-profile.json
+++ b/data/exam-intel/profiles/cis-rc-exam-profile.json
@@ -1,0 +1,1231 @@
+{
+  "certification": "cis-rc",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 83,
+  "classifiedPercentage": 83,
+  "artifactDistribution": [
+    {
+      "id": "choose_valid_components",
+      "count": 21,
+      "percentage": 25.3,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 17,
+      "percentage": 20.5,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 14,
+      "percentage": 16.9,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 13,
+      "percentage": 15.7,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 7,
+      "percentage": 8.4,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 4,
+      "percentage": 4.8,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 3,
+      "percentage": 3.6,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 3,
+      "percentage": 3.6,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 1,
+      "percentage": 1.2,
+      "artifactId": "entity_table_name_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "component_membership",
+      "count": 21,
+      "percentage": 25.3,
+      "factType": "component_membership"
+    },
+    {
+      "id": "negative_membership",
+      "count": 17,
+      "percentage": 20.5,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "ordered_process",
+      "count": 14,
+      "percentage": 16.9,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "role_permission",
+      "count": 13,
+      "percentage": 15.7,
+      "factType": "role_permission"
+    },
+    {
+      "id": "navigation_path",
+      "count": 7,
+      "percentage": 8.4,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 4,
+      "percentage": 4.8,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "relationship",
+      "count": 3,
+      "percentage": 3.6,
+      "factType": "relationship"
+    },
+    {
+      "id": "release_feature",
+      "count": 3,
+      "percentage": 3.6,
+      "factType": "release_feature"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 1,
+      "percentage": 1.2,
+      "factType": "entity_table_name"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "entity-framework",
+      "count": 16,
+      "percentage": 19.3,
+      "topic": "entity-framework"
+    },
+    {
+      "id": "common-elements",
+      "count": 13,
+      "percentage": 15.7,
+      "topic": "common-elements"
+    },
+    {
+      "id": "implementation-planning",
+      "count": 13,
+      "percentage": 15.7,
+      "topic": "implementation-planning"
+    },
+    {
+      "id": "risk-advanced-risk",
+      "count": 12,
+      "percentage": 14.5,
+      "topic": "risk-advanced-risk"
+    },
+    {
+      "id": "audit-advanced-audit",
+      "count": 10,
+      "percentage": 12,
+      "topic": "audit-advanced-audit"
+    },
+    {
+      "id": "policy-compliance",
+      "count": 10,
+      "percentage": 12,
+      "topic": "policy-compliance"
+    },
+    {
+      "id": "grc-overview",
+      "count": 9,
+      "percentage": 10.8,
+      "topic": "grc-overview"
+    }
+  ],
+  "generationTargets": {
+    "choose_valid_components": 25,
+    "identify_invalid_option": 21,
+    "configuration_order_sequence": 17,
+    "role_permission_lookup": 16,
+    "navigation_path_lookup": 8,
+    "scenario_best_tool": 5,
+    "release_feature_lookup": 5,
+    "relationship_lookup": 5,
+    "entity_table_name_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-rc-audit-advanced-audit-003",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-003",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-006",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-014",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-005",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-rc-audit-advanced-audit-009",
+      "topic": "audit-advanced-audit"
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-011",
+      "topic": "audit-advanced-audit"
+    },
+    {
+      "id": "cis-rc-common-elements-002",
+      "topic": "common-elements"
+    },
+    {
+      "id": "cis-rc-common-elements-010",
+      "topic": "common-elements"
+    },
+    {
+      "id": "cis-rc-common-elements-011",
+      "topic": "common-elements"
+    },
+    {
+      "id": "cis-rc-grc-overview-005",
+      "topic": "grc-overview"
+    },
+    {
+      "id": "cis-rc-grc-overview-008",
+      "topic": "grc-overview"
+    },
+    {
+      "id": "cis-rc-grc-overview-009",
+      "topic": "grc-overview"
+    },
+    {
+      "id": "cis-rc-implementation-planning-003",
+      "topic": "implementation-planning"
+    },
+    {
+      "id": "cis-rc-policy-compliance-001",
+      "topic": "policy-compliance"
+    },
+    {
+      "id": "cis-rc-policy-compliance-002",
+      "topic": "policy-compliance"
+    },
+    {
+      "id": "cis-rc-policy-compliance-004",
+      "topic": "policy-compliance"
+    },
+    {
+      "id": "cis-rc-policy-compliance-008",
+      "topic": "policy-compliance"
+    },
+    {
+      "id": "cis-rc-policy-compliance-009",
+      "topic": "policy-compliance"
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-001",
+      "topic": "risk-advanced-risk"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-rc-audit-advanced-audit-001",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-002",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-003",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-004",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-005",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-006",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-007",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-008",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-010",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-rc-audit-advanced-audit-012",
+      "topic": "audit-advanced-audit",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-001",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-003",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-004",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-005",
+      "topic": "common-elements",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-006",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-007",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-008",
+      "topic": "common-elements",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-009",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-012",
+      "topic": "common-elements",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-013",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-014",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-015",
+      "topic": "common-elements",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-common-elements-016",
+      "topic": "common-elements",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-001",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-002",
+      "topic": "entity-framework",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-003",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-004",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-005",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-006",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-007",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-008",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-009",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-010",
+      "topic": "entity-framework",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-011",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-012",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-013",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-014",
+      "topic": "entity-framework",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-015",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-rc-entity-framework-016",
+      "topic": "entity-framework",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-001",
+      "topic": "grc-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-002",
+      "topic": "grc-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-003",
+      "topic": "grc-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-004",
+      "topic": "grc-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-006",
+      "topic": "grc-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-007",
+      "topic": "grc-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-010",
+      "topic": "grc-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-011",
+      "topic": "grc-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-grc-overview-012",
+      "topic": "grc-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-001",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-002",
+      "topic": "implementation-planning",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-004",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-005",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-006",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-007",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-008",
+      "topic": "implementation-planning",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-009",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-010",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-011",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-012",
+      "topic": "implementation-planning",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-013",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-rc-implementation-planning-014",
+      "topic": "implementation-planning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-003",
+      "topic": "policy-compliance",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-005",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-006",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-007",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-010",
+      "topic": "policy-compliance",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-011",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-012",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-013",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-014",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-policy-compliance-015",
+      "topic": "policy-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-002",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-003",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-004",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-005",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-007",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-008",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-009",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-010",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-012",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-013",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-014",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-rc-risk-advanced-risk-015",
+      "topic": "risk-advanced-risk",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-sam-exam-profile.json
+++ b/data/exam-intel/profiles/cis-sam-exam-profile.json
@@ -1,0 +1,1305 @@
+{
+  "certification": "cis-sam",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 94,
+  "classifiedPercentage": 94,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 23,
+      "percentage": 24.5,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 13,
+      "percentage": 13.8,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 11,
+      "percentage": 11.7,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 10,
+      "percentage": 10.6,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 8,
+      "percentage": 8.5,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 7,
+      "percentage": 7.4,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 6,
+      "percentage": 6.4,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 5,
+      "percentage": 5.3,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 4,
+      "percentage": 4.3,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 3,
+      "percentage": 3.2,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 2,
+      "percentage": 2.1,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 2,
+      "percentage": 2.1,
+      "artifactId": "relationship_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 23,
+      "percentage": 24.5,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "default_value",
+      "count": 13,
+      "percentage": 13.8,
+      "factType": "default_value"
+    },
+    {
+      "id": "component_membership",
+      "count": 11,
+      "percentage": 11.7,
+      "factType": "component_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 10,
+      "percentage": 10.6,
+      "factType": "role_permission"
+    },
+    {
+      "id": "ordered_process",
+      "count": 8,
+      "percentage": 8.5,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 7,
+      "percentage": 7.4,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "concept_difference",
+      "count": 6,
+      "percentage": 6.4,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "business_outcome",
+      "count": 5,
+      "percentage": 5.3,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "release_feature",
+      "count": 4,
+      "percentage": 4.3,
+      "factType": "release_feature"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 3,
+      "percentage": 3.2,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "navigation_path",
+      "count": 2,
+      "percentage": 2.1,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "relationship",
+      "count": 2,
+      "percentage": 2.1,
+      "factType": "relationship"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "software-compliance",
+      "count": 22,
+      "percentage": 23.4,
+      "topic": "software-compliance"
+    },
+    {
+      "id": "data-integrity",
+      "count": 19,
+      "percentage": 20.2,
+      "topic": "data-integrity"
+    },
+    {
+      "id": "extending-sam",
+      "count": 18,
+      "percentage": 19.1,
+      "topic": "extending-sam"
+    },
+    {
+      "id": "sam-fundamentals",
+      "count": 18,
+      "percentage": 19.1,
+      "topic": "sam-fundamentals"
+    },
+    {
+      "id": "operational-integration",
+      "count": 17,
+      "percentage": 18.1,
+      "topic": "operational-integration"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 25,
+    "default_value_lookup": 14,
+    "choose_valid_components": 12,
+    "role_permission_lookup": 11,
+    "configuration_order_sequence": 9,
+    "entity_table_name_lookup": 7,
+    "concept_difference_lookup": 6,
+    "business_outcome_lookup": 5,
+    "release_feature_lookup": 5,
+    "scenario_best_tool": 5,
+    "relationship_lookup": 5,
+    "navigation_path_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-sam-data-integrity-417",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1219",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "numeric-setting"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-sam-data-integrity-404",
+      "topic": "data-integrity"
+    },
+    {
+      "id": "cis-sam-data-integrity-419",
+      "topic": "data-integrity"
+    },
+    {
+      "id": "cis-sam-data-integrity-422",
+      "topic": "data-integrity"
+    },
+    {
+      "id": "cis-sam-extending-sam-1403",
+      "topic": "extending-sam"
+    },
+    {
+      "id": "cis-sam-operational-integration-1204",
+      "topic": "operational-integration"
+    },
+    {
+      "id": "cis-sam-operational-integration-1209",
+      "topic": "operational-integration"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-sam-data-integrity-401",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-402",
+      "topic": "data-integrity",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-403",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-405",
+      "topic": "data-integrity",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-406",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-407",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-408",
+      "topic": "data-integrity",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-409",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-410",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-411",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-412",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-413",
+      "topic": "data-integrity",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-414",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-415",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-416",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-417",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-418",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-420",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sam-data-integrity-421",
+      "topic": "data-integrity",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1401",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1402",
+      "topic": "extending-sam",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1404",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1405",
+      "topic": "extending-sam",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1406",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1407",
+      "topic": "extending-sam",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1408",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1409",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1410",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1411",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1412",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1413",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1414",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1415",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1416",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1417",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1418",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sam-extending-sam-1419",
+      "topic": "extending-sam",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1201",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1202",
+      "topic": "operational-integration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1203",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1205",
+      "topic": "operational-integration",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1206",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1207",
+      "topic": "operational-integration",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1208",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1210",
+      "topic": "operational-integration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1211",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1212",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1213",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1214",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1215",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1216",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1217",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1218",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-operational-integration-1219",
+      "topic": "operational-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-101",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-102",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-103",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-104",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-105",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-106",
+      "topic": "sam-fundamentals",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-107",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-108",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-109",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-110",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-111",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-112",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-113",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-114",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-115",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-116",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-117",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-sam-fundamentals-118",
+      "topic": "sam-fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-801",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-802",
+      "topic": "software-compliance",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-803",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-804",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-805",
+      "topic": "software-compliance",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-806",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-807",
+      "topic": "software-compliance",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-808",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-809",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-810",
+      "topic": "software-compliance",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-811",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-812",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-813",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-814",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-815",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-816",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-817",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-818",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-819",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-820",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-821",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sam-software-compliance-822",
+      "topic": "software-compliance",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-sir-exam-profile.json
+++ b/data/exam-intel/profiles/cis-sir-exam-profile.json
@@ -1,0 +1,1314 @@
+{
+  "certification": "cis-sir",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 88,
+  "classifiedPercentage": 88,
+  "artifactDistribution": [
+    {
+      "id": "choose_valid_components",
+      "count": 16,
+      "percentage": 18.2,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 16,
+      "percentage": 18.2,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 13,
+      "percentage": 14.8,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 12,
+      "percentage": 13.6,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 12,
+      "percentage": 13.6,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 6,
+      "percentage": 6.8,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 3,
+      "percentage": 3.4,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 3,
+      "percentage": 3.4,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 2,
+      "percentage": 2.3,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 2,
+      "percentage": 2.3,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 2,
+      "percentage": 2.3,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "default_value_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "component_membership",
+      "count": 16,
+      "percentage": 18.2,
+      "factType": "component_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 16,
+      "percentage": 18.2,
+      "factType": "role_permission"
+    },
+    {
+      "id": "ordered_process",
+      "count": 13,
+      "percentage": 14.8,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "navigation_path",
+      "count": 12,
+      "percentage": 13.6,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "negative_membership",
+      "count": 12,
+      "percentage": 13.6,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "property_behavior",
+      "count": 6,
+      "percentage": 6.8,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 3,
+      "percentage": 3.4,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "release_feature",
+      "count": 3,
+      "percentage": 3.4,
+      "factType": "release_feature"
+    },
+    {
+      "id": "business_outcome",
+      "count": 2,
+      "percentage": 2.3,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "relationship",
+      "count": 2,
+      "percentage": 2.3,
+      "factType": "relationship"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 2,
+      "percentage": 2.3,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "default_value",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "default_value"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "automation",
+      "count": 18,
+      "percentage": 20.5,
+      "topic": "automation"
+    },
+    {
+      "id": "creation",
+      "count": 16,
+      "percentage": 18.2,
+      "topic": "creation"
+    },
+    {
+      "id": "overview",
+      "count": 16,
+      "percentage": 18.2,
+      "topic": "overview"
+    },
+    {
+      "id": "management",
+      "count": 15,
+      "percentage": 17,
+      "topic": "management"
+    },
+    {
+      "id": "integrations",
+      "count": 14,
+      "percentage": 15.9,
+      "topic": "integrations"
+    },
+    {
+      "id": "risk",
+      "count": 9,
+      "percentage": 10.2,
+      "topic": "risk"
+    }
+  ],
+  "generationTargets": {
+    "choose_valid_components": 18,
+    "role_permission_lookup": 18,
+    "configuration_order_sequence": 15,
+    "identify_invalid_option": 14,
+    "navigation_path_lookup": 14,
+    "property_behavior_lookup": 7,
+    "release_feature_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "scenario_best_tool": 5,
+    "relationship_lookup": 5,
+    "business_outcome_lookup": 5,
+    "default_value_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-sir-automation-013",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-001",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-003",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-014",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-015",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-006",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-sir-automation-008",
+      "topic": "automation"
+    },
+    {
+      "id": "cis-sir-automation-019",
+      "topic": "automation"
+    },
+    {
+      "id": "cis-sir-automation-021",
+      "topic": "automation"
+    },
+    {
+      "id": "cis-sir-creation-007",
+      "topic": "creation"
+    },
+    {
+      "id": "cis-sir-integrations-001",
+      "topic": "integrations"
+    },
+    {
+      "id": "cis-sir-integrations-005",
+      "topic": "integrations"
+    },
+    {
+      "id": "cis-sir-integrations-017",
+      "topic": "integrations"
+    },
+    {
+      "id": "cis-sir-management-015",
+      "topic": "management"
+    },
+    {
+      "id": "cis-sir-management-017",
+      "topic": "management"
+    },
+    {
+      "id": "cis-sir-risk-001",
+      "topic": "risk"
+    },
+    {
+      "id": "cis-sir-risk-003",
+      "topic": "risk"
+    },
+    {
+      "id": "cis-sir-risk-011",
+      "topic": "risk"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-sir-automation-001",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-002",
+      "topic": "automation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-003",
+      "topic": "automation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-004",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-005",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-006",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-007",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-009",
+      "topic": "automation",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-010",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-011",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-012",
+      "topic": "automation",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-013",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-014",
+      "topic": "automation",
+      "questionType": "multiple_select",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-015",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-016",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-017",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-018",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sir-automation-020",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-001",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-002",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-003",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-004",
+      "topic": "creation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-005",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-006",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-008",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-009",
+      "topic": "creation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-010",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-011",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-012",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-013",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-014",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-015",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-016",
+      "topic": "creation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sir-creation-017",
+      "topic": "creation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-002",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-003",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-004",
+      "topic": "integrations",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-006",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-007",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-008",
+      "topic": "integrations",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-009",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-010",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-011",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-012",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-013",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-014",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-015",
+      "topic": "integrations",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sir-integrations-016",
+      "topic": "integrations",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-management-001",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-management-002",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-management-003",
+      "topic": "management",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-management-004",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sir-management-005",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-management-006",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-management-007",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sir-management-008",
+      "topic": "management",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-management-009",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-management-010",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-management-011",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-management-012",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-management-013",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-management-014",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-management-016",
+      "topic": "management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-001",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-002",
+      "topic": "overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-003",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-004",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-005",
+      "topic": "overview",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-006",
+      "topic": "overview",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-007",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-008",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-009",
+      "topic": "overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-010",
+      "topic": "overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-011",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-012",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-013",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-014",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-015",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-overview-016",
+      "topic": "overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-002",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-004",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-005",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-006",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-007",
+      "topic": "risk",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-008",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-009",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-010",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sir-risk-012",
+      "topic": "risk",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-sm-exam-profile.json
+++ b/data/exam-intel/profiles/cis-sm-exam-profile.json
@@ -1,0 +1,1341 @@
+{
+  "certification": "cis-sm",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 103,
+  "classifiedItemCount": 92,
+  "classifiedPercentage": 89.3,
+  "artifactDistribution": [
+    {
+      "id": "default_value_lookup",
+      "count": 14,
+      "percentage": 15.2,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 14,
+      "percentage": 15.2,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 13,
+      "percentage": 14.1,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 12,
+      "percentage": 13,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 9,
+      "percentage": 9.8,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 8,
+      "percentage": 8.7,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 8,
+      "percentage": 8.7,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 4,
+      "percentage": 4.3,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 4,
+      "percentage": 4.3,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 2,
+      "percentage": 2.2,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 2,
+      "percentage": 2.2,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "concept_difference_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "default_value",
+      "count": 14,
+      "percentage": 15.2,
+      "factType": "default_value"
+    },
+    {
+      "id": "role_permission",
+      "count": 14,
+      "percentage": 15.2,
+      "factType": "role_permission"
+    },
+    {
+      "id": "negative_membership",
+      "count": 13,
+      "percentage": 14.1,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "ordered_process",
+      "count": 12,
+      "percentage": 13,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 9,
+      "percentage": 9.8,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "component_membership",
+      "count": 8,
+      "percentage": 8.7,
+      "factType": "component_membership"
+    },
+    {
+      "id": "release_feature",
+      "count": 8,
+      "percentage": 8.7,
+      "factType": "release_feature"
+    },
+    {
+      "id": "navigation_path",
+      "count": 4,
+      "percentage": 4.3,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 4,
+      "percentage": 4.3,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "property_behavior",
+      "count": 2,
+      "percentage": 2.2,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "relationship",
+      "count": 2,
+      "percentage": 2.2,
+      "factType": "relationship"
+    },
+    {
+      "id": "business_outcome",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "concept_difference",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "concept_difference"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "pattern-design",
+      "count": 25,
+      "percentage": 27.2,
+      "topic": "pattern-design"
+    },
+    {
+      "id": "sm-configuration",
+      "count": 16,
+      "percentage": 17.4,
+      "topic": "sm-configuration"
+    },
+    {
+      "id": "cmdb-integration",
+      "count": 14,
+      "percentage": 15.2,
+      "topic": "cmdb-integration"
+    },
+    {
+      "id": "discovery-configuration",
+      "count": 14,
+      "percentage": 15.2,
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "engagement-readiness",
+      "count": 10,
+      "percentage": 10.9,
+      "topic": "engagement-readiness"
+    },
+    {
+      "id": "machine-learning",
+      "count": 9,
+      "percentage": 9.8,
+      "topic": "machine-learning"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 4,
+      "percentage": 4.3,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "role_permission_lookup": 15,
+    "default_value_lookup": 15,
+    "identify_invalid_option": 14,
+    "configuration_order_sequence": 13,
+    "entity_table_name_lookup": 10,
+    "choose_valid_components": 9,
+    "release_feature_lookup": 9,
+    "scenario_best_tool": 5,
+    "navigation_path_lookup": 5,
+    "property_behavior_lookup": 5,
+    "relationship_lookup": 5,
+    "business_outcome_lookup": 5,
+    "concept_difference_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-sm-cmdb-integration-901",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-807",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-310",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-sm-cmdb-integration-1007",
+      "topic": "cmdb-integration"
+    },
+    {
+      "id": "cis-sm-discovery-configuration-604",
+      "topic": "discovery-configuration"
+    },
+    {
+      "id": "cis-sm-machine-learning-802",
+      "topic": "machine-learning"
+    },
+    {
+      "id": "cis-sm-pattern-design-106",
+      "topic": "pattern-design"
+    },
+    {
+      "id": "cis-sm-pattern-design-205",
+      "topic": "pattern-design"
+    },
+    {
+      "id": "cis-sm-pattern-design-313",
+      "topic": "pattern-design"
+    },
+    {
+      "id": "cis-sm-pattern-design-314",
+      "topic": "pattern-design"
+    },
+    {
+      "id": "cis-sm-sm-configuration-501",
+      "topic": "sm-configuration"
+    },
+    {
+      "id": "cis-sm-sm-configuration-506",
+      "topic": "sm-configuration"
+    },
+    {
+      "id": "cis-sm-sm-configuration-508",
+      "topic": "sm-configuration"
+    },
+    {
+      "id": "cis-sm-sm-configuration-514",
+      "topic": "sm-configuration"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-sm-cmdb-integration-901",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-902",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-903",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-904",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-905",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-906",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1001",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1002",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1003",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1004",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1005",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1006",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1008",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-cmdb-integration-1009",
+      "topic": "cmdb-integration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-601",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-602",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-603",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-605",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-606",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-701",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-702",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-703",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-704",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-705",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-706",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "default-value",
+        "numeric-setting"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-707",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-708",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-discovery-configuration-709",
+      "topic": "discovery-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1101",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1102",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1103",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1104",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1105",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1106",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1107",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1108",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1109",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sm-engagement-readiness-1110",
+      "topic": "engagement-readiness",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-801",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-803",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-804",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-805",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-806",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-807",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-808",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-809",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-machine-learning-810",
+      "topic": "machine-learning",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-101",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-102",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-103",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-104",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-105",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-201",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-202",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-203",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-204",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-206",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-301",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-302",
+      "topic": "pattern-design",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-303",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-304",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-305",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-306",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-307",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-308",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-309",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-310",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-311",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-312",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-315",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-316",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-pattern-design-317",
+      "topic": "pattern-design",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-401",
+      "topic": "sm-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-402",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-403",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-404",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-405",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-406",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-502",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-503",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-504",
+      "topic": "sm-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-505",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-507",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-509",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-510",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-511",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-512",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sm-sm-configuration-513",
+      "topic": "sm-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-sp-exam-profile.json
+++ b/data/exam-intel/profiles/cis-sp-exam-profile.json
@@ -1,0 +1,1270 @@
+{
+  "certification": "cis-sp",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 91,
+  "classifiedPercentage": 91,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 33,
+      "percentage": 36.3,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 12,
+      "percentage": 13.2,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 10,
+      "percentage": 11,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 9,
+      "percentage": 9.9,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 6,
+      "percentage": 6.6,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 6,
+      "percentage": 6.6,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 4,
+      "percentage": 4.4,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "release_feature_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 33,
+      "percentage": 36.3,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "default_value",
+      "count": 12,
+      "percentage": 13.2,
+      "factType": "default_value"
+    },
+    {
+      "id": "component_membership",
+      "count": 10,
+      "percentage": 11,
+      "factType": "component_membership"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 9,
+      "percentage": 9.9,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "concept_difference",
+      "count": 6,
+      "percentage": 6.6,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "role_permission",
+      "count": 6,
+      "percentage": 6.6,
+      "factType": "role_permission"
+    },
+    {
+      "id": "ordered_process",
+      "count": 4,
+      "percentage": 4.4,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "property_behavior",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "relationship",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "relationship"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "navigation_path",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "release_feature",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "release_feature"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "process-separation",
+      "count": 22,
+      "percentage": 24.2,
+      "topic": "process-separation"
+    },
+    {
+      "id": "data-separation",
+      "count": 20,
+      "percentage": 22,
+      "topic": "data-separation"
+    },
+    {
+      "id": "foundational-data-management",
+      "count": 18,
+      "percentage": 19.8,
+      "topic": "foundational-data-management"
+    },
+    {
+      "id": "initial-domain-setup",
+      "count": 16,
+      "percentage": 17.6,
+      "topic": "initial-domain-setup"
+    },
+    {
+      "id": "domain-support-applications",
+      "count": 15,
+      "percentage": 16.5,
+      "topic": "domain-support-applications"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 36,
+    "default_value_lookup": 13,
+    "choose_valid_components": 11,
+    "entity_table_name_lookup": 10,
+    "role_permission_lookup": 7,
+    "concept_difference_lookup": 7,
+    "configuration_order_sequence": 5,
+    "relationship_lookup": 5,
+    "property_behavior_lookup": 5,
+    "scenario_best_tool": 5,
+    "navigation_path_lookup": 5,
+    "release_feature_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-sp-process-separation-012",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-sp-domain-support-apps-011",
+      "topic": "domain-support-applications"
+    },
+    {
+      "id": "cis-sp-domain-support-applications-016",
+      "topic": "domain-support-applications"
+    },
+    {
+      "id": "cis-sp-foundational-data-005",
+      "topic": "foundational-data-management"
+    },
+    {
+      "id": "cis-sp-foundational-data-015",
+      "topic": "foundational-data-management"
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-017",
+      "topic": "initial-domain-setup"
+    },
+    {
+      "id": "cis-sp-process-separation-001",
+      "topic": "process-separation"
+    },
+    {
+      "id": "cis-sp-process-separation-021",
+      "topic": "process-separation"
+    },
+    {
+      "id": "cis-sp-process-separation-024",
+      "topic": "process-separation"
+    },
+    {
+      "id": "cis-sp-process-separation-025",
+      "topic": "process-separation"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-sp-data-separation-001",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-002",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-003",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-004",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-005",
+      "topic": "data-separation",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-006",
+      "topic": "data-separation",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-007",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-008",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-009",
+      "topic": "data-separation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-010",
+      "topic": "data-separation",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-011",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-012",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-013",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-014",
+      "topic": "data-separation",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-015",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-016",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-017",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-018",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-019",
+      "topic": "data-separation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-data-separation-020",
+      "topic": "data-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-001",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-002",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-003",
+      "topic": "domain-support-applications",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-004",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-005",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-006",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-007",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-008",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-009",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-010",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-012",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-013",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-014",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-apps-015",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-domain-support-applications-017",
+      "topic": "domain-support-applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-001",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-002",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-003",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-004",
+      "topic": "foundational-data-management",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-006",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-007",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-008",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-009",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-010",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-011",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-012",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-013",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-014",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-016",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-017",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-018",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-management-019",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-foundational-data-management-020",
+      "topic": "foundational-data-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-setup-001",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-setup-002",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-setup-003",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-setup-004",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-005",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-006",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-007",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-008",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-009",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-010",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-011",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-012",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-013",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-014",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-015",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-sp-initial-domain-setup-016",
+      "topic": "initial-domain-setup",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-002",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-003",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-004",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-005",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-006",
+      "topic": "process-separation",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-007",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-008",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-009",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-010",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-011",
+      "topic": "process-separation",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-012",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-013",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-014",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-015",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-016",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-017",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-018",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-019",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-020",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-022",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-023",
+      "topic": "process-separation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-sp-process-separation-026",
+      "topic": "process-separation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-spm-exam-profile.json
+++ b/data/exam-intel/profiles/cis-spm-exam-profile.json
@@ -1,0 +1,1295 @@
+{
+  "certification": "cis-spm",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 87,
+  "classifiedPercentage": 87,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 18,
+      "percentage": 20.7,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 18,
+      "percentage": 20.7,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 15,
+      "percentage": 17.2,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 7,
+      "percentage": 8,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 7,
+      "percentage": 8,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 6,
+      "percentage": 6.9,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 4,
+      "percentage": 4.6,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 4,
+      "percentage": 4.6,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 3,
+      "percentage": 3.4,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 2,
+      "percentage": 2.3,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "property_behavior_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "scenario_best_tool"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 18,
+      "percentage": 20.7,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 18,
+      "percentage": 20.7,
+      "factType": "role_permission"
+    },
+    {
+      "id": "component_membership",
+      "count": 15,
+      "percentage": 17.2,
+      "factType": "component_membership"
+    },
+    {
+      "id": "navigation_path",
+      "count": 7,
+      "percentage": 8,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "ordered_process",
+      "count": 7,
+      "percentage": 8,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "concept_difference",
+      "count": 6,
+      "percentage": 6.9,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "business_outcome",
+      "count": 4,
+      "percentage": 4.6,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "default_value",
+      "count": 4,
+      "percentage": 4.6,
+      "factType": "default_value"
+    },
+    {
+      "id": "release_feature",
+      "count": 3,
+      "percentage": 3.4,
+      "factType": "release_feature"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 2,
+      "percentage": 2.3,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "property_behavior",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "property_behavior"
+    },
+    {
+      "id": "relationship",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "relationship"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "scenario_tool_fit"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "project-management",
+      "count": 17,
+      "percentage": 19.5,
+      "topic": "project-management"
+    },
+    {
+      "id": "resource-management",
+      "count": 13,
+      "percentage": 14.9,
+      "topic": "resource-management"
+    },
+    {
+      "id": "idea-and-demand",
+      "count": 10,
+      "percentage": 11.5,
+      "topic": "idea-and-demand"
+    },
+    {
+      "id": "spm-better-together",
+      "count": 9,
+      "percentage": 10.3,
+      "topic": "spm-better-together"
+    },
+    {
+      "id": "spm-financials",
+      "count": 9,
+      "percentage": 10.3,
+      "topic": "spm-financials"
+    },
+    {
+      "id": "portfolio-planning-workspace",
+      "count": 8,
+      "percentage": 9.2,
+      "topic": "portfolio-planning-workspace"
+    },
+    {
+      "id": "spm-platform-analytics-dashboards",
+      "count": 8,
+      "percentage": 9.2,
+      "topic": "spm-platform-analytics-dashboards"
+    },
+    {
+      "id": "timecard-management",
+      "count": 8,
+      "percentage": 9.2,
+      "topic": "timecard-management"
+    },
+    {
+      "id": "spm-implementation-overview",
+      "count": 5,
+      "percentage": 5.7,
+      "topic": "spm-implementation-overview"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 21,
+    "role_permission_lookup": 21,
+    "choose_valid_components": 17,
+    "configuration_order_sequence": 8,
+    "navigation_path_lookup": 8,
+    "concept_difference_lookup": 7,
+    "business_outcome_lookup": 5,
+    "default_value_lookup": 5,
+    "release_feature_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "scenario_best_tool": 5,
+    "property_behavior_lookup": 5,
+    "relationship_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-spm-idea-and-demand-013",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-005",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-spm-idea-demand-001",
+      "topic": "idea-and-demand"
+    },
+    {
+      "id": "cis-spm-idea-demand-004",
+      "topic": "idea-and-demand"
+    },
+    {
+      "id": "cis-spm-idea-and-demand-012",
+      "topic": "idea-and-demand"
+    },
+    {
+      "id": "cis-spm-portfolio-planning-workspace-009",
+      "topic": "portfolio-planning-workspace"
+    },
+    {
+      "id": "cis-spm-project-management-007",
+      "topic": "project-management"
+    },
+    {
+      "id": "cis-spm-project-management-016",
+      "topic": "project-management"
+    },
+    {
+      "id": "cis-spm-resource-management-001",
+      "topic": "resource-management"
+    },
+    {
+      "id": "cis-spm-resource-management-014",
+      "topic": "resource-management"
+    },
+    {
+      "id": "cis-spm-spm-financials-010",
+      "topic": "spm-financials"
+    },
+    {
+      "id": "cis-spm-implementation-overview-006",
+      "topic": "spm-implementation-overview"
+    },
+    {
+      "id": "cis-spm-implementation-overview-007",
+      "topic": "spm-implementation-overview"
+    },
+    {
+      "id": "cis-spm-implementation-overview-008",
+      "topic": "spm-implementation-overview"
+    },
+    {
+      "id": "cis-spm-spm-implementation-overview-009",
+      "topic": "spm-implementation-overview"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-spm-idea-demand-002",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-003",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-005",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-006",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-007",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-008",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-009",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-010",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-demand-011",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-idea-and-demand-013",
+      "topic": "idea-and-demand",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-001",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-002",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-003",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-004",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-005",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-006",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-007",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-portfolio-planning-008",
+      "topic": "portfolio-planning-workspace",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-001",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-002",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-003",
+      "topic": "project-management",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-004",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-005",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-006",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-008",
+      "topic": "project-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-009",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-010",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-011",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-012",
+      "topic": "project-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-013",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-014",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-015",
+      "topic": "project-management",
+      "questionType": "multiple_select",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-017",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-018",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-project-management-019",
+      "topic": "project-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-002",
+      "topic": "resource-management",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-003",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-004",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-005",
+      "topic": "resource-management",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-006",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-007",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-008",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-009",
+      "topic": "resource-management",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-010",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-011",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-012",
+      "topic": "resource-management",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-013",
+      "topic": "resource-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-resource-management-015",
+      "topic": "resource-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-001",
+      "topic": "spm-better-together",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-002",
+      "topic": "spm-better-together",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-003",
+      "topic": "spm-better-together",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-004",
+      "topic": "spm-better-together",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-005",
+      "topic": "spm-better-together",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-006",
+      "topic": "spm-better-together",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-007",
+      "topic": "spm-better-together",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-better-together-008",
+      "topic": "spm-better-together",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-spm-spm-better-together-009",
+      "topic": "spm-better-together",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-001",
+      "topic": "spm-financials",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-002",
+      "topic": "spm-financials",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-003",
+      "topic": "spm-financials",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-004",
+      "topic": "spm-financials",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-005",
+      "topic": "spm-financials",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-006",
+      "topic": "spm-financials",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-007",
+      "topic": "spm-financials",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-008",
+      "topic": "spm-financials",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-spm-financials-009",
+      "topic": "spm-financials",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-implementation-overview-001",
+      "topic": "spm-implementation-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-implementation-overview-002",
+      "topic": "spm-implementation-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-implementation-overview-003",
+      "topic": "spm-implementation-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-implementation-overview-004",
+      "topic": "spm-implementation-overview",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-implementation-overview-005",
+      "topic": "spm-implementation-overview",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-001",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-002",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-003",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-004",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-005",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-006",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-spm-analytics-dashboards-007",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-spm-spm-platform-analytics-dashboards-008",
+      "topic": "spm-platform-analytics-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-001",
+      "topic": "timecard-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-002",
+      "topic": "timecard-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-003",
+      "topic": "timecard-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-004",
+      "topic": "timecard-management",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-005",
+      "topic": "timecard-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-006",
+      "topic": "timecard-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-007",
+      "topic": "timecard-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-spm-timecard-management-008",
+      "topic": "timecard-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-tprm-exam-profile.json
+++ b/data/exam-intel/profiles/cis-tprm-exam-profile.json
@@ -1,0 +1,1342 @@
+{
+  "certification": "cis-tprm",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 92,
+  "classifiedPercentage": 92,
+  "artifactDistribution": [
+    {
+      "id": "choose_valid_components",
+      "count": 22,
+      "percentage": 23.9,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "identify_invalid_option",
+      "count": 22,
+      "percentage": 23.9,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 15,
+      "percentage": 16.3,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 7,
+      "percentage": 7.6,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 6,
+      "percentage": 6.5,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 4,
+      "percentage": 4.3,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 3,
+      "percentage": 3.3,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 2,
+      "percentage": 2.2,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 1,
+      "percentage": 1.1,
+      "artifactId": "property_behavior_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "component_membership",
+      "count": 22,
+      "percentage": 23.9,
+      "factType": "component_membership"
+    },
+    {
+      "id": "negative_membership",
+      "count": 22,
+      "percentage": 23.9,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 15,
+      "percentage": 16.3,
+      "factType": "role_permission"
+    },
+    {
+      "id": "ordered_process",
+      "count": 7,
+      "percentage": 7.6,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "navigation_path",
+      "count": 6,
+      "percentage": 6.5,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "default_value",
+      "count": 4,
+      "percentage": 4.3,
+      "factType": "default_value"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "relationship",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "relationship"
+    },
+    {
+      "id": "release_feature",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "release_feature"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 3,
+      "percentage": 3.3,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "business_outcome",
+      "count": 2,
+      "percentage": 2.2,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "concept_difference",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "property_behavior",
+      "count": 1,
+      "percentage": 1.1,
+      "factType": "property_behavior"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "assessment-configuration",
+      "count": 21,
+      "percentage": 22.8,
+      "topic": "assessment-configuration"
+    },
+    {
+      "id": "fundamentals",
+      "count": 20,
+      "percentage": 21.7,
+      "topic": "fundamentals"
+    },
+    {
+      "id": "core-configuration",
+      "count": 15,
+      "percentage": 16.3,
+      "topic": "core-configuration"
+    },
+    {
+      "id": "supporting-processes",
+      "count": 13,
+      "percentage": 14.1,
+      "topic": "supporting-processes"
+    },
+    {
+      "id": "third-party-portal",
+      "count": 13,
+      "percentage": 14.1,
+      "topic": "third-party-portal"
+    },
+    {
+      "id": "application-relationships",
+      "count": 10,
+      "percentage": 10.9,
+      "topic": "application-relationships"
+    }
+  ],
+  "generationTargets": {
+    "choose_valid_components": 24,
+    "identify_invalid_option": 24,
+    "role_permission_lookup": 16,
+    "configuration_order_sequence": 8,
+    "navigation_path_lookup": 7,
+    "default_value_lookup": 5,
+    "relationship_lookup": 5,
+    "scenario_best_tool": 5,
+    "release_feature_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "business_outcome_lookup": 5,
+    "property_behavior_lookup": 5,
+    "concept_difference_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-tprm-core-config-010",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-007",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-011",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-tprm-relationships-005",
+      "topic": "application-relationships"
+    },
+    {
+      "id": "cis-tprm-relationships-007",
+      "topic": "application-relationships"
+    },
+    {
+      "id": "cis-tprm-relationships-009",
+      "topic": "application-relationships"
+    },
+    {
+      "id": "cis-tprm-assessment-configuration-022",
+      "topic": "assessment-configuration"
+    },
+    {
+      "id": "cis-tprm-fundamentals-014",
+      "topic": "fundamentals"
+    },
+    {
+      "id": "cis-tprm-fundamentals-016",
+      "topic": "fundamentals"
+    },
+    {
+      "id": "cis-tprm-supporting-013",
+      "topic": "supporting-processes"
+    },
+    {
+      "id": "cis-tprm-supporting-processes-015",
+      "topic": "supporting-processes"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-tprm-relationships-001",
+      "topic": "application-relationships",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-002",
+      "topic": "application-relationships",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-003",
+      "topic": "application-relationships",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-004",
+      "topic": "application-relationships",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-006",
+      "topic": "application-relationships",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-008",
+      "topic": "application-relationships",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-010",
+      "topic": "application-relationships",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-011",
+      "topic": "application-relationships",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-relationships-012",
+      "topic": "application-relationships",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-tprm-application-relationships-013",
+      "topic": "application-relationships",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-001",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-002",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-003",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-004",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-005",
+      "topic": "assessment-configuration",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-006",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-007",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-008",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-009",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-010",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-011",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-012",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-013",
+      "topic": "assessment-configuration",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-014",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-015",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-016",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-017",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-018",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-019",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-config-020",
+      "topic": "assessment-configuration",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-assessment-configuration-021",
+      "topic": "assessment-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-001",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-002",
+      "topic": "core-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-003",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-004",
+      "topic": "core-configuration",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-005",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-006",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-007",
+      "topic": "core-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-008",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-009",
+      "topic": "core-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-010",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-011",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-012",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-config-013",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-configuration-014",
+      "topic": "core-configuration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-tprm-core-configuration-015",
+      "topic": "core-configuration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-001",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-002",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-003",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-004",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-005",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-006",
+      "topic": "fundamentals",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-007",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-008",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-009",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-010",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-011",
+      "topic": "fundamentals",
+      "questionType": "true_false_compound",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-012",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-013",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-015",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-017",
+      "topic": "fundamentals",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-018",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-019",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-020",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-021",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-tprm-fundamentals-022",
+      "topic": "fundamentals",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-001",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-002",
+      "topic": "supporting-processes",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-003",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-004",
+      "topic": "supporting-processes",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-005",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-006",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-007",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-008",
+      "topic": "supporting-processes",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-009",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-010",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-011",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-012",
+      "topic": "supporting-processes",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-tprm-supporting-014",
+      "topic": "supporting-processes",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-001",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-002",
+      "topic": "third-party-portal",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-003",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-004",
+      "topic": "third-party-portal",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-005",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-006",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-007",
+      "topic": "third-party-portal",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-008",
+      "topic": "third-party-portal",
+      "questionType": "multiple_select",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-009",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-010",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-011",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-tprm-portal-012",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-tprm-third-party-portal-013",
+      "topic": "third-party-portal",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cis-vr-exam-profile.json
+++ b/data/exam-intel/profiles/cis-vr-exam-profile.json
@@ -1,0 +1,1290 @@
+{
+  "certification": "cis-vr",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 100,
+  "classifiedItemCount": 86,
+  "classifiedPercentage": 86,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 23,
+      "percentage": 26.7,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 18,
+      "percentage": 20.9,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 13,
+      "percentage": 15.1,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 13,
+      "percentage": 15.1,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 6,
+      "percentage": 7,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 3,
+      "percentage": 3.5,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 3,
+      "percentage": 3.5,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 3,
+      "percentage": 3.5,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 2,
+      "percentage": 2.3,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 1,
+      "percentage": 1.2,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 1,
+      "percentage": 1.2,
+      "artifactId": "scenario_best_tool"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 23,
+      "percentage": 26.7,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "component_membership",
+      "count": 18,
+      "percentage": 20.9,
+      "factType": "component_membership"
+    },
+    {
+      "id": "navigation_path",
+      "count": 13,
+      "percentage": 15.1,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "role_permission",
+      "count": 13,
+      "percentage": 15.1,
+      "factType": "role_permission"
+    },
+    {
+      "id": "default_value",
+      "count": 6,
+      "percentage": 7,
+      "factType": "default_value"
+    },
+    {
+      "id": "business_outcome",
+      "count": 3,
+      "percentage": 3.5,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 3,
+      "percentage": 3.5,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "ordered_process",
+      "count": 3,
+      "percentage": 3.5,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "concept_difference",
+      "count": 2,
+      "percentage": 2.3,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "release_feature",
+      "count": 1,
+      "percentage": 1.2,
+      "factType": "release_feature"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 1,
+      "percentage": 1.2,
+      "factType": "scenario_tool_fit"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "automation",
+      "count": 18,
+      "percentage": 20.9,
+      "topic": "automation"
+    },
+    {
+      "id": "applications",
+      "count": 17,
+      "percentage": 19.8,
+      "topic": "applications"
+    },
+    {
+      "id": "data-ingestion",
+      "count": 17,
+      "percentage": 19.8,
+      "topic": "data-ingestion"
+    },
+    {
+      "id": "management-tools",
+      "count": 17,
+      "percentage": 19.8,
+      "topic": "management-tools"
+    },
+    {
+      "id": "reporting",
+      "count": 17,
+      "percentage": 19.8,
+      "topic": "reporting"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 27,
+    "choose_valid_components": 21,
+    "navigation_path_lookup": 15,
+    "role_permission_lookup": 15,
+    "default_value_lookup": 7,
+    "business_outcome_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "configuration_order_sequence": 5,
+    "concept_difference_lookup": 5,
+    "scenario_best_tool": 5,
+    "release_feature_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cis-vr-applications-004",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-009",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-020",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-012",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-015",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-018",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-014",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cis-vr-applications-001",
+      "topic": "applications"
+    },
+    {
+      "id": "cis-vr-applications-006",
+      "topic": "applications"
+    },
+    {
+      "id": "cis-vr-applications-007",
+      "topic": "applications"
+    },
+    {
+      "id": "cis-vr-applications-015",
+      "topic": "applications"
+    },
+    {
+      "id": "cis-vr-applications-021",
+      "topic": "applications"
+    },
+    {
+      "id": "cis-vr-automation-010",
+      "topic": "automation"
+    },
+    {
+      "id": "cis-vr-data-ingestion-001",
+      "topic": "data-ingestion"
+    },
+    {
+      "id": "cis-vr-data-ingestion-003",
+      "topic": "data-ingestion"
+    },
+    {
+      "id": "cis-vr-data-ingestion-005",
+      "topic": "data-ingestion"
+    },
+    {
+      "id": "cis-vr-data-ingestion-014",
+      "topic": "data-ingestion"
+    },
+    {
+      "id": "cis-vr-management-tools-008",
+      "topic": "management-tools"
+    },
+    {
+      "id": "cis-vr-management-tools-016",
+      "topic": "management-tools"
+    },
+    {
+      "id": "cis-vr-management-tools-019",
+      "topic": "management-tools"
+    },
+    {
+      "id": "cis-vr-reporting-003",
+      "topic": "reporting"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cis-vr-applications-002",
+      "topic": "applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-003",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-004",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-005",
+      "topic": "applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-008",
+      "topic": "applications",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-009",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-010",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-011",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-012",
+      "topic": "applications",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-013",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-014",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-016",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-017",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-018",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-019",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-020",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-applications-022",
+      "topic": "applications",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-001",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-002",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-003",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-004",
+      "topic": "automation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-005",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-006",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-007",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-008",
+      "topic": "automation",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-009",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-011",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-012",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-013",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-014",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-015",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-016",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-017",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-018",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cis-vr-automation-019",
+      "topic": "automation",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-002",
+      "topic": "data-ingestion",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-004",
+      "topic": "data-ingestion",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-006",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-007",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-008",
+      "topic": "data-ingestion",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-009",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-010",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-011",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-012",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-013",
+      "topic": "data-ingestion",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-015",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-016",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-017",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-018",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-019",
+      "topic": "data-ingestion",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-020",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cis-vr-data-ingestion-021",
+      "topic": "data-ingestion",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-001",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-002",
+      "topic": "management-tools",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-003",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-004",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-005",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-006",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-007",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-009",
+      "topic": "management-tools",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-010",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-011",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-012",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-013",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-014",
+      "topic": "management-tools",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-015",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-017",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-018",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-management-tools-020",
+      "topic": "management-tools",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-001",
+      "topic": "reporting",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-002",
+      "topic": "reporting",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-004",
+      "topic": "reporting",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-005",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-006",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-007",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-008",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-009",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-010",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-011",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-012",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-013",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-014",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-015",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-016",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-017",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cis-vr-reporting-018",
+      "topic": "reporting",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/cpoa-exam-profile.json
+++ b/data/exam-intel/profiles/cpoa-exam-profile.json
@@ -1,0 +1,1790 @@
+{
+  "certification": "cpoa",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 158,
+  "classifiedItemCount": 135,
+  "classifiedPercentage": 85.4,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 23,
+      "percentage": 17,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 21,
+      "percentage": 15.6,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 16,
+      "percentage": 11.9,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 16,
+      "percentage": 11.9,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 15,
+      "percentage": 11.1,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 14,
+      "percentage": 10.4,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 9,
+      "percentage": 6.7,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 7,
+      "percentage": 5.2,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 6,
+      "percentage": 4.4,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 4,
+      "percentage": 3,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 4,
+      "percentage": 3,
+      "artifactId": "property_behavior_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 23,
+      "percentage": 17,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "ordered_process",
+      "count": 21,
+      "percentage": 15.6,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "component_membership",
+      "count": 16,
+      "percentage": 11.9,
+      "factType": "component_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 16,
+      "percentage": 11.9,
+      "factType": "role_permission"
+    },
+    {
+      "id": "concept_difference",
+      "count": 15,
+      "percentage": 11.1,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "release_feature",
+      "count": 14,
+      "percentage": 10.4,
+      "factType": "release_feature"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 9,
+      "percentage": 6.7,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "business_outcome",
+      "count": 7,
+      "percentage": 5.2,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "navigation_path",
+      "count": 6,
+      "percentage": 4.4,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 4,
+      "percentage": 3,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "property_behavior",
+      "count": 4,
+      "percentage": 3,
+      "factType": "property_behavior"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "technology",
+      "count": 59,
+      "percentage": 43.7,
+      "topic": "technology"
+    },
+    {
+      "id": "process",
+      "count": 21,
+      "percentage": 15.6,
+      "topic": "process"
+    },
+    {
+      "id": "strategy",
+      "count": 15,
+      "percentage": 11.1,
+      "topic": "strategy"
+    },
+    {
+      "id": "data",
+      "count": 14,
+      "percentage": 10.4,
+      "topic": "data"
+    },
+    {
+      "id": "governance",
+      "count": 14,
+      "percentage": 10.4,
+      "topic": "governance"
+    },
+    {
+      "id": "people",
+      "count": 12,
+      "percentage": 8.9,
+      "topic": "people"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 17,
+    "configuration_order_sequence": 16,
+    "choose_valid_components": 12,
+    "role_permission_lookup": 12,
+    "concept_difference_lookup": 11,
+    "release_feature_lookup": 10,
+    "scenario_best_tool": 7,
+    "business_outcome_lookup": 5,
+    "navigation_path_lookup": 5,
+    "entity_table_name_lookup": 5,
+    "property_behavior_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "cpoa-data-013",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cpoa-process-013",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "cpoa-data-012",
+      "topic": "data"
+    },
+    {
+      "id": "cpoa-data-016",
+      "topic": "data"
+    },
+    {
+      "id": "cpoa-governance-001",
+      "topic": "governance"
+    },
+    {
+      "id": "cpoa-governance-003",
+      "topic": "governance"
+    },
+    {
+      "id": "cpoa-governance-011",
+      "topic": "governance"
+    },
+    {
+      "id": "cpoa-people-001",
+      "topic": "people"
+    },
+    {
+      "id": "cpoa-people-002",
+      "topic": "people"
+    },
+    {
+      "id": "cpoa-people-005",
+      "topic": "people"
+    },
+    {
+      "id": "cpoa-people-009",
+      "topic": "people"
+    },
+    {
+      "id": "cpoa-people-015",
+      "topic": "people"
+    },
+    {
+      "id": "cpoa-process-002",
+      "topic": "process"
+    },
+    {
+      "id": "cpoa-process-004",
+      "topic": "process"
+    },
+    {
+      "id": "cpoa-process-008",
+      "topic": "process"
+    },
+    {
+      "id": "cpoa-process-016",
+      "topic": "process"
+    },
+    {
+      "id": "cpoa-strategy-003",
+      "topic": "strategy"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "cpoa-data-001",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-data-002",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-data-003",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-data-004",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cpoa-data-005",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-data-006",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-data-007",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-data-008",
+      "topic": "data",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-data-009",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cpoa-data-010",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-data-011",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cpoa-data-013",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cpoa-data-014",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-data-015",
+      "topic": "data",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-governance-002",
+      "topic": "governance",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-governance-004",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-governance-005",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cpoa-governance-006",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-governance-007",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "scenario-best"
+      ]
+    },
+    {
+      "id": "cpoa-governance-008",
+      "topic": "governance",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-governance-009",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-governance-010",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-governance-012",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-governance-013",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-governance-014",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-governance-015",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-governance-016",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-governance-017",
+      "topic": "governance",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "cpoa-people-003",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-people-004",
+      "topic": "people",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-people-006",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-people-007",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-people-008",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cpoa-people-010",
+      "topic": "people",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-people-011",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-people-012",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-people-013",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cpoa-people-014",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-people-016",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-people-017",
+      "topic": "people",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-process-001",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-003",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-process-005",
+      "topic": "process",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-process-006",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-process-007",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-009",
+      "topic": "process",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-process-010",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-011",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-process-012",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "cpoa-process-013",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "cpoa-process-014",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-015",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-process-017",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-process-018",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-019",
+      "topic": "process",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-process-020",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-process-021",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-022",
+      "topic": "process",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-process-023",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-process-024",
+      "topic": "process",
+      "questionType": "compound_true_false",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-process-025",
+      "topic": "process",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-001",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-002",
+      "topic": "strategy",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-004",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-005",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-006",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-007",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-008",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-009",
+      "topic": "strategy",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-010",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-011",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-012",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-014",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-015",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-016",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-strategy-017",
+      "topic": "strategy",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cpoa-technology-001",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-002",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-003",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-technology-004",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-005",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-006",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-007",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-008",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-technology-009",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-010",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-012",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "cpoa-technology-013",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-014",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-015",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-017",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-018",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-technology-019",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-020",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-technology-021",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-022",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-023",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-024",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-technology-025",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-026",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-technology-027",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cpoa-technology-028",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cpoa-technology-029",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-technology-030",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-031",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-032",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-033",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-034",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-036",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-technology-037",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cpoa-technology-038",
+      "topic": "technology",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cpoa-technology-040",
+      "topic": "technology",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cpoa-technology-041",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "cpoa-technology-042",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-043",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cpoa-technology-044",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-technology-045",
+      "topic": "technology",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-046",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-048",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cpoa-technology-049",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "cpoa-technology-050",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "cpoa-technology-051",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-052",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "cpoa-technology-053",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-technology-054",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-technology-055",
+      "topic": "technology",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cpoa-technology-056",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-technology-058",
+      "topic": "technology",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "cpoa-technology-059",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "cpoa-technology-060",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "cpoa-technology-061",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-062",
+      "topic": "technology",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "cpoa-technology-063",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "cpoa-technology-064",
+      "topic": "technology",
+      "questionType": "compound_true_false",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "cpoa-technology-066",
+      "topic": "technology",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    }
+  ]
+}

--- a/data/exam-intel/profiles/csa-exam-profile.json
+++ b/data/exam-intel/profiles/csa-exam-profile.json
@@ -1,0 +1,2725 @@
+{
+  "certification": "csa",
+  "generatedAt": "2026-06-27T00:00:00.000Z",
+  "source": "existing_snready_questions",
+  "observedItemCount": 228,
+  "classifiedItemCount": 210,
+  "classifiedPercentage": 92.1,
+  "artifactDistribution": [
+    {
+      "id": "identify_invalid_option",
+      "count": 42,
+      "percentage": 20,
+      "artifactId": "identify_invalid_option"
+    },
+    {
+      "id": "role_permission_lookup",
+      "count": 32,
+      "percentage": 15.2,
+      "artifactId": "role_permission_lookup"
+    },
+    {
+      "id": "entity_table_name_lookup",
+      "count": 27,
+      "percentage": 12.9,
+      "artifactId": "entity_table_name_lookup"
+    },
+    {
+      "id": "concept_difference_lookup",
+      "count": 23,
+      "percentage": 11,
+      "artifactId": "concept_difference_lookup"
+    },
+    {
+      "id": "choose_valid_components",
+      "count": 21,
+      "percentage": 10,
+      "artifactId": "choose_valid_components"
+    },
+    {
+      "id": "release_feature_lookup",
+      "count": 15,
+      "percentage": 7.1,
+      "artifactId": "release_feature_lookup"
+    },
+    {
+      "id": "configuration_order_sequence",
+      "count": 14,
+      "percentage": 6.7,
+      "artifactId": "configuration_order_sequence"
+    },
+    {
+      "id": "default_value_lookup",
+      "count": 12,
+      "percentage": 5.7,
+      "artifactId": "default_value_lookup"
+    },
+    {
+      "id": "scenario_best_tool",
+      "count": 10,
+      "percentage": 4.8,
+      "artifactId": "scenario_best_tool"
+    },
+    {
+      "id": "navigation_path_lookup",
+      "count": 7,
+      "percentage": 3.3,
+      "artifactId": "navigation_path_lookup"
+    },
+    {
+      "id": "relationship_lookup",
+      "count": 3,
+      "percentage": 1.4,
+      "artifactId": "relationship_lookup"
+    },
+    {
+      "id": "business_outcome_lookup",
+      "count": 2,
+      "percentage": 1,
+      "artifactId": "business_outcome_lookup"
+    },
+    {
+      "id": "property_behavior_lookup",
+      "count": 2,
+      "percentage": 1,
+      "artifactId": "property_behavior_lookup"
+    }
+  ],
+  "factTypeDistribution": [
+    {
+      "id": "negative_membership",
+      "count": 42,
+      "percentage": 20,
+      "factType": "negative_membership"
+    },
+    {
+      "id": "role_permission",
+      "count": 32,
+      "percentage": 15.2,
+      "factType": "role_permission"
+    },
+    {
+      "id": "entity_table_name",
+      "count": 27,
+      "percentage": 12.9,
+      "factType": "entity_table_name"
+    },
+    {
+      "id": "concept_difference",
+      "count": 23,
+      "percentage": 11,
+      "factType": "concept_difference"
+    },
+    {
+      "id": "component_membership",
+      "count": 21,
+      "percentage": 10,
+      "factType": "component_membership"
+    },
+    {
+      "id": "release_feature",
+      "count": 15,
+      "percentage": 7.1,
+      "factType": "release_feature"
+    },
+    {
+      "id": "ordered_process",
+      "count": 14,
+      "percentage": 6.7,
+      "factType": "ordered_process"
+    },
+    {
+      "id": "default_value",
+      "count": 12,
+      "percentage": 5.7,
+      "factType": "default_value"
+    },
+    {
+      "id": "scenario_tool_fit",
+      "count": 10,
+      "percentage": 4.8,
+      "factType": "scenario_tool_fit"
+    },
+    {
+      "id": "navigation_path",
+      "count": 7,
+      "percentage": 3.3,
+      "factType": "navigation_path"
+    },
+    {
+      "id": "relationship",
+      "count": 3,
+      "percentage": 1.4,
+      "factType": "relationship"
+    },
+    {
+      "id": "business_outcome",
+      "count": 2,
+      "percentage": 1,
+      "factType": "business_outcome"
+    },
+    {
+      "id": "property_behavior",
+      "count": 2,
+      "percentage": 1,
+      "factType": "property_behavior"
+    }
+  ],
+  "topicDistribution": [
+    {
+      "id": "ui-navigation",
+      "count": 38,
+      "percentage": 18.1,
+      "topic": "ui-navigation"
+    },
+    {
+      "id": "user-administration",
+      "count": 30,
+      "percentage": 14.3,
+      "topic": "user-administration"
+    },
+    {
+      "id": "self-service-automation",
+      "count": 27,
+      "percentage": 12.9,
+      "topic": "self-service-automation"
+    },
+    {
+      "id": "reporting-dashboards",
+      "count": 26,
+      "percentage": 12.4,
+      "topic": "reporting-dashboards"
+    },
+    {
+      "id": "database-administration",
+      "count": 23,
+      "percentage": 11,
+      "topic": "database-administration"
+    },
+    {
+      "id": "incident-management",
+      "count": 20,
+      "percentage": 9.5,
+      "topic": "incident-management"
+    },
+    {
+      "id": "change-management",
+      "count": 19,
+      "percentage": 9,
+      "topic": "change-management"
+    },
+    {
+      "id": "problem-management",
+      "count": 15,
+      "percentage": 7.1,
+      "topic": "problem-management"
+    },
+    {
+      "id": "delta-zurich",
+      "count": 12,
+      "percentage": 5.7,
+      "topic": "delta-zurich"
+    }
+  ],
+  "generationTargets": {
+    "identify_invalid_option": 20,
+    "role_permission_lookup": 15,
+    "entity_table_name_lookup": 13,
+    "concept_difference_lookup": 11,
+    "choose_valid_components": 10,
+    "release_feature_lookup": 7,
+    "configuration_order_sequence": 7,
+    "default_value_lookup": 6,
+    "scenario_best_tool": 5,
+    "navigation_path_lookup": 5,
+    "relationship_lookup": 5,
+    "business_outcome_lookup": 5,
+    "property_behavior_lookup": 5
+  },
+  "lowConfidenceExamples": [
+    {
+      "id": "csa-cm-005",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-007",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-008",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-019",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-im-005",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-inc-022",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-ss-013",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    }
+  ],
+  "unmatchedExamples": [
+    {
+      "id": "csa-cm-001",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-003",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-004",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-009",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-012",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-013",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-014",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-016",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-cm-018",
+      "topic": "change-management"
+    },
+    {
+      "id": "csa-db-016",
+      "topic": "database-administration"
+    },
+    {
+      "id": "csa-im-009",
+      "topic": "incident-management"
+    },
+    {
+      "id": "csa-im-010",
+      "topic": "incident-management"
+    },
+    {
+      "id": "csa-im-012",
+      "topic": "incident-management"
+    },
+    {
+      "id": "csa-inc-024",
+      "topic": "incident-management"
+    },
+    {
+      "id": "csa-pm-002",
+      "topic": "problem-management"
+    }
+  ],
+  "classifiedQuestions": [
+    {
+      "id": "csa-cm-002",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-cm-005",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-006",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-cm-007",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-008",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-010",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-cm-011",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-cm-015",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-cm-017",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-cm-019",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-cm-020",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-cm-021",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "csa-cm-022",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-cm-023",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-cm-024",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-cm-025",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-cm-026",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-cm-027",
+      "topic": "change-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-cm-028",
+      "topic": "change-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-db-001",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-002",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-003",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-004",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-db-005",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-006",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-db-007",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-008",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-db-009",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-010",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-db-011",
+      "topic": "database-administration",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-012",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-db-013",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-014",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-db-015",
+      "topic": "database-administration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-db-017",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-db-018",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-db-019",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "csa-db-020",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-db-021",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-db-022",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-db-023",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-db-024",
+      "topic": "database-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-001",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-002",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-003",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-004",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-005",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-006",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-007",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-008",
+      "topic": "delta-zurich",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-009",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-010",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-011",
+      "topic": "delta-zurich",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-delta-zurich-012",
+      "topic": "delta-zurich",
+      "questionType": "multiple_select",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-im-001",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "csa-im-002",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-im-003",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-im-004",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-im-005",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-im-006",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-im-007",
+      "topic": "incident-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-im-008",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "table-name",
+        "table-question"
+      ]
+    },
+    {
+      "id": "csa-im-011",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "csa-im-013",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-im-014",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-im-015",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-im-016",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-im-017",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "csa-im-018",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "csa-inc-019",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-inc-020",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-inc-021",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-inc-022",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-inc-023",
+      "topic": "incident-management",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-pm-001",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-pm-003",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-pm-004",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "csa-pm-005",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-pm-006",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-pm-007",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-pm-008",
+      "topic": "problem-management",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-pm-009",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-pm-010",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "csa-pm-011",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-pm-012",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-pm-013",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-pm-014",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "csa-pm-015",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-pm-016",
+      "topic": "problem-management",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-rd-001",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "csa-rd-002",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-rd-003",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-rd-004",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-rd-005",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-rd-006",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-rd-007",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-rd-008",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-rd-009",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-rd-010",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-rd-011",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-rd-012",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "csa-rd-013",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-rd-014",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "navigation",
+        "where-find"
+      ]
+    },
+    {
+      "id": "csa-rd-015",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-rd-016",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-rd-017",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-rd-018",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-rd-019",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-rd-020",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-rd-021",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-rd-022",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-rd-023",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-rd-024",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-rd-025",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-rd-026",
+      "topic": "reporting-dashboards",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ss-001",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ss-002",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ss-003",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ss-004",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "csa-ss-005",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "release_feature_lookup",
+      "factType": "release_feature",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "release"
+      ]
+    },
+    {
+      "id": "csa-ss-006",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ss-007",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ss-010",
+      "topic": "self-service-automation",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ss-012",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ss-013",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.65,
+      "matchedSignals": [
+        "set-membership"
+      ]
+    },
+    {
+      "id": "csa-ss-014",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-ss-015",
+      "topic": "self-service-automation",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ss-016",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "navigation_path_lookup",
+      "factType": "navigation_path",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "navigation"
+      ]
+    },
+    {
+      "id": "csa-ss-017",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "relationship_lookup",
+      "factType": "relationship",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "relationship"
+      ]
+    },
+    {
+      "id": "csa-ss-018",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-ss-019",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ss-020",
+      "topic": "self-service-automation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-ss-021",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-ss-022",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ss-023",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-ss-024",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ss-025",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "csa-ss-026",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-ss-027",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "property_behavior_lookup",
+      "factType": "property_behavior",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "property-setting"
+      ]
+    },
+    {
+      "id": "csa-ss-028",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-ss-029",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ss-030",
+      "topic": "self-service-automation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ui-001",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-002",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ui-003",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-004",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-005",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-006",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-007",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-ui-008",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-009",
+      "topic": "ui-navigation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-ui-010",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-ui-011",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ui-012",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-013",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-014",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-015",
+      "topic": "ui-navigation",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ui-016",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ui-017",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-018",
+      "topic": "ui-navigation",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-ui-019",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-ui-020",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-021",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-022",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-023",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-024",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-025",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-026",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-ui-027",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "sequence-language"
+      ]
+    },
+    {
+      "id": "csa-ui-028",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ui-029",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "concept_difference_lookup",
+      "factType": "concept_difference",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "difference"
+      ]
+    },
+    {
+      "id": "csa-ui-030",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-031",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-032",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-033",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-034",
+      "topic": "ui-navigation",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-035",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-036",
+      "topic": "ui-navigation",
+      "questionType": "multiple_select",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-037",
+      "topic": "ui-navigation",
+      "questionType": "true_false_compound",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ui-navigation-038",
+      "topic": "ui-navigation",
+      "questionType": "multiple_choice_negative",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "negative-stem",
+        "negative-type"
+      ]
+    },
+    {
+      "id": "csa-ua-001",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-002",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "role-permission",
+        "which-role"
+      ]
+    },
+    {
+      "id": "csa-ua-003",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-004",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "configuration_order_sequence",
+      "factType": "ordered_process",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "sequence-language",
+        "process-order"
+      ]
+    },
+    {
+      "id": "csa-ua-005",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "default_value_lookup",
+      "factType": "default_value",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "default-value"
+      ]
+    },
+    {
+      "id": "csa-ua-006",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-007",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-008",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ua-009",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-010",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-011",
+      "topic": "user-administration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-ua-012",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-013",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-014",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-015",
+      "topic": "user-administration",
+      "questionType": "multiple_select",
+      "artifactId": "choose_valid_components",
+      "factType": "component_membership",
+      "confidence": 0.95,
+      "matchedSignals": [
+        "set-membership",
+        "multi-select"
+      ]
+    },
+    {
+      "id": "csa-ua-016",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-ua-017",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-018",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ua-019",
+      "topic": "user-administration",
+      "questionType": "multiple_select",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-020",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-021",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-022",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "business_outcome_lookup",
+      "factType": "business_outcome",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "outcome-benefit"
+      ]
+    },
+    {
+      "id": "csa-ua-023",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "scenario_best_tool",
+      "factType": "scenario_tool_fit",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "scenario-best",
+        "application-level"
+      ]
+    },
+    {
+      "id": "csa-ua-024",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "entity_table_name_lookup",
+      "factType": "entity_table_name",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "table-name"
+      ]
+    },
+    {
+      "id": "csa-ua-025",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    },
+    {
+      "id": "csa-ua-026",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-027",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-028",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-029",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "identify_invalid_option",
+      "factType": "negative_membership",
+      "confidence": 0.8500000000000001,
+      "matchedSignals": [
+        "negative-stem"
+      ]
+    },
+    {
+      "id": "csa-ua-030",
+      "topic": "user-administration",
+      "questionType": "multiple_choice",
+      "artifactId": "role_permission_lookup",
+      "factType": "role_permission",
+      "confidence": 0.75,
+      "matchedSignals": [
+        "role-permission"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:data": "tsx scripts/test-data-integrity.ts",
     "test:e2e:smoke": "playwright test",
     "test:deployment": "playwright test",
-    "test:ci": "npm run typecheck && npm run test"
+    "test:ci": "npm run typecheck && npm run test",
+    "exam-intel:profile": "SNREADY_EXAM_INTEL_GENERATED_AT=2026-06-27T00:00:00.000Z tsx scripts/exam-intel/profile-existing-questions.ts"
   },
   "dependencies": {
     "geist": "^1.7.0",

--- a/scripts/exam-intel/profile-existing-questions.ts
+++ b/scripts/exam-intel/profile-existing-questions.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env npx tsx
+import fs from "node:fs";
+import path from "node:path";
+
+type QuestionOption = { id: string; text: string };
+type Question = {
+  id: string;
+  certification: string;
+  topic: string;
+  type?: string;
+  question: string;
+  options?: QuestionOption[];
+  correctAnswers?: string[];
+  explanation?: { correct?: string };
+  labels?: { tags?: string[]; subtopics?: string[]; domain?: string; domainSlug?: string };
+};
+type QuestionFile = { certification?: string; topic?: string; questions?: Question[] } | Question[];
+type Artifact = { id: string; factType: string };
+type Classification = {
+  artifactId: string;
+  factType: string;
+  confidence: number;
+  matchedSignals: string[];
+};
+type ClassifiedQuestion = {
+  id: string;
+  topic: string;
+  questionType: string;
+  artifactId: string;
+  factType: string;
+  confidence: number;
+  matchedSignals: string[];
+};
+type DistributionRow = { id: string; count: number; percentage: number };
+type Profile = {
+  certification: string;
+  generatedAt: string;
+  source: "existing_snready_questions";
+  observedItemCount: number;
+  classifiedItemCount: number;
+  classifiedPercentage: number;
+  artifactDistribution: Array<DistributionRow & { artifactId: string }>;
+  factTypeDistribution: Array<DistributionRow & { factType: string }>;
+  topicDistribution: Array<DistributionRow & { topic: string }>;
+  generationTargets: Record<string, number>;
+  lowConfidenceExamples: ClassifiedQuestion[];
+  unmatchedExamples: Array<{ id: string; topic: string }>;
+  classifiedQuestions: ClassifiedQuestion[];
+};
+
+const root = process.cwd();
+const registryPath = path.join(root, "data", "exam-intel", "artifacts", "servicenow-core-artifacts.json");
+const profilesDir = path.join(root, "data", "exam-intel", "profiles");
+const certFilter = process.argv.find((arg) => arg.startsWith("--cert="))?.split("=")[1];
+const writeOutput = !process.argv.includes("--dry-run");
+const ISO_NOW = process.env.SNREADY_EXAM_INTEL_GENERATED_AT ?? new Date().toISOString();
+
+const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as { artifacts: Artifact[] };
+const artifactsById = new Map(registry.artifacts.map((artifact) => [artifact.id, artifact]));
+
+const rules: Array<{ artifactId: string; signals: Array<{ name: string; pattern: RegExp; weight: number }> }> = [
+  { artifactId: "identify_invalid_option", signals: [
+    { name: "negative-stem", pattern: /\b(not|except|least likely|cannot|invalid|incorrect|does not|isn't|aren't|false)\b/i, weight: 4 },
+    { name: "negative-type", pattern: /multiple_choice_negative/i, weight: 3 },
+  ] },
+  { artifactId: "entity_table_name_lookup", signals: [
+    { name: "table-name", pattern: /\b(table|class|record type|extends|sys_|cmdb_|sn_[a-z0-9_]+)\b/i, weight: 3 },
+    { name: "table-question", pattern: /\bwhich\s+(?:table|class)|table\s+(?:stores|contains|backs)|stored\s+in\s+which\s+table\b/i, weight: 4 },
+  ] },
+  { artifactId: "role_permission_lookup", signals: [
+    { name: "role-permission", pattern: /\b(role|permission|access|admin|administrator|security_admin|itil|approver|delegate|can view|can create|can edit)\b/i, weight: 3 },
+    { name: "which-role", pattern: /\bwhich\s+role|what\s+role|requires\s+the\s+.*role\b/i, weight: 4 },
+  ] },
+  { artifactId: "configuration_order_sequence", signals: [
+    { name: "sequence-language", pattern: /\b(first|next|before|after|order|sequence|step|phase|prerequisite|dependency|then|following)\b/i, weight: 3 },
+    { name: "process-order", pattern: /\bwhat\s+is\s+the\s+(?:first|next)|which\s+step|in\s+what\s+order\b/i, weight: 4 },
+  ] },
+  { artifactId: "navigation_path_lookup", signals: [
+    { name: "navigation", pattern: /\b(navigate|navigation|application navigator|module|menu|workspace|portal|breadcrumb|homepage|dashboard|list view|form view)\b/i, weight: 3 },
+    { name: "where-find", pattern: /\bwhere\s+(?:do|can|would)|how\s+do\s+you\s+open|which\s+module\b/i, weight: 3 },
+  ] },
+  { artifactId: "default_value_lookup", signals: [
+    { name: "default-value", pattern: /\b(default|out-of-the-box|baseline|initial|preconfigured|standard value|by default)\b/i, weight: 4 },
+    { name: "numeric-setting", pattern: /\b\d+\s*(?:days?|hours?|minutes?|percent|%)\b/i, weight: 2 },
+  ] },
+  { artifactId: "release_feature_lookup", signals: [
+    { name: "release", pattern: /\b(release|zurich|yokohama|xanadu|washington|vancouver|utah|tokyo|added|introduced|new feature|enhancement)\b/i, weight: 4 },
+  ] },
+  { artifactId: "property_behavior_lookup", signals: [
+    { name: "property-setting", pattern: /\b(property|properties|system setting|setting|configuration option|enable|disable|toggle|behavior|controls how)\b/i, weight: 3 },
+  ] },
+  { artifactId: "concept_difference_lookup", signals: [
+    { name: "difference", pattern: /\b(difference|different|compare|versus| vs\.? |distinguish|unlike|instead of|rather than)\b/i, weight: 4 },
+  ] },
+  { artifactId: "relationship_lookup", signals: [
+    { name: "relationship", pattern: /\b(relationship|relates?|associated|linked|parent|child|dependency|depends on|connected|reference field|dot-walk)\b/i, weight: 3 },
+  ] },
+  { artifactId: "business_outcome_lookup", signals: [
+    { name: "outcome-benefit", pattern: /\b(benefit|outcome|value|kpi|metric|goal|objective|improve|reduce|increase|ensure|why)\b/i, weight: 3 },
+  ] },
+  { artifactId: "scenario_best_tool", signals: [
+    { name: "scenario-best", pattern: /\b(best|most appropriate|should use|recommend|scenario|wants to|needs to|requirement|use case|customer wants)\b/i, weight: 3 },
+    { name: "application-level", pattern: /\b(application|tool|feature|method|workflow|flow|business rule|script include|ui policy|data policy)\b/i, weight: 1 },
+  ] },
+  { artifactId: "choose_valid_components", signals: [
+    { name: "set-membership", pattern: /\b(which\s+(?:of\s+the\s+following|two|three)|select|components?|features?|states?|values?|included|contains|part of|valid)\b/i, weight: 2 },
+    { name: "multi-select", pattern: /\bmultiple_select|select\s+\w+\s+answers?\b/i, weight: 3 },
+  ] },
+];
+
+function normalizeQuestionFile(data: QuestionFile): Question[] {
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data.questions)) return data.questions;
+  return [];
+}
+
+function questionText(question: Question): string {
+  const options = question.options?.map((option) => option.text).join(" ") ?? "";
+  const correct = question.explanation?.correct ?? "";
+  const tags = [...(question.labels?.tags ?? []), ...(question.labels?.subtopics ?? []), question.labels?.domain ?? ""].join(" ");
+  return [question.type ?? "", question.question, options, correct, tags].join("\n");
+}
+
+function classify(question: Question): Classification | null {
+  const text = questionText(question);
+  const scored = rules.map(({ artifactId, signals }) => {
+    const matchedSignals: string[] = [];
+    let score = 0;
+    for (const signal of signals) {
+      if (signal.pattern.test(text)) {
+        matchedSignals.push(signal.name);
+        score += signal.weight;
+      }
+    }
+    return { artifactId, score, matchedSignals };
+  }).filter((row) => row.score > 0);
+
+  if (scored.length === 0) return null;
+  scored.sort((a, b) => b.score - a.score || b.matchedSignals.length - a.matchedSignals.length);
+  const top = scored[0];
+  if (top.score < 2) return null;
+  const artifact = artifactsById.get(top.artifactId);
+  if (!artifact) throw new Error(`Rule references missing artifact ${top.artifactId}`);
+  return {
+    artifactId: top.artifactId,
+    factType: artifact.factType,
+    confidence: Math.min(0.95, 0.45 + top.score / 10),
+    matchedSignals: top.matchedSignals,
+  };
+}
+
+function percent(count: number, total: number): number {
+  return total === 0 ? 0 : Number(((count / total) * 100).toFixed(1));
+}
+
+function distribution<T extends string>(counts: Map<T, number>, total: number): DistributionRow[] {
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([id, count]) => ({ id, count, percentage: percent(count, total) }));
+}
+
+function generationTargets(artifactCounts: Map<string, number>, classifiedCount: number): Record<string, number> {
+  const targets: Record<string, number> = {};
+  for (const [artifactId, count] of [...artifactCounts.entries()].sort((a, b) => b[1] - a[1])) {
+    targets[artifactId] = Math.max(5, Math.round(percent(count, classifiedCount)));
+  }
+  return targets;
+}
+
+function profileCert(cert: string): Profile {
+  const certDir = path.join(root, "data", "questions", cert);
+  const questions: Question[] = [];
+  for (const file of fs.readdirSync(certDir).filter((name) => name.endsWith(".json")).sort()) {
+    if (file.startsWith("_")) continue;
+    const data = JSON.parse(fs.readFileSync(path.join(certDir, file), "utf8")) as QuestionFile;
+    questions.push(...normalizeQuestionFile(data));
+  }
+
+  const artifactCounts = new Map<string, number>();
+  const factCounts = new Map<string, number>();
+  const topicCounts = new Map<string, number>();
+  const classifiedQuestions: ClassifiedQuestion[] = [];
+  const unmatchedExamples: Array<{ id: string; topic: string }> = [];
+
+  for (const question of questions) {
+    const classification = classify(question);
+    if (!classification) {
+      if (unmatchedExamples.length < 15) unmatchedExamples.push({ id: question.id, topic: question.topic });
+      continue;
+    }
+    artifactCounts.set(classification.artifactId, (artifactCounts.get(classification.artifactId) ?? 0) + 1);
+    factCounts.set(classification.factType, (factCounts.get(classification.factType) ?? 0) + 1);
+    topicCounts.set(question.topic, (topicCounts.get(question.topic) ?? 0) + 1);
+    classifiedQuestions.push({
+      id: question.id,
+      topic: question.topic,
+      questionType: question.type ?? "unknown",
+      ...classification,
+    });
+  }
+
+  const artifactDistribution = distribution(artifactCounts, classifiedQuestions.length).map((row) => ({ ...row, artifactId: row.id }));
+  const factTypeDistribution = distribution(factCounts, classifiedQuestions.length).map((row) => ({ ...row, factType: row.id }));
+  const topicDistribution = distribution(topicCounts, classifiedQuestions.length).map((row) => ({ ...row, topic: row.id }));
+
+  return {
+    certification: cert,
+    generatedAt: ISO_NOW,
+    source: "existing_snready_questions",
+    observedItemCount: questions.length,
+    classifiedItemCount: classifiedQuestions.length,
+    classifiedPercentage: percent(classifiedQuestions.length, questions.length),
+    artifactDistribution,
+    factTypeDistribution,
+    topicDistribution,
+    generationTargets: generationTargets(artifactCounts, classifiedQuestions.length),
+    lowConfidenceExamples: classifiedQuestions.filter((row) => row.confidence < 0.7).slice(0, 15),
+    unmatchedExamples,
+    classifiedQuestions,
+  };
+}
+
+function main() {
+  const questionRoot = path.join(root, "data", "questions");
+  const certs = fs.readdirSync(questionRoot)
+    .filter((name) => fs.statSync(path.join(questionRoot, name)).isDirectory() && !name.endsWith(".old"))
+    .filter((name) => !certFilter || name === certFilter)
+    .sort();
+  if (certs.length === 0) throw new Error(`No certifications found${certFilter ? ` for --cert=${certFilter}` : ""}`);
+  if (writeOutput) fs.mkdirSync(profilesDir, { recursive: true });
+
+  const profiles = certs.map(profileCert);
+  for (const profile of profiles) {
+    if (writeOutput) {
+      fs.writeFileSync(path.join(profilesDir, `${profile.certification}-exam-profile.json`), `${JSON.stringify(profile, null, 2)}\n`);
+    }
+    const topArtifacts = profile.artifactDistribution.slice(0, 3).map((row) => `${row.artifactId}:${row.count}`).join(", ");
+    console.log(`${profile.certification}: ${profile.classifiedItemCount}/${profile.observedItemCount} classified (${profile.classifiedPercentage}%). Top artifacts: ${topArtifacts}`);
+  }
+  const totalObserved = profiles.reduce((sum, profile) => sum + profile.observedItemCount, 0);
+  const totalClassified = profiles.reduce((sum, profile) => sum + profile.classifiedItemCount, 0);
+  console.log(`Exam-intel profiles ${writeOutput ? "written" : "checked"}: ${profiles.length} certs, ${totalClassified}/${totalObserved} classified (${percent(totalClassified, totalObserved)}%).`);
+}
+
+main();

--- a/scripts/test-data-integrity.ts
+++ b/scripts/test-data-integrity.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 type JsonObject = Record<string, unknown>;
 type Topic = { slug: string; name: string; questionCount: number; freeQuestionCount?: number };
 type Question = { id: string; certification: string; topic: string; type: string; question: string; options: Array<{ id: string; text: string }>; correctAnswers: string[]; explanation?: { correct?: string }; source?: unknown; labels?: unknown; meta?: unknown };
+type ExamIntelArtifact = { id: string; factType: string; name: string; description: string };
+type ExamIntelProfile = { certification: string; observedItemCount: number; classifiedItemCount: number; classifiedPercentage: number; artifactDistribution: Array<{ artifactId: string; count: number; percentage: number }>; factTypeDistribution: Array<{ factType: string; count: number; percentage: number }>; generationTargets: Record<string, number>; classifiedQuestions: Array<{ id: string; artifactId: string; factType: string; confidence: number }> };
 
 const root = process.cwd();
 const errors: string[] = [];
@@ -84,6 +86,47 @@ for (const cert of certs) {
     }
   }
 }
+const examIntelRegistry = readJson<{ artifacts?: ExamIntelArtifact[] }>("data/exam-intel/artifacts/servicenow-core-artifacts.json");
+const artifactIds = new Set<string>();
+const factTypesByArtifact = new Map<string, string>();
+if (examIntelRegistry) {
+  if (!Array.isArray(examIntelRegistry.artifacts) || examIntelRegistry.artifacts.length === 0) fail("data/exam-intel/artifacts/servicenow-core-artifacts.json: expected non-empty artifacts array");
+  else for (const artifact of examIntelRegistry.artifacts) {
+    if (!isNonEmptyString(artifact.id)) fail("exam-intel artifact missing id");
+    else if (artifactIds.has(artifact.id)) fail(`exam-intel duplicate artifact id ${artifact.id}`); else artifactIds.add(artifact.id);
+    if (!isNonEmptyString(artifact.factType)) fail(`exam-intel artifact ${artifact.id}: missing factType`);
+    else factTypesByArtifact.set(artifact.id, artifact.factType);
+    if (!isNonEmptyString(artifact.name)) fail(`exam-intel artifact ${artifact.id}: missing name`);
+    if (!isNonEmptyString(artifact.description)) fail(`exam-intel artifact ${artifact.id}: missing description`);
+  }
+}
+const profilesDir = path.join(root, "data/exam-intel/profiles");
+if (fs.existsSync(profilesDir)) {
+  const profileFiles = fs.readdirSync(profilesDir).filter((name) => name.endsWith("-exam-profile.json"));
+  for (const fileName of profileFiles) {
+    const relativePath = `data/exam-intel/profiles/${fileName}`;
+    const profile = readJson<ExamIntelProfile>(relativePath);
+    if (!profile) continue;
+    if (!isNonEmptyString(profile.certification)) fail(`${relativePath}: missing certification`);
+    if (typeof profile.observedItemCount !== "number" || profile.observedItemCount < 0) fail(`${relativePath}: invalid observedItemCount`);
+    if (typeof profile.classifiedItemCount !== "number" || profile.classifiedItemCount < 0 || profile.classifiedItemCount > profile.observedItemCount) fail(`${relativePath}: invalid classifiedItemCount`);
+    if (typeof profile.classifiedPercentage !== "number" || profile.classifiedPercentage < 0 || profile.classifiedPercentage > 100) fail(`${relativePath}: invalid classifiedPercentage`);
+    const artifactTotal = (profile.artifactDistribution ?? []).reduce((sum, row) => sum + row.count, 0);
+    const factTotal = (profile.factTypeDistribution ?? []).reduce((sum, row) => sum + row.count, 0);
+    if (artifactTotal !== profile.classifiedItemCount) fail(`${relativePath}: artifact distribution total ${artifactTotal} does not match classifiedItemCount ${profile.classifiedItemCount}`);
+    if (factTotal !== profile.classifiedItemCount) fail(`${relativePath}: fact distribution total ${factTotal} does not match classifiedItemCount ${profile.classifiedItemCount}`);
+    for (const row of profile.artifactDistribution ?? []) {
+      if (!artifactIds.has(row.artifactId)) fail(`${relativePath}: unknown artifactId ${row.artifactId}`);
+    }
+    for (const classified of profile.classifiedQuestions ?? []) {
+      const expectedFactType = factTypesByArtifact.get(classified.artifactId);
+      if (!expectedFactType) fail(`${relativePath}: classified question ${classified.id} references unknown artifactId ${classified.artifactId}`);
+      else if (classified.factType !== expectedFactType) fail(`${relativePath}: classified question ${classified.id} factType ${classified.factType} does not match artifact ${classified.artifactId}`);
+      if (typeof classified.confidence !== "number" || classified.confidence < 0 || classified.confidence > 1) fail(`${relativePath}: classified question ${classified.id} invalid confidence`);
+    }
+  }
+}
+
 if (warnings.length > 0) console.warn(`Data integrity warnings: ${warnings.length} non-fatal legacy/content warnings omitted from CI output.`);
 if (errors.length > 0) { console.error(`Data integrity failed with ${errors.length} error(s):`); for (const e of errors) console.error(`- ${e}`); process.exit(1); }
 console.log(`Data integrity passed: ${certCount} certifications, ${questionIds.size} unique questions validated (${totalQuestionRows} total question rows).`);


### PR DESCRIPTION
## Summary
- Adds a symbolic ServiceNow exam artifact registry under `data/exam-intel/artifacts`
- Adds `npm run exam-intel:profile` to classify existing SNReady questions into artifact/fact distributions
- Generates baseline exam profiles for 20 question-ready certifications, covering 2,268/2,463 items (92.1%)
- Extends data integrity checks to validate exam-intel registries/profiles without storing raw dump content

## Test Plan
- `npm run exam-intel:profile`
- `npm run typecheck`
- `npx eslint scripts/exam-intel/profile-existing-questions.ts scripts/test-data-integrity.ts`
- `npm run test`
- Cloudflare Pages deploy check: passed
- `PLAYWRIGHT_BASE_URL=https://c981b148.snready.pages.dev npm run test:deployment` — 16 passed
- `npm run build` attempted twice locally; prebuild validation/export passed, but `next build` exceeded the 600s local tool timeout while creating the optimized build. Cloudflare deploy completed successfully.

## Cloudflare Preview
- https://c981b148.snready.pages.dev

## Notes
- This is the first non-invasive slice of the exam-intelligence pipeline: public-symbolic profiles from existing SNReady question metadata, not raw exam dump storage.
- `/data/exam-intel/` remains inaccessible through the deployed site smoke test.
