### PR TITLE
Add Google Ads attribution tracking

### DIFF
--- a/app/checkout/success/SuccessContent.tsx
+++ b/app/checkout/success/SuccessContent.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { verifySession } from "@/lib/access";
+import { trackPurchaseOnce } from "@/lib/analytics";
 import { useAccess } from "@/components/AccessProvider";
 
 type PlanType = "single" | "all";
@@ -14,6 +15,7 @@ interface SessionResult {
   plan?: PlanType;
   expiresAt?: number;
   certification?: string;
+  amountTotal?: number;
   error?: string;
 }
 
@@ -39,6 +41,12 @@ export default function SuccessContent() {
         // Session cookie is set by the API response — refresh the auth provider
         await refresh();
         setResult(data as SessionResult);
+        trackPurchaseOnce({
+          transactionId: sessionId,
+          certification: data.certification,
+          plan: data.plan || "single",
+          value: typeof data.amountTotal === "number" ? data.amountTotal / 100 : data.plan === "all" ? 49 : 9,
+        });
         setStatus("success");
       } else {
         setResult(data as SessionResult);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import Script from "next/script";
 import Link from "next/link";
 import { BASE_URL } from "@/lib/seo";
 import { Providers } from "@/components/Providers";
+import { Analytics } from "@/components/Analytics";
 import Header from "@/components/Header";
 import "./globals.css";
 
@@ -89,7 +90,7 @@ export default function RootLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'G-21R4T0V162');
+            gtag('config', 'G-21R4T0V162', { send_page_view: false });
           `}
         </Script>
         <script
@@ -108,6 +109,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-x-hidden`}
       >
+        <Analytics />
         <Providers>
           <Header />
           <main className="min-w-0 overflow-x-hidden">

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { captureAttribution, trackPageView } from "@/lib/analytics";
+
+export function Analytics() {
+  useEffect(() => {
+    const track = () => {
+      captureAttribution();
+      const path = `${window.location.pathname}${window.location.search}`;
+      trackPageView(path);
+    };
+
+    track();
+
+    // Next.js app-router navigations update history without a full reload. Patch
+    // history once per mount so paid-search landing/click paths are visible in GA4.
+    const originalPushState = window.history.pushState;
+    const originalReplaceState = window.history.replaceState;
+    const dispatchLocationChange = () => window.dispatchEvent(new Event("snready:locationchange"));
+
+    window.history.pushState = function pushState(...args) {
+      originalPushState.apply(this, args);
+      dispatchLocationChange();
+    };
+    window.history.replaceState = function replaceState(...args) {
+      originalReplaceState.apply(this, args);
+      dispatchLocationChange();
+    };
+
+    window.addEventListener("popstate", dispatchLocationChange);
+    window.addEventListener("snready:locationchange", track);
+
+    return () => {
+      window.history.pushState = originalPushState;
+      window.history.replaceState = originalReplaceState;
+      window.removeEventListener("popstate", dispatchLocationChange);
+      window.removeEventListener("snready:locationchange", track);
+    };
+  }, []);
+
+  return null;
+}

--- a/components/CheckoutButton.tsx
+++ b/components/CheckoutButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { captureAttribution, getPlanValue, trackBeginCheckout } from "@/lib/analytics";
 import { useAccess } from "./AccessProvider";
 
 type PlanType = "single" | "all";
