### PR TITLE
fix: keep admin magic links on current host

### DIFF
--- a/app/auth/verify/VerifyContent.tsx
+++ b/app/auth/verify/VerifyContent.tsx
@@ -7,10 +7,19 @@ import { useAccess } from "@/components/AccessProvider";
 
 type Status = "loading" | "success" | "error" | "expired" | "no-access";
 
+type VerifyResponse = {
+  success?: boolean;
+  email?: string;
+  hasAccess?: boolean;
+  error?: string;
+};
+
 export default function VerifyContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const token = searchParams.get("token");
+  const redirect = searchParams.get("redirect");
+  const safeRedirect = redirect?.startsWith("/") && !redirect.startsWith("//") ? redirect : null;
   const [status, setStatus] = useState<Status>(token ? "loading" : "error");
   const [error, setError] = useState<string>(token ? "" : "No login token provided");
   const [email, setEmail] = useState<string>("");
@@ -23,7 +32,7 @@ export default function VerifyContent() {
     fetch(`/api/auth/verify?token=${encodeURIComponent(token)}`, {
       credentials: "include",
     })
-      .then((res) => res.json())
+      .then((res) => res.json() as Promise<VerifyResponse>)
       .then(async (data) => {
         if (data.success && data.email) {
           // Refresh the auth provider — it will read the session cookie
@@ -33,7 +42,7 @@ export default function VerifyContent() {
 
           // Redirect after 2 seconds
           setTimeout(() => {
-            router.push(data.hasAccess ? "/certifications" : "/account");
+            router.push(safeRedirect ?? (data.hasAccess ? "/certifications" : "/account"));
           }, 2000);
         } else if (data.error?.includes("expired")) {
           setStatus("expired");
@@ -47,7 +56,7 @@ export default function VerifyContent() {
         setStatus("error");
         setError("Failed to verify login link");
       });
-  }, [token, refresh, router]);
+  }, [token, safeRedirect, refresh, router]);
 
   if (status === "loading") {
     return (

--- a/app/salaries/SalariesClient.tsx
+++ b/app/salaries/SalariesClient.tsx
@@ -14,6 +14,25 @@ interface HeroStats {
   countries: number;
 }
 
+type SalaryStatsResponse = {
+  overall: {
+    count: number;
+    median: number;
+    p25: number;
+    p75: number;
+    countries?: number;
+  };
+  byRole?: Array<{
+    role: string;
+    count: number;
+    median: number;
+    p25: number;
+    p75: number;
+  }>;
+};
+
+type ApiErrorResponse = { error?: string };
+
 export default function SalariesClient() {
   const [view, setView] = useState<"landing" | "form" | "results">("landing");
   const [hasSubmitted, setHasSubmitted] = useState(false);
@@ -36,7 +55,7 @@ export default function SalariesClient() {
     
     // Fetch live stats for hero
     fetch('/api/salaries/stats')
-      .then(res => res.json())
+      .then(res => res.json() as Promise<SalaryStatsResponse>)
       .then(data => {
         if (data.overall) {
           setHeroStats({
@@ -73,17 +92,17 @@ export default function SalariesClient() {
     });
 
     if (!response.ok) {
-      const error = await response.json();
+      const error = await response.json() as ApiErrorResponse;
       throw new Error(error.error || 'Failed to submit salary');
     }
 
     setSubmittedData(data);
 
     const statsResponse = await fetch('/api/salaries/stats');
-    const stats = await statsResponse.json();
+    const stats = await statsResponse.json() as SalaryStatsResponse;
 
     const totalComp = data.baseSalary || (data.hourlyRate || 0) * 2080;
-    const roleStats = stats.byRole?.find((r: any) => r.role === data.role) || stats.overall;
+    const roleStats = stats.byRole?.find((r) => r.role === data.role) || stats.overall;
     
     let percentile = 50;
     if (roleStats) {

--- a/app/salaries/[segment]/SalarySegmentClient.tsx
+++ b/app/salaries/[segment]/SalarySegmentClient.tsx
@@ -141,7 +141,7 @@ export default function SalarySegmentClient({
           return;
         }
 
-        const result = await response.json();
+        const result = await response.json() as FilterResponse;
         setData(result);
       } catch (err) {
         console.error("Error fetching salary data:", err);

--- a/components/CheckoutButton.tsx
+++ b/components/CheckoutButton.tsx
@@ -12,6 +12,8 @@ interface CheckoutButtonProps {
   children: React.ReactNode;
 }
 
+type CheckoutResponse = { url?: string };
+
 export function CheckoutButton({
   certification,
   plan = "single",
@@ -45,7 +47,7 @@ export function CheckoutButton({
         body: JSON.stringify({ certification, plan, returnUrl }),
       });
 
-      const data = await response.json();
+      const data = await response.json() as CheckoutResponse;
 
       if (data.url) {
         window.location.href = data.url;

--- a/components/LoginModal.tsx
+++ b/components/LoginModal.tsx
@@ -8,6 +8,8 @@ interface LoginModalProps {
   onPurchase: () => void;
 }
 
+type MagicLinkResponse = { success?: boolean; error?: string };
+
 export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
@@ -28,7 +30,7 @@ export function LoginModal({ isOpen, onClose, onPurchase }: LoginModalProps) {
         body: JSON.stringify({ email }),
       });
 
-      const data = await response.json();
+      const data = await response.json() as MagicLinkResponse;
 
       if (data.success) {
         setSent(true);

--- a/components/salaries/SalaryDashboard.tsx
+++ b/components/salaries/SalaryDashboard.tsx
@@ -32,7 +32,7 @@ export default function SalaryDashboard({
 
   useEffect(() => {
     fetch("/api/salaries/stats")
-      .then((res) => res.json())
+      .then((res) => res.json() as Promise<APIStats>)
       .then((data) => {
         setApiStats(data);
         setLoading(false);

--- a/functions/admin/_middleware.ts
+++ b/functions/admin/_middleware.ts
@@ -1,18 +1,29 @@
+/// <reference types="@cloudflare/workers-types" />
+
 import { getSessionToken } from "../lib/session";
 
 interface Env {
   SNREADY_ACCESS: KVNamespace;
+  ADMIN_EMAILS?: string;
 }
 
-// Only these emails can access /admin/* routes
-const ADMIN_EMAILS = ["jessems@gmail.com"];
+// Only these emails can access /admin/* routes. ADMIN_EMAILS can be a comma-separated Pages env var.
+const DEFAULT_ADMIN_EMAILS = ["jessems@gmail.com"];
+
+function getAdminEmails(env: Env): string[] {
+  const configured = env.ADMIN_EMAILS
+    ?.split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+  return configured?.length ? configured : DEFAULT_ADMIN_EMAILS;
+}
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const { request, env, next } = context;
   const sessionToken = getSessionToken(request);
 
   if (!sessionToken) {
-    return new Response(unauthorizedPage("Not logged in"), {
+    return new Response(unauthorizedPage("Not logged in", new URL(request.url).pathname), {
       status: 401,
       headers: { "Content-Type": "text/html" },
     });
@@ -21,7 +32,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   // Look up session
   const sessionRaw = await env.SNREADY_ACCESS.get(`session:${sessionToken}`);
   if (!sessionRaw) {
-    return new Response(unauthorizedPage("Session expired"), {
+    return new Response(unauthorizedPage("Session expired", new URL(request.url).pathname), {
       status: 401,
       headers: { "Content-Type": "text/html" },
     });
@@ -31,7 +42,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   try {
     session = JSON.parse(sessionRaw);
   } catch {
-    return new Response(unauthorizedPage("Invalid session"), {
+    return new Response(unauthorizedPage("Invalid session", new URL(request.url).pathname), {
       status: 401,
       headers: { "Content-Type": "text/html" },
     });
@@ -40,15 +51,15 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   // Check session expiry
   if (session.expiresAt < Date.now()) {
     await env.SNREADY_ACCESS.delete(`session:${sessionToken}`);
-    return new Response(unauthorizedPage("Session expired"), {
+    return new Response(unauthorizedPage("Session expired", new URL(request.url).pathname), {
       status: 401,
       headers: { "Content-Type": "text/html" },
     });
   }
 
   // Check if email is in admin list
-  if (!ADMIN_EMAILS.includes(session.email.toLowerCase())) {
-    return new Response(unauthorizedPage("Access denied"), {
+  if (!getAdminEmails(env).includes(session.email.toLowerCase())) {
+    return new Response(unauthorizedPage("Access denied", new URL(request.url).pathname), {
       status: 403,
       headers: { "Content-Type": "text/html" },
     });
@@ -58,7 +69,8 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   return next();
 };
 
-function unauthorizedPage(reason: string): string {
+function unauthorizedPage(reason: string, redirectPath: string): string {
+  const escapedRedirectPath = redirectPath.replace(/"/g, "&quot;");
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -94,16 +106,34 @@ function unauthorizedPage(reason: string): string {
       font-size: 0.875rem;
       margin-bottom: 1.5rem;
     }
+    input {
+      width: 100%;
+      border: 1px solid #d4d4d8;
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      margin-bottom: 0.75rem;
+      font: inherit;
+    }
+    button,
     a {
       display: inline-block;
+      width: 100%;
+      border: 0;
       background: #059669;
       color: white;
       padding: 0.75rem 1.5rem;
       border-radius: 8px;
       text-decoration: none;
       font-weight: 500;
+      cursor: pointer;
     }
-    a:hover { background: #047857; }
+    button:hover, a:hover { background: #047857; }
+    button:disabled { opacity: 0.6; cursor: wait; }
+    .secondary { display: block; margin-top: 1rem; background: transparent; color: #52525b; }
+    .secondary:hover { background: transparent; color: #18181b; }
+    .message { font-size: 0.875rem; margin-top: 0.75rem; }
+    .error { color: #dc2626; }
+    .success { color: #047857; }
   </style>
 </head>
 <body>
@@ -111,8 +141,44 @@ function unauthorizedPage(reason: string): string {
     <h1>🔒 Admin Access Required</h1>
     <p>This page is restricted to site administrators.</p>
     <div class="reason">${reason}</div>
-    <a href="/">← Back to Home</a>
+    <form id="login-form">
+      <input id="email" type="email" autocomplete="email" placeholder="admin email" required />
+      <input id="redirect" type="hidden" value="${escapedRedirectPath}" />
+      <button id="submit" type="submit">Send admin login link</button>
+      <div id="message" class="message" aria-live="polite"></div>
+    </form>
+    <a class="secondary" href="/">← Back to Home</a>
   </div>
+  <script>
+    const form = document.getElementById('login-form');
+    const button = document.getElementById('submit');
+    const message = document.getElementById('message');
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      button.disabled = true;
+      message.className = 'message';
+      message.textContent = 'Sending login link...';
+      try {
+        const response = await fetch('/api/auth/send-magic-link', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: document.getElementById('email').value,
+            redirect: document.getElementById('redirect').value,
+          }),
+        });
+        const data = await response.json();
+        if (!response.ok || !data.success) throw new Error(data.error || 'Failed to send login link');
+        message.className = 'message success';
+        message.textContent = 'Login link sent. Open it from this browser to return here.';
+      } catch (error) {
+        message.className = 'message error';
+        message.textContent = error instanceof Error ? error.message : 'Failed to send login link';
+      } finally {
+        button.disabled = false;
+      }
+    });
+  </script>
 </body>
 </html>`;
 }

--- a/functions/api/auth/send-magic-link.ts
+++ b/functions/api/auth/send-magic-link.ts
@@ -54,6 +54,17 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     const normalizedEmail = email.toLowerCase().trim();
 
+    if (!env.MAGIC_LINK_SECRET || !env.RESEND_API_KEY) {
+      console.error("Magic link auth is not configured for this deployment", {
+        hasMagicLinkSecret: Boolean(env.MAGIC_LINK_SECRET),
+        hasResendApiKey: Boolean(env.RESEND_API_KEY),
+      });
+      return new Response(
+        JSON.stringify({ error: "Magic link auth is not configured for this deployment" }),
+        { status: 503, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
     // Create magic link token (valid for 15 minutes)
     const expiresAt = Date.now() + 15 * 60 * 1000;
     const token = await createToken(normalizedEmail, expiresAt, env.MAGIC_LINK_SECRET);

--- a/functions/api/auth/send-magic-link.ts
+++ b/functions/api/auth/send-magic-link.ts
@@ -1,7 +1,9 @@
+/// <reference types="@cloudflare/workers-types" />
+
 interface Env {
   RESEND_API_KEY: string;
   MAGIC_LINK_SECRET: string;
-  SITE_URL: string;
+  SITE_URL?: string;
   SNREADY_ACCESS: KVNamespace;
 }
 
@@ -26,11 +28,22 @@ async function createToken(email: string, expiresAt: number, secret: string): Pr
   return `${emailBase64}:${expiresAt}:${signatureBase64}`;
 }
 
+function getRequestOrigin(request: Request): string {
+  const url = new URL(request.url);
+  return url.origin;
+}
+
+function sanitizeRedirect(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
 
   try {
-    const { email } = await request.json() as { email: string };
+    const { email, redirect } = await request.json() as { email: string; redirect?: string };
 
     if (!email || !email.includes("@")) {
       return new Response(
@@ -45,7 +58,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     const expiresAt = Date.now() + 15 * 60 * 1000;
     const token = await createToken(normalizedEmail, expiresAt, env.MAGIC_LINK_SECRET);
     
-    const magicLink = `${env.SITE_URL}/auth/verify?token=${encodeURIComponent(token)}`;
+    const redirectPath = sanitizeRedirect(redirect);
+    const magicUrl = new URL("/auth/verify", getRequestOrigin(request));
+    magicUrl.searchParams.set("token", token);
+    if (redirectPath) magicUrl.searchParams.set("redirect", redirectPath);
+    const magicLink = magicUrl.toString();
 
     // Send email via Resend
     const resendResponse = await fetch("https://api.resend.com/emails", {

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -14,6 +14,8 @@ export interface AuthSession {
   };
 }
 
+type SessionResponse = Partial<AuthSession>;
+
 /**
  * Fetches the current session from the server.
  * The server validates the httpOnly session cookie.
@@ -23,7 +25,7 @@ export async function getAuthSession(): Promise<AuthSession> {
     const response = await fetch("/api/auth/session", {
       credentials: "include",
     });
-    const data = await response.json();
+    const data = await response.json() as SessionResponse;
     if (data.authenticated) {
       return {
         authenticated: true,

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -57,23 +57,25 @@ export async function logoutSession(): Promise<void> {
   }
 }
 
-/**
- * Verifies a Stripe checkout session. Used by the checkout success page.
- * The server may set a session cookie on this response.
- */
-export async function verifySession(sessionId: string): Promise<{
+export type VerifySessionResponse = {
   success: boolean;
   email?: string;
   plan?: PlanType;
   expiresAt?: number;
   certification?: string;
   error?: string;
-}> {
+};
+
+/**
+ * Verifies a Stripe checkout session. Used by the checkout success page.
+ * The server may set a session cookie on this response.
+ */
+export async function verifySession(sessionId: string): Promise<VerifySessionResponse> {
   try {
     const response = await fetch(`/api/session?session_id=${sessionId}`, {
       credentials: "include",
     });
-    return await response.json();
+    return await response.json() as VerifySessionResponse;
   } catch {
     return { success: false, error: "Verification failed" };
   }

--- a/scripts/update-demand-data.ts
+++ b/scripts/update-demand-data.ts
@@ -57,6 +57,12 @@ interface BraveResult {
   description: string;
 }
 
+interface BraveSearchResponse {
+  web?: {
+    results?: BraveResult[];
+  };
+}
+
 async function searchBrave(query: string): Promise<BraveResult[]> {
   const url = new URL('https://api.search.brave.com/res/v1/web/search');
   url.searchParams.set('q', query);
@@ -75,7 +81,7 @@ async function searchBrave(query: string): Promise<BraveResult[]> {
       return [];
     }
     
-    const data = await res.json();
+    const data = await res.json() as BraveSearchResponse;
     return data.web?.results || [];
   } catch (err) {
     console.error(`Error searching:`, err);

--- a/tests/functions/auth.test.ts
+++ b/tests/functions/auth.test.ts
@@ -55,6 +55,25 @@ describe("magic link auth", () => {
     expect(url.searchParams.get("redirect")).toBe("/admin/coverage");
   });
 
+  it("returns a clear configuration error when preview auth secrets are missing", async () => {
+    const response = await sendMagicLink({
+      request: new Request("https://preview.snready.pages.dev/api/auth/send-magic-link", {
+        method: "POST",
+        body: JSON.stringify({ email: "jesse@example.com", redirect: "/admin/coverage" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      env: {
+        SNREADY_ACCESS: kvStore(),
+      },
+    } as unknown as Parameters<typeof sendMagicLink>[0]);
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Magic link auth is not configured for this deployment",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it("drops unsafe magic-link redirect targets", async () => {
     await sendMagicLink({
       request: new Request("https://snready.com/api/auth/send-magic-link", {

--- a/tests/functions/auth.test.ts
+++ b/tests/functions/auth.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { onRequestPost as sendMagicLink } from "@/functions/api/auth/send-magic-link";
+import { onRequest as adminMiddleware } from "@/functions/admin/_middleware";
+
+function kvStore(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: vi.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+    put: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    delete: vi.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+  };
+}
+
+describe("magic link auth", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async () => new Response("{}", { status: 200 })) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("builds magic links from the request origin so preview/admin cookies stay on the same host", async () => {
+    const response = await sendMagicLink({
+      request: new Request("https://preview.snready.pages.dev/api/auth/send-magic-link", {
+        method: "POST",
+        body: JSON.stringify({ email: "Jesse@example.com", redirect: "/admin/coverage" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      env: {
+        RESEND_API_KEY: "re_test",
+        MAGIC_LINK_SECRET: "secret",
+        SITE_URL: "https://snready.com",
+        SNREADY_ACCESS: kvStore(),
+      },
+    } as unknown as Parameters<typeof sendMagicLink>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, message: "Magic link sent" });
+
+    const resendPayload = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]?.body as string);
+    const link = resendPayload.text.match(/https:\/\/\S+/)?.[0];
+    expect(link).toBeTruthy();
+    const url = new URL(link);
+    expect(url.origin).toBe("https://preview.snready.pages.dev");
+    expect(url.pathname).toBe("/auth/verify");
+    expect(url.searchParams.get("redirect")).toBe("/admin/coverage");
+  });
+
+  it("drops unsafe magic-link redirect targets", async () => {
+    await sendMagicLink({
+      request: new Request("https://snready.com/api/auth/send-magic-link", {
+        method: "POST",
+        body: JSON.stringify({ email: "jesse@example.com", redirect: "https://evil.example/phish" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      env: {
+        RESEND_API_KEY: "re_test",
+        MAGIC_LINK_SECRET: "secret",
+        SNREADY_ACCESS: kvStore(),
+      },
+    } as unknown as Parameters<typeof sendMagicLink>[0]);
+
+    const resendPayload = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]?.body as string);
+    const link = resendPayload.text.match(/https:\/\/\S+/)?.[0];
+    const url = new URL(link);
+    expect(url.searchParams.get("redirect")).toBeNull();
+    expect(link).not.toContain("evil.example");
+  });
+});
+
+describe("admin middleware", () => {
+  it("renders an inline login form that preserves the requested admin path", async () => {
+    const response = await adminMiddleware({
+      request: new Request("https://preview.snready.pages.dev/admin/coverage"),
+      env: { SNREADY_ACCESS: kvStore() },
+      next: vi.fn(),
+    } as unknown as Parameters<typeof adminMiddleware>[0]);
+
+    expect(response.status).toBe(401);
+    const html = await response.text();
+    expect(html).toContain("Send admin login link");
+    expect(html).toContain("/api/auth/send-magic-link");
+    expect(html).toContain('value="/admin/coverage"');
+  });
+
+  it("allows configured admin emails", async () => {
+    const next = vi.fn(async () => new Response("ok"));
+    const response = await adminMiddleware({
+      request: new Request("https://snready.com/admin/coverage", {
+        headers: { Cookie: "snready_session=session-token" },
+      }),
+      env: {
+        SNREADY_ACCESS: kvStore({
+          "session:session-token": JSON.stringify({
+            email: "owner@example.com",
+            createdAt: Date.now(),
+            expiresAt: Date.now() + 60_000,
+          }),
+        }),
+        ADMIN_EMAILS: "owner@example.com, jessems@gmail.com",
+      },
+      next,
+    } as unknown as Parameters<typeof adminMiddleware>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Generate magic links from the current request origin instead of the static SITE_URL, so preview/admin login sets cookies on the same host the user is accessing.
- Preserve safe post-login redirects such as /admin/coverage through the magic-link flow.
- Add an inline admin login form on protected admin pages and support comma-separated ADMIN_EMAILS configuration with the existing jessems@gmail.com fallback.
- Add regression tests for preview-origin magic links, unsafe redirect stripping, and admin middleware login behavior.

## Test plan
- npx tsc --noEmit --pretty false --project tsconfig.auth-smoke.json (temporary targeted smoke config; passed before removal)
- npx eslint functions/api/auth/send-magic-link.ts functions/admin/_middleware.ts app/auth/verify/VerifyContent.tsx lib/access.ts tests/functions/auth.test.ts
- npx vitest run tests/functions/auth.test.ts
- npx vitest run --testTimeout 20000
- npm run test:data
- npm run build (prebuild validation/export passed; Next production build timed out locally after 600s at “Creating an optimized production build ...”; will rely on Cloudflare preview build)

## Cloudflare preview
Pending Cloudflare Pages preview URL from PR checks.