### PR TITLE
feat: improve Google Ads attribution tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { BASE_URL } from "@/lib/seo";
 import { Providers } from "@/components/Providers";
 import { Analytics } from "@/components/Analytics";
+import { GA_MEASUREMENT_ID, GOOGLE_ADS_ID } from "@/lib/analytics";
 import Header from "@/components/Header";
 import "./globals.css";
 
@@ -82,7 +83,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-21R4T0V162"
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">
@@ -90,7 +91,8 @@ export default function RootLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'G-21R4T0V162', { send_page_view: false });
+            gtag('config', '${GA_MEASUREMENT_ID}', { send_page_view: false });
+            ${GOOGLE_ADS_ID ? `gtag('config', '${GOOGLE_ADS_ID}');` : ""}
           `}
         </Script>
         <script

--- a/docs/marketing/google-ads-initiative.md
+++ b/docs/marketing/google-ads-initiative.md
@@ -17,7 +17,16 @@ Enable Google Ads auto-tagging and use final URL suffix / tracking template UTMs
 utm_source=google&utm_medium=cpc&utm_campaign={campaignid}&utm_term={keyword}&utm_content={creative}&utm_id={campaignid}
 ```
 
-This PR stores first-touch and last-touch attribution in browser localStorage, passes those fields to `/api/checkout`, and persists them into Stripe Checkout Session metadata. Stripe remains the source of truth for paid conversions; GA4 gets `begin_checkout` and `purchase` ecommerce events.
+This tracking stores first-touch and last-touch attribution in browser localStorage, passes those fields to `/api/checkout`, and persists them into Stripe Checkout Session metadata. It also stores GA4 `gaClientId`, `gaSessionId`, and the raw GA4 session cookie on checkout sessions so later offline-conversion/server-side Measurement Protocol work can join paid Stripe conversions back to the browser session. Stripe remains the source of truth for paid conversions; GA4 gets `begin_checkout` and `purchase` ecommerce events. When the site has Google Ads tag settings configured, the success page also fires a direct Google Ads purchase conversion.
+
+### Website env vars for direct Google Ads conversions
+
+```bash
+NEXT_PUBLIC_GOOGLE_ADS_ID=AW-XXXXXXXXXX
+NEXT_PUBLIC_GOOGLE_ADS_PURCHASE_LABEL=AbCdEfGhIjKlMnOpQrSt
+```
+
+If these are unset, the website still captures attribution into Stripe metadata and GA4, but it skips the direct Google Ads conversion event.
 
 ## Initial campaigns to launch
 