@@ -28,6 +29,10 @@ export function CheckoutButton({
     try {
       // Store checkout context so success/cancel pages can recover intent.
       const returnUrl = `${window.location.pathname}${window.location.search}`;
+      const attribution = captureAttribution();
+      const value = getPlanValue(plan);
+      trackBeginCheckout({ certification, plan, value, returnUrl });
+
       localStorage.setItem("snready_checkout_return", returnUrl);
       localStorage.setItem(
         "snready_checkout_intent",
@@ -35,6 +40,7 @@ export function CheckoutButton({
           certification,
           plan,
           returnUrl,
+          attribution,
           startedAt: Date.now(),
         })
       );
@@ -44,7 +50,7 @@ export function CheckoutButton({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ certification, plan, returnUrl }),
+        body: JSON.stringify({ certification, plan, returnUrl, attribution }),
       });
 
       const data = await response.json() as CheckoutResponse;

--- a/docs/marketing/google-ads-initiative.md
+++ b/docs/marketing/google-ads-initiative.md
@@ -1,0 +1,62 @@
+# Google Ads Initiative
+
+Goal: drive incremental SNReady sales while keeping acquisition spend disciplined.
+
+## Budget rules
+
+- Start with Google Ads budget capped at **$100/month** (~$3.30/day).
+- Do not scale spend just because clicks increase.
+- If measured paid-search return is positive (ad-attributed Stripe revenue > Google Ads spend), the cap can increase to **$250/month**.
+- If ROAS is below 1.0x, pause or reduce bids/campaigns until attribution data shows a better path.
+
+## Required campaign tracking
+
+Enable Google Ads auto-tagging and use final URL suffix / tracking template UTMs:
+
+```text
+utm_source=google&utm_medium=cpc&utm_campaign={campaignid}&utm_term={keyword}&utm_content={creative}&utm_id={campaignid}
+```
+
+This PR stores first-touch and last-touch attribution in browser localStorage, passes those fields to `/api/checkout`, and persists them into Stripe Checkout Session metadata. Stripe remains the source of truth for paid conversions; GA4 gets `begin_checkout` and `purchase` ecommerce events.
+
+## Initial campaigns to launch
+
+Keep the first campaign narrow so $100/month is meaningful:
+
+1. **CSA practice test buyer intent**
+   - Landing page: `https://snready.com/csa/practice-questions`
+   - Example exact/phrase keywords: `servicenow csa practice test`, `servicenow csa exam questions`, `csa servicenow practice exam`
+   - Negative keywords: `free pdf`, `dump`, `brain dump`, `answers pdf`, `torrent`, `job`, `salary`, `training course`
+
+2. **CAD practice test buyer intent**
+   - Landing page: `https://snready.com/cad/practice-questions`
+   - Example exact/phrase keywords: `servicenow cad practice test`, `servicenow cad exam questions`, `cad servicenow practice exam`
+   - Same negative keywords as CSA.
+
+3. **CIS-ITSM practice test buyer intent**
+   - Landing page: `https://snready.com/cis-itsm/practice-questions`
+   - Example exact/phrase keywords: `servicenow cis itsm practice test`, `servicenow itsm exam questions`, `cis itsm practice exam`
+   - Same negative keywords as CSA.
+
+## Monitoring
+
+Run the local report script from the repo root:
+
+```bash
+node scripts/marketing/google-ads-attribution-report.mjs
+```
+
+Optional spend input while Google Ads API import is not connected:
+
+```bash
+GOOGLE_ADS_SPEND_MONTH_TO_DATE=42.75 node scripts/marketing/google-ads-attribution-report.mjs
+```
+
+The report reads Stripe Checkout Sessions, identifies sessions with Google Ads UTMs/click IDs, and reports month-to-date ad-attributed revenue, sales, campaign breakdown, and whether spend is eligible to scale.
+
+## Decision policy
+
+- **No ad-attributed sales after 2 weeks:** tighten match types, improve landing page message, or pause the weakest campaign.
+- **ROAS between 0 and 1:** keep under $100/month; cut expensive keywords and only keep terms with checkout starts.
+- **ROAS above 1:** allow the monthly cap to rise up to $250/month, but keep campaign-level losers paused.
+- **Attribution missing:** do not scale; fix UTMs/auto-tagging first.

--- a/functions/api/checkout.ts
+++ b/functions/api/checkout.ts
@@ -7,6 +7,48 @@ interface Env {
 
 type PlanType = "single" | "all";
 
+type AttributionData = Record<string, string | undefined>;
+
+const ATTRIBUTION_METADATA_KEYS = [
+  "firstLandingPage",
+  "firstReferrer",
+  "firstUtmSource",
+  "firstUtmMedium",
+  "firstUtmCampaign",
+  "firstUtmTerm",
+  "firstUtmContent",
+  "firstGclid",
+  "firstGbraid",
+  "firstWbraid",
+  "firstMsclkid",
+  "lastLandingPage",
+  "lastReferrer",
+  "lastUtmSource",
+  "lastUtmMedium",
+  "lastUtmCampaign",
+  "lastUtmTerm",
+  "lastUtmContent",
+  "lastGclid",
+  "lastGbraid",
+  "lastWbraid",
+  "lastMsclkid",
+  "firstSeenAt",
+  "lastSeenAt",
+] as const;
+
+function attributionMetadata(attribution: AttributionData | undefined) {
+  const metadata: Record<string, string> = {};
+  if (!attribution || typeof attribution !== "object") return metadata;
+
+  for (const key of ATTRIBUTION_METADATA_KEYS) {
+    const rawValue = attribution[key];
+    if (typeof rawValue !== "string" || !rawValue) continue;
+    metadata[key] = rawValue.slice(0, 240);
+  }
+
+  return metadata;
+}
+
 const PLANS = {
   "single": {
     price: 900, // $9.00 in cents
@@ -24,10 +66,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   const { request, env } = context;
 
   try {
-    const { certification, plan = "single", returnUrl } = await request.json() as {
+    const { certification, plan = "single", returnUrl, attribution } = await request.json() as {
       certification?: string;
       plan?: PlanType;
       returnUrl?: string;
+      attribution?: AttributionData;
     };
 
     // Prevent single-cert checkout without specifying which certification
@@ -86,6 +129,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         certification: normalizedCertification,
         plan: plan,
         returnUrl: safeReturnUrl || "",
+        ...attributionMetadata(attribution),
       },
     });
 

--- a/functions/api/session.ts
+++ b/functions/api/session.ts
@@ -131,6 +131,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         expiresAt,
         certification,
         certifications,
+        amountTotal: session.amount_total || undefined,
       }),
       {
         headers: {

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -63,6 +63,7 @@ export type VerifySessionResponse = {
   plan?: PlanType;
   expiresAt?: number;
   certification?: string;
+  amountTotal?: number;
   error?: string;
 };
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,263 @@
+export const GA_MEASUREMENT_ID = "G-21R4T0V162";
+
+export type PlanType = "single" | "all";
+
+export interface AttributionData {
+  firstLandingPage?: string;
+  firstReferrer?: string;
+  firstUtmSource?: string;
+  firstUtmMedium?: string;
+  firstUtmCampaign?: string;
+  firstUtmTerm?: string;
+  firstUtmContent?: string;
+  firstGclid?: string;
+  firstGbraid?: string;
+  firstWbraid?: string;
+  firstMsclkid?: string;
+  lastLandingPage?: string;
+  lastReferrer?: string;
+  lastUtmSource?: string;
+  lastUtmMedium?: string;
+  lastUtmCampaign?: string;
+  lastUtmTerm?: string;
+  lastUtmContent?: string;
+  lastGclid?: string;
+  lastGbraid?: string;
+  lastWbraid?: string;
+  lastMsclkid?: string;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
+}
+
+interface TouchData {
+  landingPage: string;
+  referrer: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmTerm?: string;
+  utmContent?: string;
+  gclid?: string;
+  gbraid?: string;
+  wbraid?: string;
+  msclkid?: string;
+  seenAt: string;
+}
+
+interface StoredAttribution {
+  first?: TouchData;
+  last?: TouchData;
+}
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+const STORAGE_KEY = "snready_attribution";
+const ATTRIBUTION_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+function truncate(value: string | null | undefined, maxLength = 240) {
+  if (!value) return undefined;
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function readStoredAttribution(): StoredAttribution {
+  if (!isBrowser()) return {};
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw) as StoredAttribution;
+    const lastSeen = parsed.last?.seenAt ? Date.parse(parsed.last.seenAt) : 0;
+    if (lastSeen && Date.now() - lastSeen > ATTRIBUTION_TTL_MS) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return {};
+    }
+
+    return parsed || {};
+  } catch {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return {};
+  }
+}
+
+function writeStoredAttribution(attribution: StoredAttribution) {
+  if (!isBrowser()) return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(attribution));
+}
+
+function getParam(params: URLSearchParams, key: string) {
+  return truncate(params.get(key) || undefined);
+}
+
+function hasCampaignParams(touch: TouchData) {
+  return Boolean(
+    touch.utmSource ||
+      touch.utmMedium ||
+      touch.utmCampaign ||
+      touch.utmTerm ||
+      touch.utmContent ||
+      touch.gclid ||
+      touch.gbraid ||
+      touch.wbraid ||
+      touch.msclkid
+  );
+}
+
+function currentTouch(): TouchData | null {
+  if (!isBrowser()) return null;
+
+  const url = new URL(window.location.href);
+  const params = url.searchParams;
+  return {
+    landingPage: truncate(`${url.pathname}${url.search}`) || "/",
+    referrer: truncate(document.referrer) || "",
+    utmSource: getParam(params, "utm_source"),
+    utmMedium: getParam(params, "utm_medium"),
+    utmCampaign: getParam(params, "utm_campaign"),
+    utmTerm: getParam(params, "utm_term"),
+    utmContent: getParam(params, "utm_content"),
+    gclid: getParam(params, "gclid"),
+    gbraid: getParam(params, "gbraid"),
+    wbraid: getParam(params, "wbraid"),
+    msclkid: getParam(params, "msclkid"),
+    seenAt: new Date().toISOString(),
+  };
+}
+
+function flattenAttribution(stored: StoredAttribution): AttributionData {
+  return {
+    firstLandingPage: stored.first?.landingPage,
+    firstReferrer: stored.first?.referrer,
+    firstUtmSource: stored.first?.utmSource,
+    firstUtmMedium: stored.first?.utmMedium,
+    firstUtmCampaign: stored.first?.utmCampaign,
+    firstUtmTerm: stored.first?.utmTerm,
+    firstUtmContent: stored.first?.utmContent,
+    firstGclid: stored.first?.gclid,
+    firstGbraid: stored.first?.gbraid,
+    firstWbraid: stored.first?.wbraid,
+    firstMsclkid: stored.first?.msclkid,
+    lastLandingPage: stored.last?.landingPage,
+    lastReferrer: stored.last?.referrer,
+    lastUtmSource: stored.last?.utmSource,
+    lastUtmMedium: stored.last?.utmMedium,
+    lastUtmCampaign: stored.last?.utmCampaign,
+    lastUtmTerm: stored.last?.utmTerm,
+    lastUtmContent: stored.last?.utmContent,
+    lastGclid: stored.last?.gclid,
+    lastGbraid: stored.last?.gbraid,
+    lastWbraid: stored.last?.wbraid,
+    lastMsclkid: stored.last?.msclkid,
+    firstSeenAt: stored.first?.seenAt,
+    lastSeenAt: stored.last?.seenAt,
+  };
+}
+
+export function captureAttribution(): AttributionData {
+  if (!isBrowser()) return {};
+
+  const stored = readStoredAttribution();
+  const touch = currentTouch();
+  if (!touch) return flattenAttribution(stored);
+
+  const next: StoredAttribution = {
+    first: stored.first || touch,
+    last: !stored.last || hasCampaignParams(touch) ? touch : stored.last,
+  };
+
+  writeStoredAttribution(next);
+  return flattenAttribution(next);
+}
+
+export function getStoredAttribution(): AttributionData {
+  return flattenAttribution(readStoredAttribution());
+}
+
+export function trackEvent(eventName: string, params: Record<string, unknown> = {}) {
+  if (!isBrowser() || typeof window.gtag !== "function") return;
+  window.gtag("event", eventName, params);
+}
+
+export function trackPageView(path: string) {
+  if (!isBrowser() || typeof window.gtag !== "function") return;
+
+  window.gtag("event", "page_view", {
+    page_path: path,
+    page_location: window.location.href,
+    page_title: document.title,
+    content_group: getContentGroup(path),
+  });
+}
+
+export function trackBeginCheckout(params: {
+  certification?: string;
+  plan: PlanType;
+  value: number;
+  returnUrl: string;
+}) {
+  trackEvent("begin_checkout", {
+    currency: "USD",
+    value: params.value,
+    plan: params.plan,
+    certification: params.certification || "ALL",
+    checkout_start_path: params.returnUrl,
+    items: [commerceItem(params.plan, params.certification, params.value)],
+  });
+}
+
+export function trackPurchaseOnce(params: {
+  transactionId: string;
+  certification?: string;
+  plan: PlanType;
+  value: number;
+}) {
+  if (!isBrowser()) return;
+
+  const dedupeKey = `snready_purchase_tracked:${params.transactionId}`;
+  if (window.localStorage.getItem(dedupeKey)) return;
+  window.localStorage.setItem(dedupeKey, new Date().toISOString());
+
+  trackEvent("purchase", {
+    transaction_id: params.transactionId,
+    currency: "USD",
+    value: params.value,
+    plan: params.plan,
+    certification: params.certification || "ALL",
+    items: [commerceItem(params.plan, params.certification, params.value)],
+  });
+}
+
+export function getPlanValue(plan: PlanType) {
+  return plan === "all" ? 49 : 9;
+}
+
+function commerceItem(plan: PlanType, certification: string | undefined, value: number) {
+  return {
+    item_id: `${plan}-${certification || "all"}`,
+    item_name: plan === "all" ? "All Certifications" : `${certification?.toUpperCase()} Certification`,
+    item_category: "ServiceNow certification prep",
+    item_variant: plan,
+    price: value,
+    quantity: 1,
+  };
+}
+
+function getContentGroup(path: string) {
+  if (path.startsWith("/blog")) return "blog";
+  if (path.startsWith("/salaries")) return "salary";
+  if (path.startsWith("/courses")) return "course";
+  if (path.includes("practice-questions")) return "practice";
+  if (path.includes("study-guide")) return "study-guide";
+  if (path.startsWith("/checkout")) return "checkout";
+  if (path.startsWith("/certifications")) return "certifications";
+  return "site";
+}