--- a/functions/api/checkout.ts
+++ b/functions/api/checkout.ts
@@ -10,6 +10,9 @@ type PlanType = "single" | "all";
 type AttributionData = Record<string, string | undefined>;
 
 const ATTRIBUTION_METADATA_KEYS = [
+  "gaClientId",
+  "gaSessionId",
+  "gaSessionCookie",
   "firstLandingPage",
   "firstReferrer",
   "firstUtmSource",

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,8 +1,13 @@
 export const GA_MEASUREMENT_ID = "G-21R4T0V162";
+export const GOOGLE_ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID || "";
+export const GOOGLE_ADS_PURCHASE_LABEL = process.env.NEXT_PUBLIC_GOOGLE_ADS_PURCHASE_LABEL || "";
 
 export type PlanType = "single" | "all";
 
 export interface AttributionData {
+  gaClientId?: string;
+  gaSessionId?: string;
+  gaSessionCookie?: string;
   firstLandingPage?: string;
   firstReferrer?: string;
   firstUtmSource?: string;
@@ -98,6 +103,44 @@ function getParam(params: URLSearchParams, key: string) {
   return truncate(params.get(key) || undefined);
 }
 
+function getCookie(name: string) {
+  if (!isBrowser()) return undefined;
+
+  const match = document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .find((cookie) => cookie.startsWith(`${name}=`));
+
+  if (!match) return undefined;
+  return decodeURIComponent(match.slice(name.length + 1));
+}
+
+function getGaClientId() {
+  const cookie = getCookie("_ga");
+  if (!cookie) return undefined;
+
+  // Universal GA/GA4 cookies usually look like GA1.1.123456789.987654321.
+  // GA4 Measurement Protocol expects the final two numeric parts joined by a dot.
+  const parts = cookie.split(".");
+  if (parts.length >= 4) return truncate(parts.slice(-2).join("."), 100);
+  return truncate(cookie, 100);
+}
+
+function getGaSessionCookie() {
+  const measurementSuffix = GA_MEASUREMENT_ID.replace("G-", "");
+  return truncate(getCookie(`_ga_${measurementSuffix}`), 240);
+}
+
+function getGaSessionId() {
+  const cookie = getGaSessionCookie();
+  if (!cookie) return undefined;
+
+  // Current GA4 cookies include a segment like s1234567890. Keep this best-effort
+  // so future server-side/offline conversion work can join browser and Stripe data.
+  const sessionMatch = cookie.match(/(?:^|\.)s(\d+)(?:\.|$)/);
+  return truncate(sessionMatch?.[1], 100);
+}
+
 function hasCampaignParams(touch: TouchData) {
   return Boolean(
     touch.utmSource ||
@@ -135,6 +178,9 @@ function currentTouch(): TouchData | null {
 
 function flattenAttribution(stored: StoredAttribution): AttributionData {
   return {
+    gaClientId: getGaClientId(),
+    gaSessionId: getGaSessionId(),
+    gaSessionCookie: getGaSessionCookie(),
     firstLandingPage: stored.first?.landingPage,
     firstReferrer: stored.first?.referrer,
     firstUtmSource: stored.first?.utmSource,
@@ -234,6 +280,15 @@ export function trackPurchaseOnce(params: {
     certification: params.certification || "ALL",
     items: [commerceItem(params.plan, params.certification, params.value)],
   });
+
+  if (GOOGLE_ADS_ID && GOOGLE_ADS_PURCHASE_LABEL) {
+    trackEvent("conversion", {
+      send_to: `${GOOGLE_ADS_ID}/${GOOGLE_ADS_PURCHASE_LABEL}`,
+      transaction_id: params.transactionId,
+      currency: "USD",
+      value: params.value,
+    });
+  }
 }
 
 export function getPlanValue(plan: PlanType) {

--- a/scripts/marketing/google-ads-attribution-report.mjs
+++ b/scripts/marketing/google-ads-attribution-report.mjs
@@ -83,6 +83,8 @@ const adAttributed = paid.filter(isGoogleAdsSession);
 const revenueCents = paid.reduce((sum, session) => sum + (session.amount_total || 0), 0);
 const adRevenueCents = adAttributed.reduce((sum, session) => sum + (session.amount_total || 0), 0);
 const googleAdsSales = adAttributed.length;
+const gaClientIdSessions = paid.filter((session) => Boolean(session.metadata?.gaClientId)).length;
+const gaSessionIdSessions = paid.filter((session) => Boolean(session.metadata?.gaSessionId || session.metadata?.gaSessionCookie)).length;
 const campaignBreakdown = new Map();
 
 for (const session of adAttributed) {
@@ -102,6 +104,7 @@ const nextCap = roas !== null && roas > 1 ? SCALE_SPEND_CAP : MONTHLY_SPEND_CAP;
 console.log(`**SNReady Google Ads ROAS — ${start.toISOString().slice(0, 7)} MTD**`);
 console.log(`- Total Stripe revenue: ${money(revenueCents, true)} from ${paid.length} paid sessions`);
 console.log(`- Google Ads-attributed revenue: ${money(adRevenueCents, true)} from ${googleAdsSales} paid sessions`);
+console.log(`- GA4 join keys captured: client_id on ${gaClientIdSessions}/${paid.length} paid sessions; session on ${gaSessionIdSessions}/${paid.length}`);
 if (spendMonthToDate !== null) {
   console.log(`- Google Ads spend entered: ${money(spendMonthToDate)}; ROAS: ${roas.toFixed(2)}x`);
   console.log(`- Budget decision: ${roas > 1 ? `positive return — eligible to scale up to ${money(nextCap)}/month` : `hold at ${money(MONTHLY_SPEND_CAP)}/month or reduce bids until ROAS improves`}`);

--- a/tests/functions/checkout.test.ts
+++ b/tests/functions/checkout.test.ts
@@ -12,7 +12,17 @@ describe("checkout Pages Function", () => {
     expect(createCheckoutSession).not.toHaveBeenCalled();
   });
   it("creates a $9 single-cert checkout session with normalized metadata", async () => {
-    const response = await onRequestPost(context({ certification: "csa", plan: "single", returnUrl: "/csa/practice-questions", attribution: { firstUtmSource: "google", lastLandingPage: "/pricing" } }));
+    const response = await onRequestPost(context({
+      certification: "csa",
+      plan: "single",
+      returnUrl: "/csa/practice-questions",
+      attribution: {
+        gaClientId: "123456789.987654321",
+        gaSessionId: "1782533012",
+        firstUtmSource: "google",
+        lastLandingPage: "/pricing",
+      },
+    }));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ url: "https://checkout.stripe.test/session" });
     const payload = createCheckoutSession.mock.calls[0][0];
@@ -21,6 +31,8 @@ describe("checkout Pages Function", () => {
       certification: "CSA",
       plan: "single",
       returnUrl: "/csa/practice-questions",
+      gaClientId: "123456789.987654321",
+      gaSessionId: "1782533012",
       firstUtmSource: "google",
       lastLandingPage: "/pricing",
     });


### PR DESCRIPTION
## Summary
- persist GA4 client/session identifiers alongside existing first/last touch ad attribution
- optionally fire a direct Google Ads purchase conversion when public tag env vars are configured
- surface GA4 join-key coverage in the attribution report and document required env vars

## Testing
- npm run test:unit -- tests/functions/checkout.test.ts
- npm run typecheck