--- a/scripts/marketing/google-ads-attribution-report.mjs
+++ b/scripts/marketing/google-ads-attribution-report.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const STRIPE_KEY_PATH = process.env.STRIPE_KEY_PATH || "/root/.hermes/profiles/snready/home/.hermes/profiles/snready/.stripe_key";
+const MONTHLY_SPEND_CAP = Number(process.env.GOOGLE_ADS_MONTHLY_SPEND_CAP || "100");
+const SCALE_SPEND_CAP = Number(process.env.GOOGLE_ADS_SCALE_SPEND_CAP || "250");
+const spendMonthToDate = process.env.GOOGLE_ADS_SPEND_MONTH_TO_DATE ? Number(process.env.GOOGLE_ADS_SPEND_MONTH_TO_DATE) : null;
+
+function monthWindow(now = new Date()) {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0));
+  const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
+  return { start, next };
+}
+
+function isGoogleAdsSession(session) {
+  const m = session.metadata || {};
+  const values = [
+    m.firstUtmSource,
+    m.lastUtmSource,
+    m.firstUtmMedium,
+    m.lastUtmMedium,
+    m.firstUtmCampaign,
+    m.lastUtmCampaign,
+    m.firstGclid,
+    m.lastGclid,
+    m.firstGbraid,
+    m.lastGbraid,
+    m.firstWbraid,
+    m.lastWbraid,
+  ].filter(Boolean).map((value) => String(value).toLowerCase());
+
+  return values.some((value) =>
+    value === "google" ||
+    value === "cpc" ||
+    value === "ppc" ||
+    value.includes("google") ||
+    value.startsWith("gclid") ||
+    value.length > 20 && /^[a-z0-9_-]+$/i.test(value)
+  );
+}
+
+async function stripeGet(path, params = {}) {
+  const key = fs.readFileSync(STRIPE_KEY_PATH, "utf8").trim();
+  const url = new URL(`https://api.stripe.com/v1/${path}`);
+  for (const [keyName, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) url.searchParams.set(keyName, String(value));
+  }
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Stripe ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function listCheckoutSessions(start, end) {
+  const sessions = [];
+  let startingAfter;
+  do {
+    const page = await stripeGet("checkout/sessions", {
+      limit: 100,
+      "created[gte]": Math.floor(start.getTime() / 1000),
+      "created[lt]": Math.floor(end.getTime() / 1000),
+      starting_after: startingAfter,
+    });
+    sessions.push(...page.data);
+    startingAfter = page.has_more ? page.data.at(-1)?.id : undefined;
+  } while (startingAfter);
+
+  return sessions.filter((session) => session.payment_status === "paid");
+}
+
+function money(centsOrDollars, cents = false) {
+  const value = cents ? centsOrDollars / 100 : centsOrDollars;
+  return `$${value.toFixed(2)}`;
+}
+
+const { start, next } = monthWindow();
+const paid = await listCheckoutSessions(start, next);
+const adAttributed = paid.filter(isGoogleAdsSession);
+const revenueCents = paid.reduce((sum, session) => sum + (session.amount_total || 0), 0);
+const adRevenueCents = adAttributed.reduce((sum, session) => sum + (session.amount_total || 0), 0);
+const googleAdsSales = adAttributed.length;
+const campaignBreakdown = new Map();
+
+for (const session of adAttributed) {
+  const m = session.metadata || {};
+  const campaign = m.lastUtmCampaign || m.firstUtmCampaign || "unlabeled-google-ads";
+  const current = campaignBreakdown.get(campaign) || { sales: 0, revenueCents: 0 };
+  current.sales += 1;
+  current.revenueCents += session.amount_total || 0;
+  campaignBreakdown.set(campaign, current);
+}
+
+const dailyBudget = MONTHLY_SPEND_CAP / 30.4;
+const maxSpendToDate = dailyBudget * ((Date.now() - start.getTime()) / (24 * 60 * 60 * 1000));
+const roas = spendMonthToDate && spendMonthToDate > 0 ? adRevenueCents / 100 / spendMonthToDate : null;
+const nextCap = roas !== null && roas > 1 ? SCALE_SPEND_CAP : MONTHLY_SPEND_CAP;
+
+console.log(`**SNReady Google Ads ROAS — ${start.toISOString().slice(0, 7)} MTD**`);
+console.log(`- Total Stripe revenue: ${money(revenueCents, true)} from ${paid.length} paid sessions`);
+console.log(`- Google Ads-attributed revenue: ${money(adRevenueCents, true)} from ${googleAdsSales} paid sessions`);
+if (spendMonthToDate !== null) {
+  console.log(`- Google Ads spend entered: ${money(spendMonthToDate)}; ROAS: ${roas.toFixed(2)}x`);
+  console.log(`- Budget decision: ${roas > 1 ? `positive return — eligible to scale up to ${money(nextCap)}/month` : `hold at ${money(MONTHLY_SPEND_CAP)}/month or reduce bids until ROAS improves`}`);
+} else {
+  console.log(`- Spend data unavailable to this script. Keep Google Ads account budget at or below ${money(MONTHLY_SPEND_CAP)}/month until spend import/API access is connected.`);
+  console.log(`- Pacing guardrail for today: expected MTD spend should be <= ${money(maxSpendToDate)} at the ${money(MONTHLY_SPEND_CAP)}/month cap.`);
+}
+
+const campaigns = [...campaignBreakdown.entries()].sort((a, b) => b[1].revenueCents - a[1].revenueCents).slice(0, 5);
+if (campaigns.length) {
+  console.log("- Campaigns:");
+  for (const [campaign, stats] of campaigns) {
+    console.log(`  - ${campaign}: ${money(stats.revenueCents, true)} from ${stats.sales} sales`);
+  }
+} else {
+  console.log("- Campaigns: no paid sessions with Google Ads attribution yet");
+}
+
+console.log("- Required tracking convention: use auto-tagging plus UTM tags like utm_source=google&utm_medium=cpc&utm_campaign={campaignid}&utm_term={keyword}&utm_content={creative}.");

--- a/tests/functions/checkout.test.ts
+++ b/tests/functions/checkout.test.ts
@@ -17,7 +17,13 @@ describe("checkout Pages Function", () => {
     expect(await response.json()).toEqual({ url: "https://checkout.stripe.test/session" });
     const payload = createCheckoutSession.mock.calls[0][0];
     expect(payload.line_items[0].price_data.unit_amount).toBe(900);
-    expect(payload.metadata).toMatchObject({ certification: "CSA", plan: "single", returnUrl: "/csa/practice-questions" });
+    expect(payload.metadata).toMatchObject({
+      certification: "CSA",
+      plan: "single",
+      returnUrl: "/csa/practice-questions",
+      firstUtmSource: "google",
+      lastLandingPage: "/pricing",
+    });
     expect(payload.success_url).toBe("https://snready.com/checkout/success?session_id={CHECKOUT_SESSION_ID}");
     expect(payload.cancel_url).toContain("return_to=%2Fcsa%2Fpractice-questions");
   });


### PR DESCRIPTION
## Summary
- Capture first-touch and last-touch paid-search attribution in localStorage, including UTM, gclid, gbraid, wbraid, and msclkid values.
- Send attribution metadata into Stripe Checkout Sessions and emit GA4 begin_checkout/purchase ecommerce events.
- Add a Google Ads launch/guardrail doc and a Stripe-based ROAS reporting script for disciplined $100/month initial spend.

## Cloudflare Preview
- https://7c8b558f.snready.pages.dev

## Verification
- ✅ GitHub Actions / Cloudflare Pages deploy passed: https://github.com/jessems/snready/actions/runs/32160917449
- ✅ `npx eslint app/layout.tsx components/Analytics.tsx components/CheckoutButton.tsx app/checkout/success/SuccessContent.tsx functions/api/checkout.ts functions/api/session.ts lib/access.ts tests/functions/checkout.test.ts`
- ✅ `npx vitest run tests/functions/checkout.test.ts` — 3 tests passed
- ✅ `npm run test:data` — 21 certifications, 2405 unique questions validated
- ✅ `node scripts/marketing/google-ads-attribution-report.mjs` — live Stripe report ran; Aug MTD total revenue $246 from 14 paid sessions, $0 Google Ads-attributed revenue before launch
- ✅ Preview deployment smoke: `PLAYWRIGHT_BASE_URL=https://7c8b558f.snready.pages.dev npm run test:deployment -- --reporter=list` — 17 passed
- ✅ Preview attribution smoke: UTM + gclid landing page writes `snready_attribution` in localStorage

## Notes
- Full `npx tsc --noEmit --pretty false --incremental false` hung in the temporary worktree; GitHub Actions build/type path completed successfully from a clean install.
